### PR TITLE
added api validation

### DIFF
--- a/lib/repositories/forms_repository.rb
+++ b/lib/repositories/forms_repository.rb
@@ -16,6 +16,14 @@ class Repositories::FormsRepository
   end
 
   def update(form)
+    if form[:live_at]
+      the_form = @database[:forms].where(id: form[:form_id])
+      raise "Invalid email" unless form[:submission_email].include?("@")
+      raise "Form has no name" unless form[:name]
+      raise "Form has no pages" unless @database[:pages].where(form_id: form[:form_id]).count > 0
+      raise "Form has a privacy policy" unless form[:privacy_policy_url]
+    end
+
     @database[:forms].where(id: form[:form_id]).update(
       name: form[:name],
       submission_email: form[:submission_email],

--- a/lib/repositories/forms_repository.rb
+++ b/lib/repositories/forms_repository.rb
@@ -18,10 +18,18 @@ class Repositories::FormsRepository
   def update(form)
     if form[:live_at]
       the_form = @database[:forms].where(id: form[:form_id])
-      raise "Invalid email" unless form[:submission_email].include?("@")
-      raise "Form has no name" unless form[:name]
-      raise "Form has no pages" unless @database[:pages].where(form_id: form[:form_id]).count > 0
-      raise "Form has a privacy policy" unless form[:privacy_policy_url]
+      if not form[:submission_email].include?("@")
+        error!({ error: 'invalid', detail: 'email field' }, 400)
+      end
+      if not form[:name]
+        error!({ error: 'missing', detail: 'form name field' }, 400)
+      end
+      if @database[:pages].where(form_id: form[:form_id]).count < 1
+        error!({ error: 'missing', detail: 'form has no pages' }, 400)
+      end
+      if not form[:privacy_policy_url]
+        error!({ error: 'missing', detail: 'form has no privacy policy url' }, 400)
+      end
     end
 
     @database[:forms].where(id: form[:form_id]).update(

--- a/spec/repositories/forms_repository_spec.rb
+++ b/spec/repositories/forms_repository_spec.rb
@@ -82,6 +82,28 @@ describe Repositories::FormsRepository do
       expect(form[:privacy_policy_url]).to eq("https://example.com/privacy-policy")
       expect(form[:what_happens_next_text]).to eq("text on what happens next")
     end
+    it "updates a form with bad data" do
+      pages_repository = Repositories::PagesRepository.new(@database)
+
+      page_id = pages_repository.create(page)
+      page.id = page_id
+      page.question_text = "question_text2"
+      page.question_short_name = "question_short_name2"
+      page.hint_text = "hint_text2"
+      page.answer_type = "answer_type2"
+      page.next_page = "next_page"
+      page.form_id = form_id
+      
+      update_result = subject.update({ form_id:, name: "name2", submission_email: "submissionemail2", org: "org2", live_at: Time.now, privacy_policy_url: "https://example.com/privacy-policy" })
+      form = subject.get(form_id)
+      expect(update_result).to eq(1)
+      expect(form[:name]).to eq("name2")
+      expect(form[:submission_email]).to eq("submission@email2")
+      expect(form[:org]).to eq("org2")
+      expect(form[:updated_at].to_i).to be_within(3).of(Time.now.to_i)
+      expect(form[:live_at].to_i).to be_within(3).of(Time.now.to_i)
+      expect(form[:privacy_policy_url]).to eq("https://example.com/privacy-policy")
+    end
   end
 
   context "deleting a form" do


### PR DESCRIPTION
To allow a difference between form creators to have forms which are in a draft state/live state.

Add API validation on changing the live_at field to validate the submission_email, name, at least one page and privacy notice exist.

#### What problem does the pull request solve?

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


