### PR TITLE
Add deployment pipeline for main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL=postgres://example
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GOV.UK PaaS
 
 on:
   push:
-    branches: [ deployment-pipeline ]
+    branches: [ main ]
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy to GOV.UK PaaS
+
+on:
+  push:
+    branches: [ deployment-pipeline ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: dev
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Install cloudfoundry
+        shell: bash
+        id: install-cf-cli
+        run: |
+          wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
+          echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+          sudo apt-get update
+          sudo apt-get install cf8-cli
+
+      - name: Deploy to Gov.uk PaaS
+        id: deploy-to-paas
+        shell: bash
+        run: |
+          cf api ${{ secrets.CF_API }}
+          cf auth "${{ secrets.CF_USER }}" "${{ secrets.CF_PASSWORD }}"
+          cf target -o ${{ secrets.CF_ORGANISATION }} -s ${{ secrets.CF_SPACE }}
+          cf push --strategy rolling

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env.development
+

--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,11 @@ ruby File.read(".ruby-version").chomp
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
+gem "pg", "~> 1.3.5"
 gem "puma", "~> 5.0"
+gem "sequel", "~> 5.55"
 gem "sinatra", "~> 2.2.0"
 gem "zeitwerk", "~> 2.5"
-gem 'sequel', '~> 5.55'
-gem 'pg', '~> 1.3.5'
 
 group :development do
   gem "rubocop"

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gem "puma", "~> 5.0"
 gem "sinatra", "~> 2.2.0"
 gem "zeitwerk", "~> 2.5"
+gem 'sequel', '~> 5.55'
+gem 'pg', '~> 1.3.5'
 
 group :development do
   gem "rubocop"

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,10 @@ gem "sequel", "~> 5.55"
 gem "sinatra", "~> 2.2.0"
 gem "zeitwerk", "~> 2.5"
 
+group :development, :test do
+  gem "dotenv"
+end
+
 group :development do
   gem "rubocop"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,9 +9,9 @@ gem "puma", "~> 5.0"
 gem "sequel", "~> 5.55"
 gem "sinatra", "~> 2.2.0"
 gem "zeitwerk", "~> 2.5"
+gem "dotenv", "~> 2.7.6"
 
 group :development, :test do
-  gem "dotenv"
   gem "pry"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "zeitwerk", "~> 2.5"
 
 group :development, :test do
   gem "dotenv"
+  gem "pry"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    coderay (1.1.3)
     diff-lcs (1.5.0)
     dotenv (2.7.6)
+    method_source (1.0.0)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
     nio4r (2.5.8)
@@ -11,6 +13,9 @@ GEM
     parser (3.1.1.0)
       ast (~> 2.4.1)
     pg (1.3.5)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     puma (5.6.4)
       nio4r (~> 2.0)
     rack (2.2.3)
@@ -61,6 +66,7 @@ PLATFORMS
 DEPENDENCIES
   dotenv
   pg (~> 1.3.5)
+  pry
   puma (~> 5.0)
   rspec
   rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
     parallel (1.22.1)
     parser (3.1.1.0)
       ast (~> 2.4.1)
+    pg (1.3.5)
     puma (5.6.4)
       nio4r (~> 2.0)
     rack (2.2.3)
@@ -43,6 +44,7 @@ GEM
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
+    sequel (5.55.0)
     sinatra (2.2.0)
       mustermann (~> 1.0)
       rack (~> 2.2)
@@ -56,9 +58,11 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  pg (~> 1.3.5)
   puma (~> 5.0)
   rspec
   rubocop
+  sequel (~> 5.55)
   sinatra (~> 2.2.0)
   zeitwerk (~> 2.5)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  dotenv
+  dotenv (~> 2.7.6)
   pg (~> 1.3.5)
   pry
   puma (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     ast (2.4.2)
     diff-lcs (1.5.0)
+    dotenv (2.7.6)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
     nio4r (2.5.8)
@@ -58,6 +59,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  dotenv
   pg (~> 1.3.5)
   puma (~> 5.0)
   rspec

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,8 @@
 RACK_ENV = ENV['RACK_ENV'] ||= 'development' unless defined?(RACK_ENV)
+require 'dotenv'
 require './lib/loader'
+
+Dotenv.load(".env.#{RACK_ENV}")
 
 $stdout.sync = true
 

--- a/db/database.rb
+++ b/db/database.rb
@@ -1,0 +1,12 @@
+require 'sequel'
+
+class Database
+  def self.use
+    database = Sequel.connect(ENV['DATABASE_URL'])
+    database.extension :pg_json
+    database.extension :pg_array
+    yield(database)
+  ensure
+    database.disconnect
+  end
+end

--- a/db/database.rb
+++ b/db/database.rb
@@ -1,8 +1,8 @@
-require 'sequel'
+require "sequel"
 
 class Database
   def self.use
-    database = Sequel.connect(ENV['DATABASE_URL'])
+    database = Sequel.connect(ENV["DATABASE_URL"])
     database.extension :pg_json
     database.extension :pg_array
     yield(database)

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -1,3 +1,4 @@
+require "dotenv/load"
 require "zeitwerk"
 require_relative "server"
 require_relative "../db/database"

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -1,4 +1,3 @@
-require "dotenv/load"
 require "zeitwerk"
 require_relative "server"
 require_relative "../db/database"

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -1,5 +1,6 @@
 require "zeitwerk"
 require_relative "server"
+require_relative "../db/database"
 
 loader = Zeitwerk::Loader.new
 loader.push_dir(__dir__)

--- a/lib/repositories/example_repository.rb
+++ b/lib/repositories/example_repository.rb
@@ -1,0 +1,12 @@
+class Repositories::ExampleRepository
+  def test_query
+    res = nil
+    Database.use do |db|
+      res = db.fetch("SELECT 1 as test").first
+    end
+
+    {
+      result: res[:test]
+    }
+  end
+end

--- a/lib/server.rb
+++ b/lib/server.rb
@@ -2,6 +2,9 @@ require "sinatra"
 
 class Server < Sinatra::Base
   get "/" do
-    Services::Example.new.execute
+    repo = Repositories::ExampleRepository.new
+    res = repo.test_query
+
+    Services::Example.new.execute(res[:result])
   end
 end

--- a/lib/services/example.rb
+++ b/lib/services/example.rb
@@ -1,5 +1,5 @@
 class Services::Example
-  def execute
-    "GOV.UK Forms API"
+  def execute(example)
+    "GOV.UK Forms API: #{example}"
   end
 end

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,9 @@
+---
+applications:
+- name: forms-api-dev
+  memory: 256M
+  command: bundle exec rackup -o 0.0.0.0 -p $PORT
+  services:
+    - forms-api-dev-db
+  env:
+    RACK_ENV: production


### PR DESCRIPTION
This adds a deployment pipeline for on merge to main. Alongside this it also adds example code for connecting to a database and creating service classes. This is both to serve as a future example, but also to test that the loader/database connection is set up correctly.

It also adds `dotenv` for managing environement variables locally