### PR TITLE
Configure number of instances

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,4 +32,5 @@ jobs:
           cf push --strategy rolling \
             --var PAAS_ENVIRONMENT=dev \
             --var SENTRY_DSN=${{ secrets.SENTRY_DSN }} \
+            --var INSTANCES=2 \
             --var API_KEY=${{ secrets.API_KEY }}

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,6 +2,7 @@
 applications:
   - name: forms-api-((PAAS_ENVIRONMENT))
     memory: 256M
+    instances: ((INSTANCES))
     command: bundle exec rackup -o 0.0.0.0 -p $PORT
     services:
       - forms-api-((PAAS_ENVIRONMENT))-db


### PR DESCRIPTION
Allow the number of app instances to be configurable when deploying to PaaS. Set the number of instances to 2 in development.

### What problem does the pull request solve?
We should run at least two instances to avoid down time to PaaS maintenance and if an application instance crashes. The number of instances can be configured per environment should more than two be necessary for capacity planning reasons.

Dev has been set to 2 because often issues arise when going from a single to multiple instances and this will allow us to see such problems in dev environments.

Linked to: https://github.com/alphagov/forms-deploy/compare/configure_instances?expand=1
