### PR TITLE
Minor amendments to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,20 @@
-FROM ruby:3.1.1-alpine
+# NOTE: Before using in production we must consider the need to pin
+# images to a SHA
+FROM ruby:3.1.1-alpine3.15
 
-RUN apk --no-cache add postgresql-dev postgresql-libs postgresql-client less
+RUN apk update
+RUN apk upgrade --available
+RUN apk --no-cache add libpq-dev
 
 WORKDIR /app
 COPY .ruby-version Gemfile Gemfile.lock ./
 RUN apk --no-cache add alpine-sdk && bundle install && apk del alpine-sdk
 
-ADD . /app
+RUN adduser -D ruby
+USER ruby
+
+# Consider whittling this down to just what we need to run the app
+COPY --chown=ruby:ruby . .
 
 EXPOSE 9292
-CMD bundle exec rackup
+CMD ["rackup", "--host", "0.0.0.0", "--port", "9292"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  aarch64-linux-musl
   arm64-darwin-21
   x86_64-darwin-20
   x86_64-linux


### PR DESCRIPTION
- Add and use a non-root user named ruby
- Run the server to listen on 0.0.0.0 so it'll work without needing host networking

#### What problem does the pull request solve?
Using a non-root user is more secure. Currently the image is only used for Cypress testing forms-admin where the network mode is set to host. In order for this image to work without host networking the server needs to listen on `0.0.0.0` which will bind to all network interfaces in the network namespace.

### Testing
This builds ok on my M1 mac. We'll add github actions to run the build of these Dockerfiles on any change.

There's a small risk that this might break the forms-admin cypress tests but since the exposed port remains as `9292` it should be ok.

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


