### PR TITLE
Update next to next page

### DIFF
--- a/db/migrations/9_rename_next_to_next_pages.rb
+++ b/db/migrations/9_rename_next_to_next_pages.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  up do
+    rename_column :pages, :next, :next_page
+  end
+
+  down do
+    rename_column :pages, :next_page, :next
+  end
+end

--- a/lib/api_v1.rb
+++ b/lib/api_v1.rb
@@ -147,7 +147,7 @@ class APIv1 < Grape::API
             optional :hint_text, type: String, desc: "Hint text"
             requires :answer_type, type: String,
                                    values: %w[single_line address date email national_insurance_number phone_number], desc: "Answer type"
-            optional :next, type: String, desc: "The ID of the next page"
+            optional :next_page, type: String, desc: "The ID of the next page"
           end
           put do
             repository = Repositories::PagesRepository.new(@database)
@@ -158,7 +158,7 @@ class APIv1 < Grape::API
               p.question_short_name = params[:question_short_name]
               p.hint_text = params[:hint_text]
               p.answer_type = params[:answer_type]
-              p.next = params[:next]
+              p.next_page = params[:next_page]
             end
 
             repository.update(page)

--- a/lib/domain/page.rb
+++ b/lib/domain/page.rb
@@ -5,7 +5,7 @@ class Domain::Page
                 :question_short_name,
                 :hint_text,
                 :answer_type,
-                :next
+                :next_page
 
   def to_h
     {
@@ -15,7 +15,7 @@ class Domain::Page
       question_short_name:,
       hint_text:,
       answer_type:,
-      next:
+      next_page:
     }
   end
 end

--- a/lib/repositories/pages_repository.rb
+++ b/lib/repositories/pages_repository.rb
@@ -5,8 +5,8 @@ class Repositories::PagesRepository
 
   def create(page)
     # Append the page to the end of the page linked list this means that we
-    # have to set the next value of the page which was last (if there are any
-    # pages) this page would have had next = null. We insert the page then set
+    # have to set the next_page value of the page which was last (if there are any
+    # pages) this page would have had next_page = null. We insert the page then set
     # the value in a single transaction
     @database.transaction(isolation: :serializable) do
       new_page_id = @database[:pages].insert(
@@ -17,7 +17,7 @@ class Repositories::PagesRepository
         answer_type: page.answer_type
       )
 
-      @database[:pages].where(form_id: page.form_id, next: nil).exclude(id: new_page_id).update(next: new_page_id)
+      @database[:pages].where(form_id: page.form_id, next_page: nil).exclude(id: new_page_id).update(next_page: new_page_id)
 
       new_page_id
     end
@@ -35,7 +35,7 @@ class Repositories::PagesRepository
       question_short_name: page.question_short_name,
       hint_text: page.hint_text,
       answer_type: page.answer_type,
-      next: page.next
+      next_page: page.next_page
     )
   end
 
@@ -45,8 +45,8 @@ class Repositories::PagesRepository
 
       # get the next value of our page and update any pages which pointed to us
       # to that instead
-      next_page_id = pages.where(id: page_id).get(:next)
-      pages.where(next: page_id.to_s).update(next: next_page_id)
+      next_page_id = pages.where(id: page_id).get(:next_page)
+      pages.where(next_page: page_id.to_s).update(next_page: next_page_id)
       pages.where(id: page_id).delete
     end
   end
@@ -65,7 +65,7 @@ class Repositories::PagesRepository
       page.question_short_name = page_data[:question_short_name]
       page.hint_text = page_data[:hint_text]
       page.answer_type = page_data[:answer_type]
-      page.next = page_data[:next]
+      page.next_page = page_data[:next_page]
     end
   end
 end

--- a/spec/db/migration_9_spec.rb
+++ b/spec/db/migration_9_spec.rb
@@ -1,0 +1,25 @@
+describe "migration 9" do
+  include_context "with database"
+
+  let(:migrator) { Migrator.new }
+
+  before do
+    migrator.migrate_to(database, 8)
+  end
+  it "adds renames next to next_page and changes type to int from v8 to v9" do
+    form1 = database[:forms].insert(name: "name", submission_email: "submission_email", org: "testorg")
+    form2 = database[:forms].insert(name: "name", submission_email: "submission_email", org: "testorg")
+
+    page_id1 = database[:pages].insert(id: 1, form_id: form1, next: "2", question_text: "question_text", answer_type: "answer_type")
+    page_id2 = database[:pages].insert(id: 2, form_id: form1, next: "3", question_text: "question_text", answer_type: "answer_type")
+    page_id3 = database[:pages].insert(id: 3, form_id: form2, next: nil, question_text: "question_text", answer_type: "answer_type")
+
+    migrator.migrate_to(database, 9)
+
+    expect(database[:pages].where(id: page_id1).first[:next]).to be_nil
+    expect(database[:pages].where(id: page_id1).first[:next_page]).to eq(page_id2.to_s)
+
+    expect(database[:pages].where(id: page_id2).first[:next_page]).to eq(page_id3.to_s)
+    expect(database[:pages].where(id: page_id3).first[:next_page]).to be_nil
+  end
+end

--- a/spec/domain/page_spec.rb
+++ b/spec/domain/page_spec.rb
@@ -7,14 +7,14 @@ describe Domain::Page do
       page.question_short_name = "question_short_name"
       page.hint_text = "hint_text"
       page.answer_type = "answer_type"
-      page.next = "next"
+      page.next_page = "next"
     end
     hashed_page = test_page.to_h
     expect(hashed_page[:question_text]).to eq("question_text")
     expect(hashed_page[:question_short_name]).to eq("question_short_name")
     expect(hashed_page[:hint_text]).to eq("hint_text")
     expect(hashed_page[:answer_type]).to eq("answer_type")
-    expect(hashed_page[:next]).to eq("next")
+    expect(hashed_page[:next_page]).to eq("next")
     expect(hashed_page[:form_id]).to eq("5678")
     expect(hashed_page[:id]).to eq("1234")
   end

--- a/spec/repositories/pages_repository_spec.rb
+++ b/spec/repositories/pages_repository_spec.rb
@@ -17,7 +17,7 @@ describe Repositories::PagesRepository do
       page.question_short_name = "question_short_name"
       page.hint_text = "hint_text"
       page.answer_type = "answer_type"
-      page.next = nil
+      page.next_page = nil
     end
   end
 
@@ -28,7 +28,7 @@ describe Repositories::PagesRepository do
       page.question_short_name = "question_short_name"
       page.hint_text = "hint_text"
       page.answer_type = "answer_type"
-      page.next = nil
+      page.next_page = nil
     end
   end
 
@@ -43,21 +43,21 @@ describe Repositories::PagesRepository do
       expect(created_page[:hint_text]).to eq("hint_text")
       expect(created_page[:answer_type]).to eq("answer_type")
       expect(created_page[:form_id]).to eq(form_id)
-      expect(created_page[:next]).to be_nil
+      expect(created_page[:next_page]).to be_nil
     end
   end
 
   context "create a second page for the same form" do
-    it "should set the previous next attribute to the new page id" do
+    it "should set the previous next_page attribute to the new page id" do
       first_page_id = subject.create(page)
       second_page_id = subject.create(page)
 
       first_page_result = database[:pages].where(id: first_page_id)
 
-      expect(first_page_result.get(:next)).to eq(second_page_id.to_s)
+      expect(first_page_result.get(:next_page)).to eq(second_page_id.to_s)
     end
 
-    it "should not update another form pages next attribute" do
+    it "should not update another form pages next_page attribute" do
       another_form_page_id = subject.create(page_for_another_form)
       first_page_id = subject.create(page)
       second_page_id = subject.create(page)
@@ -65,8 +65,8 @@ describe Repositories::PagesRepository do
       first_page_result = database[:pages].where(id: first_page_id)
       another_form_page_result = database[:pages].where(id: another_form_page_id)
 
-      expect(first_page_result.get(:next)).to eq(second_page_id.to_s)
-      expect(another_form_page_result.get(:next)).to be_nil
+      expect(first_page_result.get(:next_page)).to eq(second_page_id.to_s)
+      expect(another_form_page_result.get(:next_page)).to be_nil
     end
   end
 
@@ -90,7 +90,7 @@ describe Repositories::PagesRepository do
       page.question_short_name = "question_short_name2"
       page.hint_text = "hint_text2"
       page.answer_type = "answer_type2"
-      page.next = "next_page"
+      page.next_page = "next_page"
       update_result = subject.update(page)
 
       page = subject.get(page_id)
@@ -99,7 +99,7 @@ describe Repositories::PagesRepository do
       expect(page.question_short_name).to eq("question_short_name2")
       expect(page.hint_text).to eq("hint_text2")
       expect(page.answer_type).to eq("answer_type2")
-      expect(page.next).to eq("next_page")
+      expect(page.next_page).to eq("next_page")
       expect(page.form_id).to eq(form_id)
 
       repository = Repositories::FormsRepository.new(@database)
@@ -117,43 +117,43 @@ describe Repositories::PagesRepository do
       expect(result).to eq(1)
     end
 
-    it "updates other page next values" do
+    it "updates other page next_page values" do
       first_page_id = subject.create(page)
       second_page_id = subject.create(page)
       third_page_id = subject.create(page)
 
       result = subject.delete(second_page_id)
 
-      first_page_next = database[:pages].where(id: first_page_id).get(:next)
+      first_page_next = database[:pages].where(id: first_page_id).get(:next_page)
       expect(first_page_next).to eq(third_page_id.to_s)
 
       expect(result).to eq(1)
     end
 
-    it "updates other page next values" do
+    it "updates other page next_page values" do
       first_page_id = subject.create(page)
       second_page_id = subject.create(page)
       third_page_id = subject.create(page)
 
       result = subject.delete(second_page_id)
 
-      first_page_next = database[:pages].where(id: first_page_id).get(:next)
+      first_page_next = database[:pages].where(id: first_page_id).get(:next_page)
       expect(first_page_next).to eq(third_page_id.to_s)
       expect(result).to eq(1)
     end
   end
 
   context "deleting a page which does not exist" do
-    it "does not update other page next values" do
+    it "does not update other page next_page values" do
       first_page_id = subject.create(page)
       second_page_id = subject.create(page)
       third_page_id = subject.create(page)
 
       result = subject.delete(999)
 
-      first_page_next = database[:pages].where(id: first_page_id).get(:next)
-      second_page_next = database[:pages].where(id: second_page_id).get(:next)
-      third_page_next = database[:pages].where(id: third_page_id).get(:next)
+      first_page_next = database[:pages].where(id: first_page_id).get(:next_page)
+      second_page_next = database[:pages].where(id: second_page_id).get(:next_page)
+      third_page_next = database[:pages].where(id: third_page_id).get(:next_page)
 
       expect(result).to eq(0)
       expect(first_page_next).to eq(second_page_id.to_s)
@@ -163,16 +163,16 @@ describe Repositories::PagesRepository do
   end
 
   context "deleting a page which does not exist" do
-    it "does not update other page next values" do
+    it "does not update other page next_page values" do
       first_page_id = subject.create(page)
       second_page_id = subject.create(page)
       third_page_id = subject.create(page)
 
       result = subject.delete(999)
 
-      first_page_next = database[:pages].where(id: first_page_id).get(:next)
-      second_page_next = database[:pages].where(id: second_page_id).get(:next)
-      third_page_next = database[:pages].where(id: third_page_id).get(:next)
+      first_page_next = database[:pages].where(id: first_page_id).get(:next_page)
+      second_page_next = database[:pages].where(id: second_page_id).get(:next_page)
+      third_page_next = database[:pages].where(id: third_page_id).get(:next_page)
 
       expect(result).to eq(0)
       expect(first_page_next).to eq(second_page_id.to_s)


### PR DESCRIPTION
#### What problem does the pull request solve?
We've decided to rename the `next` column in the pages table to `next_page`. This is because `next` is a reserved keyword in ruby and we want to save ourselves issues in the future. 

Before this is merged I'll need to make PRs in the admin and runner reflecting this change. 

I will also be updating this column to be an integer, not a string, but this will be part of a separate PR 

#### Checklist

- [x] I've used the pull request template
- [x] I've written unit tests for these changes (if code change)



