### PR TITLE
18 add form specific contact details for support to forms api

### DIFF
--- a/db/migrations/013_add_contact_details_to_forms.rb
+++ b/db/migrations/013_add_contact_details_to_forms.rb
@@ -1,0 +1,14 @@
+Sequel.migration do
+  up do
+    add_column :forms, :support_email, String
+    add_column :forms, :support_phone, String
+    add_column :forms, :support_url, String
+    add_column :forms, :support_url_text, String
+  end
+  down do
+    drop_column :forms, :support_email
+    drop_column :forms, :support_phone
+    drop_column :forms, :support_url
+    drop_column :forms, :support_url_text
+  end
+end

--- a/lib/api_v1.rb
+++ b/lib/api_v1.rb
@@ -79,6 +79,10 @@ class APIv1 < Grape::API
         requires :live_at, type: String, desc: "Live at."
         optional :privacy_policy_url, type: String, desc: "Privacy policy URL."
         optional :what_happens_next_text, type: String, desc: "What happens next."
+        optional :support_email, type: String, desc: "Support email address"
+        optional :support_phone, type: String, desc: "Support phone contact details"
+        optional :support_url, type: String, desc: "Support url"
+        optional :support_url_text, type: String, desc: "Support url text"
       end
       put do
         repository = Repositories::FormsRepository.new(@database)

--- a/lib/repositories/forms_repository.rb
+++ b/lib/repositories/forms_repository.rb
@@ -24,6 +24,10 @@ class Repositories::FormsRepository
       privacy_policy_url: form[:privacy_policy_url],
       what_happens_next_text: form[:what_happens_next_text],
       form_slug: form[:name].parameterize,
+      support_email: form[:support_email],
+      support_phone: form[:support_phone],
+      support_url: form[:support_url],
+      support_url_text: form[:support_url_text],
       updated_at: Time.now
     )
   end

--- a/spec/db/migration_013_spec.rb
+++ b/spec/db/migration_013_spec.rb
@@ -1,0 +1,27 @@
+describe "migration 13" do
+  include_context "with database"
+
+  let(:migrator) { Migrator.new }
+  let(:support_email) { "test@email.com" }
+  let(:support_phone) { "8675309" }
+  let(:support_url) { "http://www.example.com" }
+  let(:support_url_text) { "Support page" }
+
+  before do
+    migrator.migrate_to(database, 12)
+  end
+  it "adds contact details to forms from v12 to v13" do
+    form_id = database[:forms].insert(name: "name", submission_email: "submission_email", org: "testorg")
+
+    migrator.migrate_to(database, 13)
+
+    database[:forms].where(id: form_id).update(support_email:, support_phone:, support_url:, support_url_text:)
+
+    updated_form = database[:forms].where(id: form_id).first
+
+    expect(updated_form[:support_email]).to eq(support_email)
+    expect(updated_form[:support_phone]).to eq(support_phone)
+    expect(updated_form[:support_url]).to eq(support_url)
+    expect(updated_form[:support_url_text]).to eq(support_url_text)
+  end
+end

--- a/spec/repositories/forms_repository_spec.rb
+++ b/spec/repositories/forms_repository_spec.rb
@@ -44,7 +44,7 @@ describe Repositories::FormsRepository do
   context "updating a form" do
     it "updates a form" do
       form_id = subject.create("Form 1 (basic form)?", "submission_email", "org")
-      update_result = subject.update({ form_id:, name: "Form 2 (basic form)?", submission_email: "submission_email2", org: "org2", live_at: Time.now, privacy_policy_url: "https://example.com/privacy-policy", what_happens_next_text: "text on what happens next" })
+      update_result = subject.update({ form_id:, name: "Form 2 (basic form)?", submission_email: "submission_email2", org: "org2", live_at: Time.now, privacy_policy_url: "https://example.com/privacy-policy", what_happens_next_text: "text on what happens next", support_email: "test@email.com", support_phone: "8675309", support_url: "http://www.example.com", support_url_text: "Support page" })
       form = subject.get(form_id)
       expect(update_result).to eq(1)
       expect(form[:name]).to eq("Form 2 (basic form)?")
@@ -55,6 +55,10 @@ describe Repositories::FormsRepository do
       expect(form[:live_at].to_i).to be_within(3).of(Time.now.to_i)
       expect(form[:privacy_policy_url]).to eq("https://example.com/privacy-policy")
       expect(form[:what_happens_next_text]).to eq("text on what happens next")
+      expect(form[:support_email]).to eq("test@email.com")
+      expect(form[:support_phone]).to eq("8675309")
+      expect(form[:support_url]).to eq("http://www.example.com")
+      expect(form[:support_url_text]).to eq("Support page")
     end
   end
 


### PR DESCRIPTION
#### What problem does the pull request solve?

https://trello.com/c/92U8erwW/18-add-form-specific-contact-details-for-support-to-forms-api-should-have

Adds four contact details columns to the forms model - `support_email`, `support_phone`, `support_url`, `support_url_link` 

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [x] I've updated the documentation in (If any documentation requires updating)
    - [x] README.md
    - [x] Elsewhere (please link)


