### PR TITLE
Switch is_optional from TrueClass to String

### DIFF
--- a/lib/api_v1.rb
+++ b/lib/api_v1.rb
@@ -117,7 +117,7 @@ class APIv1 < Grape::API
           optional :hint_text, type: String, desc: "Hint text"
           requires :answer_type, type: String,
                                  values: %w[single_line address date email national_insurance_number phone_number], desc: "Answer type"
-          optional :is_optional, type: TrueClass, desc: "Optional question?"
+          optional :is_optional, type: String, desc: "Optional question?"
         end
         post do
           repository = Repositories::PagesRepository.new(@database)
@@ -155,7 +155,7 @@ class APIv1 < Grape::API
             requires :answer_type, type: String,
                                    values: %w[single_line address date email national_insurance_number phone_number], desc: "Answer type"
             optional :next_page, type: String, desc: "The ID of the next page"
-            optional :is_optional, type: TrueClass, desc: "Optional question?"
+            optional :is_optional, type: String, desc: "Optional question?"
           end
           put do
             repository = Repositories::PagesRepository.new(@database)


### PR DESCRIPTION
#### What problem does the pull request solve?
None of our other params have specific types. There also had a problem with the requests coming from forms-admin where the value was being sent as strings in the call. The database column is setup as boolean so should fail any requests that try to set it to non-boolean values.

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


