### PR TITLE
Add privacy policy URL to update methods

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/api_v1.rb
+++ b/lib/api_v1.rb
@@ -77,10 +77,11 @@ class APIv1 < Grape::API
         requires :submission_email, type: String, desc: "Submission email."
         requires :org, type: String, desc: "Organization slug."
         requires :live_at, type: String, desc: "Live at."
+        optional :privacy_policy_url, type: String, desc: "Privacy policy URL."
       end
       put do
         repository = Repositories::FormsRepository.new(@database)
-        repository.update(params[:form_id], params[:name], params[:submission_email], params[:org], params[:live_at])
+        repository.update(params)
         { success: true }
       end
 

--- a/lib/repositories/forms_repository.rb
+++ b/lib/repositories/forms_repository.rb
@@ -15,12 +15,13 @@ class Repositories::FormsRepository
     @database[:forms].where(org:).all
   end
 
-  def update(form_id, name, submission_email, org, live_at)
-    @database[:forms].where(id: form_id).update(
-      name:,
-      submission_email:,
-      org:,
-      live_at:,
+  def update(form)
+    @database[:forms].where(id: form[:form_id]).update(
+      name: form[:name],
+      submission_email: form[:submission_email],
+      org: form[:org],
+      live_at: form[:live_at],
+      privacy_policy_url: form[:privacy_policy_url],
       updated_at: Time.now
     )
   end

--- a/lib/server.rb
+++ b/lib/server.rb
@@ -8,7 +8,6 @@ class Server < Grape::API
     content_type "text/plain"
     body "PONG"
   end
-
   # Private API version 1 endpoints
   mount APIv1
 

--- a/spec/repositories/forms_repository_spec.rb
+++ b/spec/repositories/forms_repository_spec.rb
@@ -43,7 +43,7 @@ describe Repositories::FormsRepository do
   context "updating a form" do
     it "updates a form" do
       form_id = subject.create("name", "submission_email", "org")
-      update_result = subject.update(form_id, "name2", "submission_email2", "org2", Time.now)
+      update_result = subject.update({ form_id:, name: "name2", submission_email: "submission_email2", org: "org2", live_at: Time.now, privacy_policy_url: "https://example.com/privacy-policy" })
       form = subject.get(form_id)
       expect(update_result).to eq(1)
       expect(form[:name]).to eq("name2")
@@ -51,6 +51,7 @@ describe Repositories::FormsRepository do
       expect(form[:org]).to eq("org2")
       expect(form[:updated_at].to_i).to be_within(3).of(Time.now.to_i)
       expect(form[:live_at].to_i).to be_within(3).of(Time.now.to_i)
+      expect(form[:privacy_policy_url]).to eq("https://example.com/privacy-policy")
     end
   end
 


### PR DESCRIPTION
#### What problem does the pull request solve?
The [previous privacy policy PR](https://github.com/alphagov/forms-api/pull/61) added the relevant fields to the databse, but didn't include the logic to update them from the endpoints, this one adds that logic.

Trello card: https://trello.com/c/Q5wKHZ75/15-add-link-to-privacy-information-to-forms-api-needs-dev-review

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
    - [n/a] README.md
    - [n/a] Elsewhere (please link)


