### PR TITLE
Setup a Database Connection Once

### DIFF
--- a/db/database.rb
+++ b/db/database.rb
@@ -3,11 +3,15 @@ require "uri"
 require_relative "./migrator"
 
 class Database
+  @database = nil
+
   def self.existing_database
-    database = Sequel.connect(ENV["DATABASE_URL"])
-    database.extension :pg_json
-    database.extension :pg_array
-    database
+    if @database.nil?
+      @database = Sequel.connect(ENV["DATABASE_URL"])
+      @database.extension :pg_json
+      @database.extension :pg_array
+    end
+    @database
   end
 
   def self.fresh_database

--- a/lib/api_v1.rb
+++ b/lib/api_v1.rb
@@ -27,10 +27,6 @@ class APIv1 < Grape::API
     @database = Database.existing_database
   end
 
-  finally do
-    @database.disconnect if @database.present?
-  end
-
   resource :forms do
     desc "Return all forms by org."
     params do


### PR DESCRIPTION
Create a single instance of the  Sequel Database object and use it to run queries across all API requests. Previously a new Sequel Database object was being created for every API request which were not being garbage collected and so eventually exhausted memory.

#### What problem does the pull request solve?
Forms-api micro service routinely crashes after exhausting available memory, as shown in the memory stats from production below. The app logs note 'app crashed' and the container exits with status code 137.

![Screenshot 2022-10-13 at 12 05 52 pm](https://user-images.githubusercontent.com/31340341/197555262-9d88c184-2f47-44c7-9a73-82b956ac603a.png)

The issue can be replicated locally with the docker-compose set-up and sending requests to simply get the first page of a form. The heap dumps showed a linear build up of database related objects and memory allocation with each api call. This seems to be because a new Sequel database object was being instantiated each time with calling `Sequel.connect`: 
https://sequel.jeremyevans.net/rdoc/files/doc/opening_databases_rdoc.html

I think the consequences of creating a new Sequel database object have been seen previously and likely the cause of the ever increasing database connections which was initially[ resolved by calling `disconnect`](https://github.com/alphagov/forms-api/commit/1cb0d4fa0100831f3ae9ae0e48131c67aa17167e). Note from the Sequel docs

> All Database instances have their own connection pools.
https://sequel.jeremyevans.net/rdoc/classes/Sequel/Database.html#4+-+Methods+relating+to+adapters-2C+connecting-2C+disconnecting-2C+and+sharding

However only disconnecting seems to leave the related objects on the heap and eventually exhausts the memory. It seems more efficient to instantiate a single instance of the Sequel database object with its connection pool and allow those connections to be managed by the database object.

### Heap dumps
The following snippet shows heap dumps at 1, 2,  3 and 4 requests before the fix with prominent sql and pg objects building up linearly. Note the increase in pg objects from pg/connection

<details>
 <summary>Show heap dump summaries (formatting isn't great...)</summary>

 1st request:
GDS11321:forms-api dan.worth$ heapy diff heap.dump.2022-10-14T07\:33\:34Z heap.dump.2022-10-14T07\:33\:50Z | head -n 10
Allocated STRING 326 objects of size 13468/444150 (in bytes) at: /usr/local/bundle/gems/pg-1.4.3/lib/pg/connection.rb:278
Allocated STRING 314 objects of size 12930/444150 (in bytes) at: /usr/local/bundle/gems/pg-1.4.3/lib/pg/connection.rb:692
Allocated STRING 304 objects of size 12530/444150 (in bytes) at: /usr/local/bundle/gems/pg-1.4.3/lib/pg/connection.rb:691
Allocated STRING 254 objects of size 37326/444150 (in bytes) at: /usr/local/bundle/gems/rack-2.2.3.1/lib/rack/lint.rb:81
Allocated IMEMO 170 objects of size 17552/444150 (in bytes) at: /usr/local/bundle/gems/sequel-5.61.0/lib/sequel/extensions/pg_array.rb:214
Allocated STRING 144 objects of size 6920/444150 (in bytes) at: /usr/local/lib/ruby/3.1.0/time.rb:380
Allocated STRING 142 objects of size 5982/444150 (in bytes) at: /usr/local/bundle/gems/pg-1.4.3/lib/pg/connection.rb:39
Allocated DATA 112 objects of size 8960/444150 (in bytes) at: /usr/local/bundle/gems/sequel-5.61.0/lib/sequel/extensions/pg_array.rb:214
Allocated ARRAY 80 objects of size 3200/444150 (in bytes) at: /usr/local/bundle/gems/grape-1.6.2/lib/grape/request.rb:38
Allocated HASH 76 objects of size 15808/444150 (in bytes) at: /usr/local/bundle/gems/pg-1.4.3/lib/pg/connection.rb:692

2nd request:
GDS11321:forms-api dan.worth$ heapy diff heap.dump.2022-10-14T07\:33\:34Z heap.dump.2022-10-14T07\:36\:25Z | head -n 10
Allocated STRING 762 objects of size 111960/1017253 (in bytes) at: /usr/local/bundle/gems/rack-2.2.3.1/lib/rack/lint.rb:81
Allocated STRING 652 objects of size 26936/1017253 (in bytes) at: /usr/local/bundle/gems/pg-1.4.3/lib/pg/connection.rb:278
Allocated STRING 628 objects of size 25860/1017253 (in bytes) at: /usr/local/bundle/gems/pg-1.4.3/lib/pg/connection.rb:692
Allocated STRING 608 objects of size 25060/1017253 (in bytes) at: /usr/local/bundle/gems/pg-1.4.3/lib/pg/connection.rb:691
Allocated IMEMO 340 objects of size 35104/1017253 (in bytes) at: /usr/local/bundle/gems/sequel-5.61.0/lib/sequel/extensions/pg_array.rb:214
Allocated STRING 288 objects of size 13840/1017253 (in bytes) at: /usr/local/lib/ruby/3.1.0/time.rb:380
Allocated STRING 284 objects of size 11964/1017253 (in bytes) at: /usr/local/bundle/gems/pg-1.4.3/lib/pg/connection.rb:39
Allocated DATA 224 objects of size 17920/1017253 (in bytes) at: /usr/local/bundle/gems/sequel-5.61.0/lib/sequel/extensions/pg_array.rb:214
Allocated ARRAY 171 objects of size 6840/1017253 (in bytes) at: /usr/local/bundle/gems/puma-5.6.5/lib/puma/thread_pool.rb:282
Allocated ARRAY 160 objects of size 6400/1017253 (in bytes) at: /usr/local/bundle/gems/grape-1.6.2/lib/grape/request.rb:38

3rd request:
GDS11321:forms-api dan.worth$ heapy diff heap.dump.2022-10-14T07\:33\:34Z heap.dump.2022-10-14T07\:38\:49Z | head -n 10
Allocated STRING 1270 objects of size 186594/1589732 (in bytes) at: /usr/local/bundle/gems/rack-2.2.3.1/lib/rack/lint.rb:81
Allocated STRING 978 objects of size 40404/1589732 (in bytes) at: /usr/local/bundle/gems/pg-1.4.3/lib/pg/connection.rb:278
Allocated STRING 942 objects of size 38790/1589732 (in bytes) at: /usr/local/bundle/gems/pg-1.4.3/lib/pg/connection.rb:692
Allocated STRING 912 objects of size 37590/1589732 (in bytes) at: /usr/local/bundle/gems/pg-1.4.3/lib/pg/connection.rb:691
Allocated IMEMO 510 objects of size 52656/1589732 (in bytes) at: /usr/local/bundle/gems/sequel-5.61.0/lib/sequel/extensions/pg_array.rb:214
Allocated STRING 432 objects of size 20760/1589732 (in bytes) at: /usr/local/lib/ruby/3.1.0/time.rb:380
Allocated STRING 426 objects of size 17946/1589732 (in bytes) at: /usr/local/bundle/gems/pg-1.4.3/lib/pg/connection.rb:39
Allocated DATA 336 objects of size 26880/1589732 (in bytes) at: /usr/local/bundle/gems/sequel-5.61.0/lib/sequel/extensions/pg_array.rb:214
Allocated ARRAY 318 objects of size 12720/1589732 (in bytes) at: /usr/local/bundle/gems/puma-5.6.5/lib/puma/thread_pool.rb:282
Allocated ARRAY 240 objects of size 9600/1589732 (in bytes) at: /usr/local/bundle/gems/grape-1.6.2/lib/grape/request.rb:38

4th Request (approx 20 minutes later)
Allocated STRING 1304 objects of size 53872/2197867 (in bytes) at: /usr/local/bundle/gems/pg-1.4.3/lib/pg/connection.rb:278
Allocated STRING 1256 objects of size 51720/2197867 (in bytes) at: /usr/local/bundle/gems/pg-1.4.3/lib/pg/connection.rb:692
Allocated ARRAY 1250 objects of size 50000/2197867 (in bytes) at: /usr/local/bundle/gems/puma-5.6.5/lib/puma/thread_pool.rb:282
Allocated STRING 1216 objects of size 50120/2197867 (in bytes) at: /usr/local/bundle/gems/pg-1.4.3/lib/pg/connection.rb:691
Allocated IMEMO 680 objects of size 70208/2197867 (in bytes) at: /usr/local/bundle/gems/sequel-5.61.0/lib/sequel/extensions/pg_array.rb:214
Allocated STRING 576 objects of size 27680/2197867 (in bytes) at: /usr/local/lib/ruby/3.1.0/time.rb:380
Allocated STRING 568 objects of size 23928/2197867 (in bytes) at: /usr/local/bundle/gems/pg-1.4.3/lib/pg/connection.rb:39
Allocated DATA 448 objects of size 35840/2197867 (in bytes) at: /usr/local/bundle/gems/sequel-5.61.0/lib/sequel/extensions/pg_array.rb:214
Allocated ARRAY 320 objects of size 12800/2197867 (in bytes) at: /usr/local/bundle/gems/grape-1.6.2/lib/grape/request.rb:38
</details>

### Testing with 1000 api requests
Before the fix, 1000 api requests results in a memory usage of 153MB and usage grew with each request.
```
CONTAINER ID   NAME                   CPU %     MEM USAGE / LIMIT     MEM %     NET I/O           BLOCK I/O         PIDS
82d2d3339bda   local_forms-api_1      0.04%     153.3MiB / 256MiB     59.88%    8.82MB / 5.75MB   14.4MB / 0B       6
```

After the this change is applied it peaks at 46MB and remains constant.

```
CONTAINER ID   NAME                   CPU %     MEM USAGE / LIMIT     MEM %     NET I/O           BLOCK I/O        PIDS
4feaecc100d1   local_forms-api_1      0.01%     46.03MiB / 256MiB     17.98%    4.76MB / 2.27MB   0B / 0B          5

```

The total number of connections as reported by `pg_stat_database` is only 2 for the `forms-api` database which seems to suggest we do not hit the growing number of connections with this approach.
```
forms_api=> select numbackends from pg_stat_database where datname = 'forms_api';
-[ RECORD 1 ]--
numbackends | 2
```

### Reviewer notes
My Ruby and even more so my knowledge of Grape is limited. There might be a more idomatic way of instantiating a single db client once and using it througout api requests so please let me know (I couldn't see it in the Grape docs).

It possible that instantiating a single forms and pages repository might be beneficial but I thought we'd make one change at a time.

I have no prior experience with this DB client so I'm not sure how well it handles recovering from failed connections etc. Ideally we'd have a health check endpoint which would check its connectivity and report on a scheduled basis. Possibly a means to attempt to reconnect if connection is lost (but i'd expect the db client to manage that, unless anyone knows otherwise).

This PR is probably worth talking through so please let me know if you're interested.

#### Checklist

- [x] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


