### PR TITLE
Add apple silicon platform support to ruby Gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
#### What problem does the pull request solve?
Gemfile.lock is updated for devs that are using apple m1 macbooks.

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


