### PR TITLE
Add declaration completion status field

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/db/migrations/017_add_declaration_section_completed_to_form.rb
+++ b/db/migrations/017_add_declaration_section_completed_to_form.rb
@@ -1,0 +1,12 @@
+Sequel.migration do
+  up do
+    add_column :forms, :declaration_section_completed, TrueClass, default: false
+
+    from(:forms).exclude(live_at: nil).each do |live_form|
+      from(:forms).where(id: live_form[:id]).update(declaration_section_completed: true)
+    end
+  end
+  down do
+    drop_column :forms, :declaration_section_completed
+  end
+end

--- a/lib/api_v1.rb
+++ b/lib/api_v1.rb
@@ -76,6 +76,7 @@ class APIv1 < Grape::API
         optional :privacy_policy_url, type: String, desc: "Privacy policy URL."
         optional :what_happens_next_text, type: String, desc: "What happens next."
         optional :declaration_text, type: String, desc: "Declaration text."
+        optional :declaration_section_completed, type: String, desc: "Used to identify whether forms questions section has been completed"
         optional :question_section_completed, type: String, desc: "Used to identify whether forms questions section has been completed"
         optional :support_email, type: String, desc: "Support email address"
         optional :support_phone, type: String, desc: "Support phone contact details"

--- a/lib/repositories/forms_repository.rb
+++ b/lib/repositories/forms_repository.rb
@@ -24,6 +24,7 @@ class Repositories::FormsRepository
       privacy_policy_url: form[:privacy_policy_url],
       what_happens_next_text: form[:what_happens_next_text],
       declaration_text: form[:declaration_text],
+      declaration_section_completed: form[:declaration_section_completed],
       question_section_completed: form[:question_section_completed],
       form_slug: form[:name]&.parameterize,
       support_email: form[:support_email],

--- a/spec/db/migration_017_spec.rb
+++ b/spec/db/migration_017_spec.rb
@@ -1,0 +1,40 @@
+describe "migration 17" do
+  include_context "with database"
+
+  let(:migrator) { Migrator.new }
+
+  before do
+    migrator.migrate_to(database, 16)
+  end
+  it "adds a declaration_section_completed field to forms table from v16 to v17" do
+    declaration_not_completed_form_id = database[:forms].insert(name: "name 1", submission_email: "submission_email", org: "testorg")
+    declaration_section_completed_form_id = database[:forms].insert(name: "name 2", submission_email: "submission_email", org: "testorg")
+
+    migrator.migrate_to(database, 17)
+
+    database[:forms].where(id: declaration_section_completed_form_id).update(declaration_section_completed: true)
+
+    updated_form = database[:forms].where(id: declaration_section_completed_form_id).first
+
+    expect(updated_form[:declaration_section_completed]).to eq true
+
+    existing_form = database[:forms].where(id: declaration_not_completed_form_id).first
+
+    expect(existing_form[:declaration_section_completed]).to eq false
+  end
+
+  it "marks existing live forms declaration_section_completed to true" do
+    live_form_id = database[:forms].insert(name: "name 1", submission_email: "submission_email", org: "testorg", live_at: Time.now)
+    draft_form_id = database[:forms].insert(name: "name 2", submission_email: "submission_email", org: "testorg")
+
+    migrator.migrate_to(database, 17)
+
+    live_form = database[:forms].where(id: live_form_id).first
+
+    expect(live_form[:declaration_section_completed]).to eq true
+
+    draft_form = database[:forms].where(id: draft_form_id).first
+
+    expect(draft_form[:declaration_section_completed]).to eq false
+  end
+end

--- a/spec/repositories/forms_repository_spec.rb
+++ b/spec/repositories/forms_repository_spec.rb
@@ -44,7 +44,7 @@ describe Repositories::FormsRepository do
   context "updating a form" do
     it "updates a form" do
       form_id = subject.create("Form 1 (basic form)?", "submission_email", "org")
-      update_result = subject.update({ form_id:, name: "Form 2 (basic form)?", submission_email: "submission_email2", org: "org2", live_at: Time.now, privacy_policy_url: "https://example.com/privacy-policy", what_happens_next_text: "text on what happens next", declaration_text: "declaration text", support_email: "test@email.com", support_phone: "8675309", support_url: "http://www.example.com", support_url_text: "Support page", question_section_completed: true })
+      update_result = subject.update({ form_id:, name: "Form 2 (basic form)?", submission_email: "submission_email2", org: "org2", live_at: Time.now, privacy_policy_url: "https://example.com/privacy-policy", what_happens_next_text: "text on what happens next", declaration_text: "declaration text", support_email: "test@email.com", support_phone: "8675309", support_url: "http://www.example.com", support_url_text: "Support page", question_section_completed: true, declaration_section_completed: true })
       form = subject.get(form_id)
       expect(update_result).to eq(1)
       expect(form[:name]).to eq("Form 2 (basic form)?")
@@ -56,6 +56,7 @@ describe Repositories::FormsRepository do
       expect(form[:privacy_policy_url]).to eq("https://example.com/privacy-policy")
       expect(form[:what_happens_next_text]).to eq("text on what happens next")
       expect(form[:declaration_text]).to eq("declaration text")
+      expect(form[:declaration_section_completed]).to eq true
       expect(form[:question_section_completed]).to eq true
       expect(form[:support_email]).to eq("test@email.com")
       expect(form[:support_phone]).to eq("8675309")


### PR DESCRIPTION
#### What problem does the pull request solve?
Adds a new `declaration_section_completed` field to the form so that the user can mark the declaration as complete.

Unlike the `question_section_completed` field, we're not doing anything special here to reset the field when the declaration text is edited. This is because the declaration text and the `declaration_section_completed` question are in the same form, so the user isn't able to set the declaration text without also setting the declaration completion status to their desired value.

Trello card: https://trello.com/c/6kzPVxj1/286-add-are-you-finished-section-to-the-form-admin-add-a-declaration-task
Related admin PR: https://github.com/alphagov/forms-admin/pull/193

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
