### PR TITLE
Add declaration_text to forms

### DIFF
--- a/db/migrations/015_add_declaration_to_forms.rb
+++ b/db/migrations/015_add_declaration_to_forms.rb
@@ -1,0 +1,8 @@
+Sequel.migration do
+  up do
+    add_column :forms, :declaration_text, String
+  end
+  down do
+    drop_column :forms, :declaration_text
+  end
+end

--- a/lib/api_v1.rb
+++ b/lib/api_v1.rb
@@ -79,6 +79,7 @@ class APIv1 < Grape::API
         requires :live_at, type: String, desc: "Live at."
         optional :privacy_policy_url, type: String, desc: "Privacy policy URL."
         optional :what_happens_next_text, type: String, desc: "What happens next."
+        optional :declaration_text, type: String, desc: "Declaration text."
         optional :support_email, type: String, desc: "Support email address"
         optional :support_phone, type: String, desc: "Support phone contact details"
         optional :support_url, type: String, desc: "Support url"

--- a/lib/repositories/forms_repository.rb
+++ b/lib/repositories/forms_repository.rb
@@ -23,6 +23,7 @@ class Repositories::FormsRepository
       live_at: form[:live_at],
       privacy_policy_url: form[:privacy_policy_url],
       what_happens_next_text: form[:what_happens_next_text],
+      declaration_text: form[:declaration_text],
       form_slug: form[:name].parameterize,
       support_email: form[:support_email],
       support_phone: form[:support_phone],

--- a/spec/db/migration_015_spec.rb
+++ b/spec/db/migration_015_spec.rb
@@ -1,0 +1,20 @@
+describe "migration 14" do
+  include_context "with database"
+
+  let(:migrator) { Migrator.new }
+
+  before do
+    migrator.migrate_to(database, 14)
+  end
+  it "adds a declaration_text field to forms table from v14 to v15" do
+    form_id = database[:forms].insert(name: "name", submission_email: "submission_email", org: "testorg")
+
+    migrator.migrate_to(database, 15)
+
+    database[:forms].where(id: form_id).update(declaration_text: "some declaration text")
+
+    updated_form = database[:forms].where(id: form_id).first
+
+    expect(updated_form[:declaration_text]).to eq("some declaration text")
+  end
+end

--- a/spec/repositories/forms_repository_spec.rb
+++ b/spec/repositories/forms_repository_spec.rb
@@ -44,7 +44,7 @@ describe Repositories::FormsRepository do
   context "updating a form" do
     it "updates a form" do
       form_id = subject.create("Form 1 (basic form)?", "submission_email", "org")
-      update_result = subject.update({ form_id:, name: "Form 2 (basic form)?", submission_email: "submission_email2", org: "org2", live_at: Time.now, privacy_policy_url: "https://example.com/privacy-policy", what_happens_next_text: "text on what happens next", support_email: "test@email.com", support_phone: "8675309", support_url: "http://www.example.com", support_url_text: "Support page" })
+      update_result = subject.update({ form_id:, name: "Form 2 (basic form)?", submission_email: "submission_email2", org: "org2", live_at: Time.now, privacy_policy_url: "https://example.com/privacy-policy", what_happens_next_text: "text on what happens next", declaration_text: "declaration text", support_email: "test@email.com", support_phone: "8675309", support_url: "http://www.example.com", support_url_text: "Support page" })
       form = subject.get(form_id)
       expect(update_result).to eq(1)
       expect(form[:name]).to eq("Form 2 (basic form)?")
@@ -55,6 +55,7 @@ describe Repositories::FormsRepository do
       expect(form[:live_at].to_i).to be_within(3).of(Time.now.to_i)
       expect(form[:privacy_policy_url]).to eq("https://example.com/privacy-policy")
       expect(form[:what_happens_next_text]).to eq("text on what happens next")
+      expect(form[:declaration_text]).to eq("declaration text")
       expect(form[:support_email]).to eq("test@email.com")
       expect(form[:support_phone]).to eq("8675309")
       expect(form[:support_url]).to eq("http://www.example.com")


### PR DESCRIPTION
#### What problem does the pull request solve?
https://trello.com/c/T2Hl1g1p/232-add-custom-declaration-field-for-the-check-your-answers-page-to-the-api

This PR adds a new field to forms - declaration text. This field store the declaration a form creator would like the form-filler to see before submitting the form.

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


