### PR TITLE
Add feature: reordering the pages in a form

### DIFF
--- a/db/migrations/019_add_page_order_to_form.rb
+++ b/db/migrations/019_add_page_order_to_form.rb
@@ -1,0 +1,21 @@
+Sequel.migration do
+  up do
+    add_column :forms, :page_order, "integer[]", default: []
+
+    # Before this change, the order of pages is defined by page id, which
+    # increases with every new page. Running this update collects the page ids for each
+    # form and adds them to the form as an array, in the correct order.
+    update_existing = <<~SQL
+      UPDATE forms
+         SET page_order=pages_id_order
+        FROM (SELECT form_id, array_agg(id ORDER BY id) pages_id_order FROM pages GROUP BY form_id) forms_pages
+       WHERE forms_pages.form_id=forms.id
+    SQL
+
+    run update_existing
+  end
+
+  down do
+    drop_column :forms, :page_order
+  end
+end

--- a/lib/api_v1.rb
+++ b/lib/api_v1.rb
@@ -62,8 +62,9 @@ class APIv1 < Grape::API
         page_repository = Repositories::PagesRepository.new(@database)
 
         form = repository.get(params[:form_id])
-        pages = page_repository.get_pages_in_form(params[:form_id]).sort_by(&:id)
-        form[:start_page] = (pages.first.id if pages.any?)
+
+        form[:start_page] = page_repository.get_pages_in_form(params[:form_id])&.first&.id
+
         form
       end
 
@@ -106,7 +107,7 @@ class APIv1 < Grape::API
         desc "Return all pages for the form"
         get do
           repository = Repositories::PagesRepository.new(@database)
-          repository.get_pages_in_form(params[:form_id]).sort_by(&:id).map(&:to_h)
+          repository.get_pages_in_form(params[:form_id]).map(&:to_h)
         end
 
         desc "Create a new page."
@@ -149,6 +150,25 @@ class APIv1 < Grape::API
           get do
             repository = Repositories::PagesRepository.new(@database)
             repository.get(params[:page_id]).to_h
+          end
+
+          desc "Move a page later in the form."
+          put "/down" do
+            page_id = params[:page_id].to_i
+            form_id = params[:form_id].to_i
+
+            repository = Repositories::PagesRepository.new(@database)
+            success = repository.move_page_down(form_id, page_id)
+            { success: }
+          end
+
+          put "/up" do
+            page_id = params[:page_id].to_i
+            form_id = params[:form_id].to_i
+
+            repository = Repositories::PagesRepository.new(@database)
+            success = repository.move_page_up(form_id, page_id)
+            { success: }
           end
 
           desc "Update a page."

--- a/lib/repositories/pages_repository.rb
+++ b/lib/repositories/pages_repository.rb
@@ -3,11 +3,8 @@ class Repositories::PagesRepository
     @database = database
   end
 
+  # Create a new page at the end of the forms page_order array
   def create(page)
-    # Append the page to the end of the page linked list this means that we
-    # have to set the next_page value of the page which was last (if there are any
-    # pages) this page would have had next_page = null. We insert the page then set
-    # the value in a single transaction
     @database.transaction(isolation: :serializable) do
       new_page_id = @database[:pages].insert(
         form_id: page.form_id,
@@ -19,48 +16,86 @@ class Repositories::PagesRepository
         answer_settings: page.answer_settings
       )
 
-      @database[:pages].where(form_id: page.form_id, next_page: nil).exclude(id: new_page_id).update(next_page: new_page_id)
-
+      @database[:forms].where(id: page.form_id).update(page_order: @database["SELECT array_append(page_order,?) from forms where id=?", new_page_id, page.form_id])
       @database[:forms].where(id: page.form_id).update(question_section_completed: false)
 
       new_page_id
     end
   end
 
+  # Return a single page, given a page_id
   def get(page_id)
-    found_page = @database[:pages].where(id: page_id).all.last
-
+    # Find the page, and use the pages form_id to find the pages next_page
+    single_page_with_next = <<~SQL
+      SELECT p.*,
+             f.page_order[array_position(f.page_order, p.id::int) + 1] AS calulated_next_page
+        FROM pages p
+        JOIN forms f
+          ON p.form_id=f.id WHERE p.id=?
+    SQL
+    found_page = @database[single_page_with_next, page_id].all.last
     page_from_data(found_page)
   end
 
   def update(page)
+    # Updating a page cannot change the order of pages in a form, so we don't
+    # need to perform any extra steps
     @database[:pages].where(id: page.id).update(
       question_text: page.question_text,
       question_short_name: page.question_short_name,
       hint_text: page.hint_text,
       answer_type: page.answer_type,
-      next_page: page.next_page,
       is_optional: page.is_optional,
       answer_settings: page.answer_settings
+      is_optional: page.is_optional
     )
 
     @database[:forms].where(id: page.form_id).update(question_section_completed: false)
   end
 
   def delete(page_id)
+    delete_count = 0
     @database.transaction(isolation: :serializable) do
-      pages = @database[:pages]
+      # delete the page, then use the form_id of the deleted page to remove the
+      # page_id from the forms page_order array
+      @database[:pages].returning(:form_id).where(id: page_id).delete do |page_hash|
+        delete_count += 1
+        @database[:forms].where(id: page_hash[:form_id]).update(page_order: @database["SELECT array_remove(page_order,?) FROM forms WHERE id=?", page_id, page_hash[:form_id]])
+      end
+    end
+    delete_count
+  end
 
-      # get the next value of our page and update any pages which pointed to us
-      # to that instead
-      next_page_id = pages.where(id: page_id).get(:next_page)
-      pages.where(next_page: page_id).update(next_page: next_page_id)
-      pages.where(id: page_id).delete
+  # Return the pages in form, listed in an array in order. The first page in
+  # the array will be the start_page. For each page, calculate the column of next_page.
+  def get_pages_in_form(form_id)
+    ordered_pages_with_next = <<~SQL
+      SELECT p.*,
+             f.page_order[array_position(f.page_order, p.id::int) + 1] AS calulated_next_page
+      FROM forms f,
+           unnest(f.page_order) WITH ORDINALITY page(id, nr)
+      JOIN pages p
+        ON p.id=page.id
+      WHERE f.id = ?
+      ORDER BY page.nr
+    SQL
+
+    pages_in_order = @database.fetch(ordered_pages_with_next, form_id).all
+    pages_in_order.map { |p| page_from_data(p) }
+  end
+
+  def move_page_down(form_id, page_id)
+    @database.transaction(isolation: :serializable) do
+      page_order = @database[:forms].where(id: form_id).get(:page_order)
+      @database[:forms].where(id: form_id).update(page_order: Sequel.pg_array(move_item_down(page_id, page_order)))
     end
   end
 
-  def get_pages_in_form(form_id)
-    @database[:pages].where(form_id:).order(:id).all.map { |p| page_from_data(p) }
+  def move_page_up(form_id, page_id)
+    @database.transaction(isolation: :serializable) do
+      page_order = @database[:forms].where(id: form_id).get(:page_order)
+      @database[:forms].where(id: form_id).update(page_order: Sequel.pg_array(move_item_up(page_id, page_order)))
+    end
   end
 
   private
@@ -73,9 +108,31 @@ class Repositories::PagesRepository
       page.question_short_name = page_data[:question_short_name]
       page.hint_text = page_data[:hint_text]
       page.answer_type = page_data[:answer_type]
-      page.next_page = page_data[:next_page]
+      page.next_page = page_data[:calulated_next_page]
       page.is_optional = page_data[:is_optional]
       page.answer_settings = page_data[:answer_settings]
     end
+  end
+
+  # Find an array element by value and move it one position towards the end of
+  # the array. If the item is the last element of the array or the array does not
+  # contain the element, return the array unchanged.
+  # move_item_down(2, [1,2,3]) -> [1,3,2]
+  def move_item_down(value, arr)
+    i = arr.index(value)
+    return arr if (i == arr.length - 1) || i.nil?
+
+    arr.insert(i + 1, arr.delete_at(i))
+  end
+
+  # Find an array element by value and move it one position towards the start of
+  # the array. If the item is the first element of the array or the array does not
+  # contain the element, return the array unchanged.
+  # move_item_up(2, [1,2,3]) -> [2,1,3]
+  def move_item_up(value, arr)
+    i = arr.index(value)
+    return arr if i.zero? || i.nil?
+
+    arr.insert(i - 1, arr.delete_at(i))
   end
 end

--- a/spec/db/migration_019_spec.rb
+++ b/spec/db/migration_019_spec.rb
@@ -1,0 +1,33 @@
+describe "migration 19" do
+  include_context "with database"
+
+  let(:migrator) { Migrator.new }
+
+  before do
+    migrator.migrate_to(database, 18)
+  end
+
+  it "adds correct page page_order values to forms" do
+    empty_form = database[:forms].insert(name: "name 1", submission_email: "submission_email", org: "testorg")
+
+    single_page_form = database[:forms].insert(name: "name 2", submission_email: "submission_email", org: "testorg")
+    page_id1 = database[:pages].insert(form_id: single_page_form, question_text: "question_text", question_short_name: "question_short_name", hint_text: "hint_text", answer_type: "answer_type")
+
+    multi_page_form = database[:forms].insert(name: "name 3", submission_email: "submission_email", org: "testorg")
+    page_id2 = database[:pages].insert(form_id: multi_page_form, question_text: "question_text", question_short_name: "question_short_name", hint_text: "hint_text", answer_type: "answer_type")
+    page_id3 = database[:pages].insert(form_id: multi_page_form, question_text: "question_text", question_short_name: "question_short_name", hint_text: "hint_text", answer_type: "answer_type")
+    page_id4 = database[:pages].insert(form_id: multi_page_form, question_text: "question_text", question_short_name: "question_short_name", hint_text: "hint_text", answer_type: "answer_type")
+
+    other_multi_page_form = database[:forms].insert(name: "name 3", submission_email: "submission_email", org: "testorg")
+    page_id5 = database[:pages].insert(form_id: other_multi_page_form, question_text: "question_text", question_short_name: "question_short_name", hint_text: "hint_text", answer_type: "answer_type")
+    page_id6 = database[:pages].insert(form_id: other_multi_page_form, question_text: "question_text", question_short_name: "question_short_name", hint_text: "hint_text", answer_type: "answer_type")
+    page_id7 = database[:pages].insert(form_id: other_multi_page_form, question_text: "question_text", question_short_name: "question_short_name", hint_text: "hint_text", answer_type: "answer_type")
+
+    migrator.migrate_to(database, 19)
+
+    expect(database[:forms].where(id: empty_form).get(:page_order)).to eq([])
+    expect(database[:forms].where(id: single_page_form).get(:page_order)).to eq([page_id1])
+    expect(database[:forms].where(id: multi_page_form).get(:page_order)).to eq([page_id2, page_id3, page_id4])
+    expect(database[:forms].where(id: other_multi_page_form).get(:page_order)).to eq([page_id5, page_id6, page_id7])
+  end
+end

--- a/spec/repositories/pages_repository_spec.rb
+++ b/spec/repositories/pages_repository_spec.rb
@@ -70,6 +70,9 @@ describe Repositories::PagesRepository do
       first_page_result = subject.get(first_page_id)
 
       expect(first_page_result.next_page).to eq(second_page_id)
+
+      # Check legacy page ordering code
+      expect(first_page_result.next_page).to eq(second_page_id)
     end
 
     it "should not update another form pages next_page attribute" do
@@ -80,6 +83,10 @@ describe Repositories::PagesRepository do
       first_page_result = subject.get(first_page_id)
       another_form_page_result = subject.get(another_form_page_id)
 
+      expect(first_page_result.next_page).to eq(second_page_id)
+      expect(another_form_page_result.next_page).to be_nil
+
+      # Check legacy page ordering code
       expect(first_page_result.next_page).to eq(second_page_id)
       expect(another_form_page_result.next_page).to be_nil
     end
@@ -133,7 +140,6 @@ describe Repositories::PagesRepository do
     end
   end
 
-  # rubocop:disable Metrics/BlockLength
   context "updating a page" do
     it "updates a page" do
       page_id = subject.create(page)
@@ -163,8 +169,6 @@ describe Repositories::PagesRepository do
       expect(form[:updated_at].to_i).to be_within(0).of(Time.now.to_i)
     end
   end
-  # rubocop:enable Metrics/BlockLength
-
   context "updating a page, resets form attributes" do
     it "resets forms 'question_section_completed' value" do
       database[:forms].where(id: form_id).update(question_section_completed: true)
@@ -227,6 +231,15 @@ describe Repositories::PagesRepository do
       expect(first_page_next).to eq(second_page_id)
       expect(second_page_next).to eq(third_page_id)
       expect(third_page_next).to eq(nil)
+
+      # Expect legacy next_page to still be updated and working
+      legacy_first_page_next = database[:pages].where(id: first_page_id).get(:next_page)
+      legacy_second_page_next = database[:pages].where(id: second_page_id).get(:next_page)
+      legacy_third_page_next = database[:pages].where(id: third_page_id).get(:next_page)
+
+      expect(legacy_first_page_next).to eq(second_page_id)
+      expect(legacy_second_page_next).to eq(third_page_id)
+      expect(legacy_third_page_next).to eq(nil)
     end
   end
 


### PR DESCRIPTION
Currently users cannot change the order of pages in a form - they must
delete and recreate them.

The API returns pages ordered by id, when serving a form. This order is
used to display the pages in the admin's page list. This works because
the page.id always increases, and because the user has no way of moving
pages.

Pages in a form use the .next_page attribute to form an implicit linked
list. The start_page acts as the head of the list.

The runner uses the `start_page` attribute, which is not stored in the
database and is calculated by the API when retrieving a form, based on
lowest page id. It then moves from page to page using the id found in
the next_page attribute.

Adding reordering
This PR introduces two new endpoints for moving a page earlier and later
in the order of a form. This can then then be used to move pages up and
down in the admin.

To do this, we need to do three things:
- Change how the order of pages is calculated
- Change how the start_page is calculated
- Add a new endpoint for moving a page in the list

This commit introduces a new column on the forms table, page_order,
which contains a pg_array of page_ids, in the order they appear in the
form. This is used for all page ordering operations, including
calculating the .next_page attribute of pages. The next_page column
could be dropped. This commit doesn't do that in case we need to roll
back.

The .next_page attribute of pages used to be stored in column and was
altered on page creation and deletion. The new scheme calculates the
next_page attribute when fetch a single or multiple forms. Calculating
this doesn't seem to be too expensive but given how often all the pages
of a form are fetched, we should monitor it. If it does become an
issue, we could write the next_page attributes when order has been
modified. As we are considering other changes to the data model and API
I think it's worth holding of unless we know it's an issue.

Two new routes have been added to the API for moving the order of pages
by one place.

```
PUT /api/v1/forms/<form_id>/pages/<page_id>/up
PUT /api/v1/forms/<form_id>/pages/<page_id>/down
```

Whenever API routes are called which might result in changes to the order, the
page_order is modified too.

There are no constraints on the page_order column which prevent the data
being inconsistent. Care has to be taken when changing it to stop it
containing duplicates, referencing pages which don't belong to the form
or pages which don't exist. page_order is not exposed by the API for
this reason. If more feaures are added to modify the array, we should
add more validation checks when it's changed.

Effect on the runner
-----------
The runner is quite robust if a creator changes the order of a form
whilst a user is filling out a form. The worst consequence seems to what
appears to be repeated questions from the point of view of the filler
inner. These questions will already be filled out and the filler can
continue through the form.

Performance
-----------

I ran some very unscientific tests with forms with a very large number
of pages. The results are below. There was nothing alarming in them -
but I don't think they tell us very much either.

```bash

DEFAULTVALUE='government-digital-service'
curl --include --silent --show-error \
  --request POST \
  -H 'Content-Type: application/json' \
  -H "X-Api-Token: ${API_KEY}" \
  --url "$API_BASE/forms/$1/pages" -d @-
```

```bash
printf '{"question_text": "q %s", "answer_type": "single_line"}' $i | ./add_page.sh 1
```

```bash

DEFAULTVALUE='government-digital-service'
curl -vv last_trace.curl \
  --include --silent --show-error \
  --request GET \
  -H 'Content-Type: application/json' \
  -H "X-Api-Token: ${API_KEY}" \
  --url "$API_BASE/forms/$1/pages" | tee last_response.http | sed '1,/^\r\{0,1\}$/d' | jq
```

Number of forms, Seconds to perfom a request to fetch all pages of the form
1000  0.161
2000  0.281
3000  0.369
4000  0.409
5000  0.528
6000  0.598
7000  0.695
8000  0.958
9000  0.958
10000 1.231
#### What problem does the pull request solve?

Trello card: https://trello.com/c/vUh413Cv/296-spike-exploration-data-model-redesign-reorder-questions

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
