### PR TITLE
Change create/delete page to alter order

### DIFF
--- a/lib/repositories/pages_repository.rb
+++ b/lib/repositories/pages_repository.rb
@@ -52,7 +52,7 @@ class Repositories::PagesRepository
   end
 
   def get_pages_in_form(form_id)
-    @database[:pages].where(form_id:).order(:next).all.map { |p| page_from_data(p) }
+    @database[:pages].where(form_id:).order(:id).all.map { |p| page_from_data(p) }
   end
 
   private

--- a/lib/repositories/pages_repository.rb
+++ b/lib/repositories/pages_repository.rb
@@ -4,14 +4,23 @@ class Repositories::PagesRepository
   end
 
   def create(page)
-    @database[:pages].insert(
-      form_id: page.form_id,
-      question_text: page.question_text,
-      question_short_name: page.question_short_name,
-      hint_text: page.hint_text,
-      answer_type: page.answer_type,
-      next: page.next
-    )
+    # Append the page to the end of the page linked list this means that we
+    # have to set the next value of the page which was last (if there are any
+    # pages) this page would have had next = null. We insert the page then set
+    # the value in a single transaction
+    @database.transaction(isolation: :serializable) do
+      new_page_id = @database[:pages].insert(
+        form_id: page.form_id,
+        question_text: page.question_text,
+        question_short_name: page.question_short_name,
+        hint_text: page.hint_text,
+        answer_type: page.answer_type
+      )
+
+      @database[:pages].where(next: nil).exclude(id: new_page_id).update(next: new_page_id)
+
+      new_page_id
+    end
   end
 
   def get(page_id)
@@ -31,11 +40,19 @@ class Repositories::PagesRepository
   end
 
   def delete(page_id)
-    @database[:pages].where(id: page_id).delete
+    @database.transaction(isolation: :serializable) do
+      pages = @database[:pages]
+
+      # get the next value of our page and update any pages which pointed to us
+      # to that instead
+      next_page_id = pages.where(id: page_id).get(:next)
+      pages.where(next: page_id.to_s).update(next: next_page_id)
+      pages.where(id: page_id).delete
+    end
   end
 
   def get_pages_in_form(form_id)
-    @database[:pages].where(form_id:).all.map { |p| page_from_data(p) }
+    @database[:pages].where(form_id:).order(:next).all.map { |p| page_from_data(p) }
   end
 
   private

--- a/lib/server.rb
+++ b/lib/server.rb
@@ -103,7 +103,6 @@ class Server < Grape::API
           optional :hint_text, type: String, desc: "Hint text"
           requires :answer_type, type: String,
                                  values: %w[single_line address date email national_insurance_number phone_number], desc: "Answer type"
-          optional :next, type: String, desc: "The ID of the next page"
         end
         post do
           repository = Repositories::PagesRepository.new(@database)
@@ -114,7 +113,6 @@ class Server < Grape::API
           page.question_short_name = params[:question_short_name]
           page.hint_text = params[:hint_text]
           page.answer_type = params[:answer_type]
-          page.next = params[:next]
 
           id = repository.create(page)
           { id: }

--- a/spec/repositories/pages_repository_spec.rb
+++ b/spec/repositories/pages_repository_spec.rb
@@ -16,14 +16,15 @@ describe Repositories::PagesRepository do
 
   context "creating a new page" do
     it "creates a page" do
-      result = subject.create(page)
-      created_page = database[:pages].where(id: result).all.last
+      first_page_result = subject.create(page)
+      subject.create(page)
+
+      created_page = database[:pages].where(id: first_page_result).all.last
 
       expect(created_page[:question_text]).to eq("question_text")
       expect(created_page[:question_short_name]).to eq("question_short_name")
       expect(created_page[:hint_text]).to eq("hint_text")
       expect(created_page[:answer_type]).to eq("answer_type")
-      expect(created_page[:next]).to eq("next")
       expect(created_page[:form_id]).to eq(form_id)
     end
   end
@@ -36,7 +37,6 @@ describe Repositories::PagesRepository do
       expect(found_page.question_short_name).to eq("question_short_name")
       expect(found_page.hint_text).to eq("hint_text")
       expect(found_page.answer_type).to eq("answer_type")
-      expect(found_page.next).to eq("next")
       expect(found_page.form_id).to eq(form_id)
     end
   end
@@ -63,11 +63,43 @@ describe Repositories::PagesRepository do
     end
   end
 
-  context "deleting a page" do
+  context "deleting a page which exists" do
     it "deletes a page" do
       page_id = subject.create(page)
       result = subject.delete(page_id)
+
       expect(result).to eq(1)
+    end
+
+    it "updates other page next values" do
+      first_page_id = subject.create(page)
+      second_page_id = subject.create(page)
+      third_page_id = subject.create(page)
+
+      result = subject.delete(second_page_id)
+
+      first_page_next = database[:pages].where(id: first_page_id).get(:next)
+      expect(first_page_next).to eq(third_page_id.to_s)
+      expect(result).to eq(1)
+    end
+  end
+
+  context "deleting a page which does not exist" do
+    it "does not update other page next values" do
+      first_page_id = subject.create(page)
+      second_page_id = subject.create(page)
+      third_page_id = subject.create(page)
+
+      result = subject.delete(999)
+
+      first_page_next = database[:pages].where(id: first_page_id).get(:next)
+      second_page_next = database[:pages].where(id: second_page_id).get(:next)
+      third_page_next = database[:pages].where(id: third_page_id).get(:next)
+
+      expect(result).to eq(0)
+      expect(first_page_next).to eq(second_page_id.to_s)
+      expect(second_page_next).to eq(third_page_id.to_s)
+      expect(third_page_next).to eq(nil)
     end
   end
 


### PR DESCRIPTION
Pages form a linked list. Currently the client is responsible for
ensuring the consistency of the list.

This commit changes this by making sure new pages are 'appended' to the end
of the list. Deleting a page in the middle of the page list now connects
the two lists together. These changes mean there should only be one
connected list of pages.

This means clients are no longer able to create pages which random
'next' values. The update route hasn't been changed to keep that
possibility available, but maybe should be closed off too to ensure
consistency.

#### What problem does the pull request solve?

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


