### PR TITLE
Fix adding next page to other forms

### DIFF
--- a/db/migrations/5_update_incorrect_next_page_attribute_value.rb
+++ b/db/migrations/5_update_incorrect_next_page_attribute_value.rb
@@ -1,0 +1,11 @@
+Sequel.migration do
+  up do
+    from(:pages).exclude(next: nil).each do |page|
+      current_page = from(:pages).where(id: page[:id])
+
+      next_page = from(:pages).where(id: page[:next])
+
+      current_page.update(next: nil) if next_page.get(:form_id) != current_page.get(:form_id)
+    end
+  end
+end

--- a/lib/repositories/pages_repository.rb
+++ b/lib/repositories/pages_repository.rb
@@ -17,7 +17,7 @@ class Repositories::PagesRepository
         answer_type: page.answer_type
       )
 
-      @database[:pages].where(next: nil).exclude(id: new_page_id).update(next: new_page_id)
+      @database[:pages].where(form_id: page.form_id, next: nil).exclude(id: new_page_id).update(next: new_page_id)
 
       new_page_id
     end

--- a/spec/db/migration_5_spec.rb
+++ b/spec/db/migration_5_spec.rb
@@ -1,0 +1,23 @@
+describe "migration 5" do
+  include_context "with database"
+
+  let(:migrator) { Migrator.new }
+
+  before do
+    migrator.migrate_to(database, 4)
+  end
+  it "adds a sensible default org from v4 to v5" do
+    form1 = database[:forms].insert(name: "Form 1", submission_email: "submission_email")
+    form2 = database[:forms].insert(name: "Form 2", submission_email: "submission_email")
+
+    page_id1 = database[:pages].insert(id: 1, form_id: form1, next: "2", question_text: "question_text", answer_type: "answer_type")
+    page_id2 = database[:pages].insert(id: 2, form_id: form1, next: "3", question_text: "question_text", answer_type: "answer_type")
+    page_id3 = database[:pages].insert(id: 3, form_id: form2, next: nil, question_text: "question_text", answer_type: "answer_type")
+
+    migrator.migrate_to(database, 5)
+
+    expect(database[:pages].where(id: page_id1).first[:next]).to eq(page_id2.to_s)
+    expect(database[:pages].where(id: page_id2).first[:next]).to be_nil
+    expect(database[:pages].where(id: page_id3).first[:next]).to be_nil
+  end
+end

--- a/spec/repositories/pages_repository_spec.rb
+++ b/spec/repositories/pages_repository_spec.rb
@@ -2,7 +2,8 @@ describe Repositories::PagesRepository do
   include_context "with database"
 
   let(:subject) { described_class.new(database) }
-  let(:form_id) { database[:forms].insert(name: "name", submission_email: "email") }
+  let(:form_id) { database[:forms].insert(name: "Form 1", submission_email: "email") }
+  let(:another_form_id) { database[:forms].insert(name: "Form 2", submission_email: "email") }
   let(:page) do
     Domain::Page.new.tap do |page|
       page.form_id = form_id
@@ -10,14 +11,24 @@ describe Repositories::PagesRepository do
       page.question_short_name = "question_short_name"
       page.hint_text = "hint_text"
       page.answer_type = "answer_type"
-      page.next = "next"
+      page.next = nil
+    end
+  end
+
+  let(:page_for_another_form) do
+    Domain::Page.new.tap do |page|
+      page.form_id = another_form_id
+      page.question_text = "question_text"
+      page.question_short_name = "question_short_name"
+      page.hint_text = "hint_text"
+      page.answer_type = "answer_type"
+      page.next = nil
     end
   end
 
   context "creating a new page" do
-    it "creates a page" do
+    it "creates a single page" do
       first_page_result = subject.create(page)
-      subject.create(page)
 
       created_page = database[:pages].where(id: first_page_result).all.last
 
@@ -26,6 +37,30 @@ describe Repositories::PagesRepository do
       expect(created_page[:hint_text]).to eq("hint_text")
       expect(created_page[:answer_type]).to eq("answer_type")
       expect(created_page[:form_id]).to eq(form_id)
+      expect(created_page[:next]).to be_nil
+    end
+  end
+
+  context "create a second page for the same form" do
+    it "should set the previous next attribute to the new page id" do
+      first_page_id = subject.create(page)
+      second_page_id = subject.create(page)
+
+      first_page_result = database[:pages].where(id: first_page_id)
+
+      expect(first_page_result.get(:next)).to eq(second_page_id.to_s)
+    end
+
+    it "should not update another form pages next attribute" do
+      another_form_page_id = subject.create(page_for_another_form)
+      first_page_id = subject.create(page)
+      second_page_id = subject.create(page)
+
+      first_page_result = database[:pages].where(id: first_page_id)
+      another_form_page_result = database[:pages].where(id: another_form_page_id)
+
+      expect(first_page_result.get(:next)).to eq(second_page_id.to_s)
+      expect(another_form_page_result.get(:next)).to be_nil
     end
   end
 


### PR DESCRIPTION
#### What problem does the pull request solve?
Relates to https://trello.com/c/30BWYuYQ/42-bug-next-page-value-not-being-set-correctly
When new pages were being created for a
specific form we were setting the next page
attribute for all pages even if the page
wasn't linked to the form that we were updating.
#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [x] I've updated the documentation in (If any documentation requires updating)
    - [x] README.md
    - [x] Elsewhere (please link)


