### PR TITLE
Allow form-creators to mark "Questions" task as complete

### DIFF
--- a/db/migrations/016_add_question_section_completed_to_form.rb
+++ b/db/migrations/016_add_question_section_completed_to_form.rb
@@ -1,6 +1,10 @@
 Sequel.migration do
   up do
     add_column :forms, :question_section_completed, TrueClass, default: false
+
+    from(:forms).exclude(live_at: nil).each do |live_form|
+      from(:forms).where(id: live_form[:id]).update(question_section_completed: true)
+    end
   end
   down do
     drop_column :forms, :question_section_completed

--- a/db/migrations/016_add_question_section_completed_to_form.rb
+++ b/db/migrations/016_add_question_section_completed_to_form.rb
@@ -1,0 +1,8 @@
+Sequel.migration do
+  up do
+    add_column :forms, :question_section_completed, TrueClass, default: false
+  end
+  down do
+    drop_column :forms, :question_section_completed
+  end
+end

--- a/lib/api_v1.rb
+++ b/lib/api_v1.rb
@@ -76,6 +76,7 @@ class APIv1 < Grape::API
         optional :privacy_policy_url, type: String, desc: "Privacy policy URL."
         optional :what_happens_next_text, type: String, desc: "What happens next."
         optional :declaration_text, type: String, desc: "Declaration text."
+        optional :question_section_completed, type: String, desc: "Used to identify whether forms questions section has been completed"
         optional :support_email, type: String, desc: "Support email address"
         optional :support_phone, type: String, desc: "Support phone contact details"
         optional :support_url, type: String, desc: "Support url"

--- a/lib/repositories/forms_repository.rb
+++ b/lib/repositories/forms_repository.rb
@@ -25,7 +25,7 @@ class Repositories::FormsRepository
       what_happens_next_text: form[:what_happens_next_text],
       declaration_text: form[:declaration_text],
       question_section_completed: form[:question_section_completed],
-      form_slug: form[:name].parameterize,
+      form_slug: form[:name]&.parameterize,
       support_email: form[:support_email],
       support_phone: form[:support_phone],
       support_url: form[:support_url],

--- a/lib/repositories/forms_repository.rb
+++ b/lib/repositories/forms_repository.rb
@@ -24,6 +24,7 @@ class Repositories::FormsRepository
       privacy_policy_url: form[:privacy_policy_url],
       what_happens_next_text: form[:what_happens_next_text],
       declaration_text: form[:declaration_text],
+      question_section_completed: form[:question_section_completed],
       form_slug: form[:name].parameterize,
       support_email: form[:support_email],
       support_phone: form[:support_phone],

--- a/lib/repositories/pages_repository.rb
+++ b/lib/repositories/pages_repository.rb
@@ -39,6 +39,8 @@ class Repositories::PagesRepository
       next_page: page.next_page,
       is_optional: page.is_optional
     )
+
+    @database[:forms].where(id: page.form_id).update(question_section_completed: false)
   end
 
   def delete(page_id)

--- a/lib/repositories/pages_repository.rb
+++ b/lib/repositories/pages_repository.rb
@@ -20,6 +20,8 @@ class Repositories::PagesRepository
 
       @database[:pages].where(form_id: page.form_id, next_page: nil).exclude(id: new_page_id).update(next_page: new_page_id)
 
+      @database[:forms].where(id: page.form_id).update(question_section_completed: false)
+
       new_page_id
     end
   end

--- a/spec/db/migration_015_spec.rb
+++ b/spec/db/migration_015_spec.rb
@@ -1,4 +1,4 @@
-describe "migration 14" do
+describe "migration 15" do
   include_context "with database"
 
   let(:migrator) { Migrator.new }

--- a/spec/db/migration_016_spec.rb
+++ b/spec/db/migration_016_spec.rb
@@ -1,0 +1,26 @@
+describe "migration 16" do
+  include_context "with database"
+
+  let(:migrator) { Migrator.new }
+
+  before do
+    migrator.migrate_to(database, 15)
+  end
+  it "adds a question_section_completed field to forms table from v15 to v16" do
+    question_not_completed_form_id = database[:forms].insert(name: "name 1", submission_email: "submission_email", org: "testorg")
+    question_section_completed_form_id = database[:forms].insert(name: "name 2", submission_email: "submission_email", org: "testorg")
+
+    migrator.migrate_to(database, 16)
+
+    database[:forms].where(id: question_section_completed_form_id).update(question_section_completed: true)
+
+    updated_form = database[:forms].where(id: question_section_completed_form_id).first
+
+    expect(updated_form[:question_section_completed]).to eq true
+
+    existing_form = database[:forms].where(id: question_not_completed_form_id).first
+
+    expect(existing_form[:question_section_completed]).to eq false
+
+  end
+end

--- a/spec/db/migration_016_spec.rb
+++ b/spec/db/migration_016_spec.rb
@@ -21,7 +21,6 @@ describe "migration 16" do
     existing_form = database[:forms].where(id: question_not_completed_form_id).first
 
     expect(existing_form[:question_section_completed]).to eq false
-
   end
 
   it "marks existing live forms question_section_completed to true" do

--- a/spec/db/migration_016_spec.rb
+++ b/spec/db/migration_016_spec.rb
@@ -23,4 +23,19 @@ describe "migration 16" do
     expect(existing_form[:question_section_completed]).to eq false
 
   end
+
+  it "marks existing live forms question_section_completed to true" do
+    live_form_id = database[:forms].insert(name: "name 1", submission_email: "submission_email", org: "testorg", live_at: Time.now)
+    draft_form_id = database[:forms].insert(name: "name 2", submission_email: "submission_email", org: "testorg")
+
+    migrator.migrate_to(database, 17)
+
+    live_form = database[:forms].where(id: live_form_id).first
+
+    expect(live_form[:question_section_completed]).to eq true
+
+    draft_form = database[:forms].where(id: draft_form_id).first
+
+    expect(draft_form[:question_section_completed]).to eq false
+  end
 end

--- a/spec/repositories/forms_repository_spec.rb
+++ b/spec/repositories/forms_repository_spec.rb
@@ -44,18 +44,7 @@ describe Repositories::FormsRepository do
   context "updating a form" do
     it "updates a form" do
       form_id = subject.create("Form 1 (basic form)?", "submission_email", "org")
-      update_result = subject.update({form_id:,
-                                      name: "Form 2 (basic form)?",
-                                      submission_email: "submission_email2",
-                                      org: "org2",
-                                      live_at: Time.now,
-                                      privacy_policy_url: "https://example.com/privacy-policy",
-                                      what_happens_next_text: "text on what happens next",
-                                      declaration_text: "declaration text",
-                                      support_email: "test@email.com",
-                                      support_phone: "8675309",
-                                      support_url: "http://www.example.com",
-                                      support_url_text: "Support page" })
+      update_result = subject.update({ form_id:, name: "Form 2 (basic form)?", submission_email: "submission_email2", org: "org2", live_at: Time.now, privacy_policy_url: "https://example.com/privacy-policy", what_happens_next_text: "text on what happens next", declaration_text: "declaration text", support_email: "test@email.com", support_phone: "8675309", support_url: "http://www.example.com", support_url_text: "Support page", question_section_completed: true })
       form = subject.get(form_id)
       expect(update_result).to eq(1)
       expect(form[:name]).to eq("Form 2 (basic form)?")
@@ -67,23 +56,11 @@ describe Repositories::FormsRepository do
       expect(form[:privacy_policy_url]).to eq("https://example.com/privacy-policy")
       expect(form[:what_happens_next_text]).to eq("text on what happens next")
       expect(form[:declaration_text]).to eq("declaration text")
+      expect(form[:question_section_completed]).to eq true
       expect(form[:support_email]).to eq("test@email.com")
       expect(form[:support_phone]).to eq("8675309")
       expect(form[:support_url]).to eq("http://www.example.com")
       expect(form[:support_url_text]).to eq("Support page")
-    end
-
-    it "updates forms question_section_completed" do
-      form_id = subject.create("Form 1 (basic form)?", "submission_email", "org")
-
-      form = subject.get(form_id)
-      expect(form[:question_section_completed]).to eq false
-
-      update_result = subject.update({form_id:,name: "Form 2 (basic form)?",
-                                      question_section_completed: true })
-      form = subject.get(form_id)
-      expect(update_result).to eq(1)
-      expect(form[:question_section_completed]).to eq true
     end
   end
 

--- a/spec/repositories/forms_repository_spec.rb
+++ b/spec/repositories/forms_repository_spec.rb
@@ -44,7 +44,18 @@ describe Repositories::FormsRepository do
   context "updating a form" do
     it "updates a form" do
       form_id = subject.create("Form 1 (basic form)?", "submission_email", "org")
-      update_result = subject.update({ form_id:, name: "Form 2 (basic form)?", submission_email: "submission_email2", org: "org2", live_at: Time.now, privacy_policy_url: "https://example.com/privacy-policy", what_happens_next_text: "text on what happens next", declaration_text: "declaration text", support_email: "test@email.com", support_phone: "8675309", support_url: "http://www.example.com", support_url_text: "Support page" })
+      update_result = subject.update({form_id:,
+                                      name: "Form 2 (basic form)?",
+                                      submission_email: "submission_email2",
+                                      org: "org2",
+                                      live_at: Time.now,
+                                      privacy_policy_url: "https://example.com/privacy-policy",
+                                      what_happens_next_text: "text on what happens next",
+                                      declaration_text: "declaration text",
+                                      support_email: "test@email.com",
+                                      support_phone: "8675309",
+                                      support_url: "http://www.example.com",
+                                      support_url_text: "Support page" })
       form = subject.get(form_id)
       expect(update_result).to eq(1)
       expect(form[:name]).to eq("Form 2 (basic form)?")
@@ -60,6 +71,19 @@ describe Repositories::FormsRepository do
       expect(form[:support_phone]).to eq("8675309")
       expect(form[:support_url]).to eq("http://www.example.com")
       expect(form[:support_url_text]).to eq("Support page")
+    end
+
+    it "updates forms question_section_completed" do
+      form_id = subject.create("Form 1 (basic form)?", "submission_email", "org")
+
+      form = subject.get(form_id)
+      expect(form[:question_section_completed]).to eq false
+
+      update_result = subject.update({form_id:,name: "Form 2 (basic form)?",
+                                      question_section_completed: true })
+      form = subject.get(form_id)
+      expect(update_result).to eq(1)
+      expect(form[:question_section_completed]).to eq true
     end
   end
 

--- a/spec/repositories/pages_repository_spec.rb
+++ b/spec/repositories/pages_repository_spec.rb
@@ -48,6 +48,15 @@ describe Repositories::PagesRepository do
       expect(created_page[:next_page]).to be_nil
       expect(created_page[:is_optional]).to be_nil
     end
+
+    it "resets forms 'question_section_completed' value" do
+      database[:forms].where(id: form_id).update(question_section_completed: true)
+      subject.create(page)
+
+      repository = Repositories::FormsRepository.new(@database)
+      form = repository.get(form_id)
+      expect(form[:question_section_completed]).to be false
+    end
   end
 
   context "create a second page for the same form" do

--- a/spec/repositories/pages_repository_spec.rb
+++ b/spec/repositories/pages_repository_spec.rb
@@ -115,6 +115,18 @@ describe Repositories::PagesRepository do
     end
   end
 
+  context "updating a page, resets form attributes" do
+    it "resets forms 'question_section_completed' value" do
+      database[:forms].where(id: form_id).update(question_section_completed: true)
+      subject.create(page)
+      subject.update(page)
+
+      repository = Repositories::FormsRepository.new(@database)
+      form = repository.get(form_id)
+      expect(form[:question_section_completed]).to be false
+    end
+  end
+
   context "deleting a page which exists" do
     it "deletes a page" do
       page_id = subject.create(page)


### PR DESCRIPTION
#### What problem does the pull request solve?

- add a new boolean attribute called `question_section_completed` to `forms` table
- default value is set to false
- Resets this attribute back to `false` if a form creator creates/edits another page after marking the question_section_completed to true.


Relates to https://trello.com/c/xyAJo5Wp/187-forms-api-store-progress-for-page-questions-section-of-forms:
#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
    - [ ] README.md
    - [ ] Elsewhere (please link)


