### PR TITLE
Add what happens next

### DIFF
--- a/db/migrations/012_add_what_happens_next_to_forms.rb
+++ b/db/migrations/012_add_what_happens_next_to_forms.rb
@@ -1,0 +1,8 @@
+Sequel.migration do
+  up do
+    add_column :forms, :what_happens_next_text, String
+  end
+  down do
+    drop_column :forms, :what_happens_next_text
+  end
+end

--- a/lib/api_v1.rb
+++ b/lib/api_v1.rb
@@ -78,6 +78,7 @@ class APIv1 < Grape::API
         requires :org, type: String, desc: "Organization slug."
         requires :live_at, type: String, desc: "Live at."
         optional :privacy_policy_url, type: String, desc: "Privacy policy URL."
+        optional :what_happens_next_text, type: String, desc: "What happens next."
       end
       put do
         repository = Repositories::FormsRepository.new(@database)

--- a/lib/repositories/forms_repository.rb
+++ b/lib/repositories/forms_repository.rb
@@ -22,6 +22,7 @@ class Repositories::FormsRepository
       org: form[:org],
       live_at: form[:live_at],
       privacy_policy_url: form[:privacy_policy_url],
+      what_happens_next_text: form[:what_happens_next_text],
       form_slug: form[:name].parameterize,
       updated_at: Time.now
     )

--- a/spec/db/migration_012_spec.rb
+++ b/spec/db/migration_012_spec.rb
@@ -1,0 +1,20 @@
+describe "migration 12" do
+  include_context "with database"
+
+  let(:migrator) { Migrator.new }
+
+  before do
+    migrator.migrate_to(database, 11)
+  end
+  it "adds a what_happens_next_text field to forms table from v11 to v12" do
+    form_id = database[:forms].insert(name: "name", submission_email: "submission_email", org: "testorg")
+
+    migrator.migrate_to(database, 12)
+
+    database[:forms].where(id: form_id).update(what_happens_next_text: "some text on what happens next")
+
+    updated_form = database[:forms].where(id: form_id).first
+
+    expect(updated_form[:what_happens_next_text]).to eq("some text on what happens next 1")
+  end
+end

--- a/spec/db/migration_012_spec.rb
+++ b/spec/db/migration_012_spec.rb
@@ -15,6 +15,6 @@ describe "migration 12" do
 
     updated_form = database[:forms].where(id: form_id).first
 
-    expect(updated_form[:what_happens_next_text]).to eq("some text on what happens next 1")
+    expect(updated_form[:what_happens_next_text]).to eq("some text on what happens next")
   end
 end

--- a/spec/repositories/forms_repository_spec.rb
+++ b/spec/repositories/forms_repository_spec.rb
@@ -44,7 +44,7 @@ describe Repositories::FormsRepository do
   context "updating a form" do
     it "updates a form" do
       form_id = subject.create("Form 1 (basic form)?", "submission_email", "org")
-      update_result = subject.update({ form_id:, name: "Form 2 (basic form)?", submission_email: "submission_email2", org: "org2", live_at: Time.now, privacy_policy_url: "https://example.com/privacy-policy" })
+      update_result = subject.update({ form_id:, name: "Form 2 (basic form)?", submission_email: "submission_email2", org: "org2", live_at: Time.now, privacy_policy_url: "https://example.com/privacy-policy", what_happens_next_text: "text on what happens next" })
       form = subject.get(form_id)
       expect(update_result).to eq(1)
       expect(form[:name]).to eq("Form 2 (basic form)?")
@@ -54,6 +54,7 @@ describe Repositories::FormsRepository do
       expect(form[:updated_at].to_i).to be_within(3).of(Time.now.to_i)
       expect(form[:live_at].to_i).to be_within(3).of(Time.now.to_i)
       expect(form[:privacy_policy_url]).to eq("https://example.com/privacy-policy")
+      expect(form[:what_happens_next_text]).to eq("text on what happens next")
     end
   end
 


### PR DESCRIPTION
#### What problem does the pull request solve?
This PR adds a field called "what_happens_next_text" field to the form table. Happy to hear any suggestions on a better name if you have one. 
relates to this trello ticket: https://trello.com/c/4mCMqpda/356-add-what-happens-next-to-the-confirmation-page-should-have

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- N/A I've updated the documentation in (If any documentation requires updating)
    - N/A README.md
    - N/A Elsewhere (please link)


