### PR TITLE
Add selection answer type and its options

### DIFF
--- a/db/migrations/018_add_answer_options_to_page.rb
+++ b/db/migrations/018_add_answer_options_to_page.rb
@@ -1,0 +1,8 @@
+Sequel.migration do
+  up do
+    add_column :pages, :answer_settings, :jsonb
+  end
+  down do
+    drop_column :pages, :answer_settings
+  end
+end

--- a/lib/api_v1.rb
+++ b/lib/api_v1.rb
@@ -115,7 +115,11 @@ class APIv1 < Grape::API
           optional :question_short_name, type: String, desc: "Question short name."
           optional :hint_text, type: String, desc: "Hint text"
           requires :answer_type, type: String,
-                                 values: %w[single_line address date email national_insurance_number phone_number long_text number], desc: "Answer type"
+                                 values: %w[single_line address date email national_insurance_number phone_number long_text number selection], desc: "Answer type"
+          optional :answer_settings, type: JSON do
+            optional :allow_multiple_answers, type: String, desc: "Allow multiple answers"
+            optional :selection_options, type: Array[JSON], desc: "Selection options"
+          end
           optional :is_optional, type: String, desc: "Optional question?"
         end
         post do
@@ -128,6 +132,7 @@ class APIv1 < Grape::API
           page.hint_text = params[:hint_text]
           page.answer_type = params[:answer_type]
           page.is_optional = params[:is_optional]
+          page.answer_settings = params[:answer_settings].to_json
 
           id = repository.create(page)
           { id: }
@@ -152,7 +157,12 @@ class APIv1 < Grape::API
             optional :question_short_name, type: String, desc: "Question short name."
             optional :hint_text, type: String, desc: "Hint text"
             requires :answer_type, type: String,
-                                   values: %w[single_line address date email national_insurance_number phone_number long_text number], desc: "Answer type"
+                                   values: %w[single_line address date email national_insurance_number phone_number long_text number selection], desc: "Answer type"
+
+            optional :answer_settings, type: JSON do
+              optional :allow_multiple_answers, type: String, desc: "Allow multiple answers"
+              optional :selection_options, type: Array[JSON], desc: "Selection options"
+            end
             optional :next_page, type: String, desc: "The ID of the next page"
             optional :is_optional, type: String, desc: "Optional question?"
           end
@@ -167,6 +177,7 @@ class APIv1 < Grape::API
               p.answer_type = params[:answer_type]
               p.next_page = params[:next_page]
               p.is_optional = params[:is_optional]
+              p.answer_settings = params[:answer_settings].to_json
             end
 
             repository.update(page)

--- a/lib/domain/page.rb
+++ b/lib/domain/page.rb
@@ -6,7 +6,8 @@ class Domain::Page
                 :hint_text,
                 :answer_type,
                 :next_page,
-                :is_optional
+                :is_optional,
+                :answer_settings
 
   def to_h
     {
@@ -17,7 +18,8 @@ class Domain::Page
       hint_text:,
       answer_type:,
       next_page:,
-      is_optional:
+      is_optional:,
+      answer_settings:
     }
   end
 end

--- a/lib/repositories/pages_repository.rb
+++ b/lib/repositories/pages_repository.rb
@@ -15,7 +15,8 @@ class Repositories::PagesRepository
         question_short_name: page.question_short_name,
         hint_text: page.hint_text,
         answer_type: page.answer_type,
-        is_optional: page.is_optional
+        is_optional: page.is_optional,
+        answer_settings: page.answer_settings
       )
 
       @database[:pages].where(form_id: page.form_id, next_page: nil).exclude(id: new_page_id).update(next_page: new_page_id)
@@ -39,7 +40,8 @@ class Repositories::PagesRepository
       hint_text: page.hint_text,
       answer_type: page.answer_type,
       next_page: page.next_page,
-      is_optional: page.is_optional
+      is_optional: page.is_optional,
+      answer_settings: page.answer_settings
     )
 
     @database[:forms].where(id: page.form_id).update(question_section_completed: false)
@@ -73,6 +75,7 @@ class Repositories::PagesRepository
       page.answer_type = page_data[:answer_type]
       page.next_page = page_data[:next_page]
       page.is_optional = page_data[:is_optional]
+      page.answer_settings = page_data[:answer_settings]
     end
   end
 end

--- a/spec/db/migration_018_spec.rb
+++ b/spec/db/migration_018_spec.rb
@@ -1,0 +1,26 @@
+describe "migration 18" do
+  include_context "with database"
+
+  let(:migrator) { Migrator.new }
+
+  before do
+    migrator.migrate_to(database, 17)
+  end
+  it "adds an answer_settings field to pages table from v17 to v18" do
+    form = database[:forms].insert(name: "Form", submission_email: "submission_email")
+    page1_id = database[:pages].insert(id: 1, form_id: form, next_page: "2", question_text: "question_text", answer_type: "answer_type")
+    page2_id = database[:pages].insert(id: 2, form_id: form, next_page: "3", question_text: "question_text", answer_type: "answer_type")
+
+    migrator.migrate_to(database, 18)
+
+    answer_settings = { allow_multiple_answers: true }.to_json
+    database[:pages].where(id: page1_id).update(answer_settings:)
+
+    page1 = database[:pages].where(id: page1_id).first
+
+    page2 = database[:pages].where(id: page2_id).first
+
+    expect(page1[:answer_settings].to_json).to eq(answer_settings)
+    expect(page2[:answer_settings]).to be_nil
+  end
+end

--- a/spec/domain/page_spec.rb
+++ b/spec/domain/page_spec.rb
@@ -8,6 +8,7 @@ describe Domain::Page do
       page.hint_text = "hint_text"
       page.answer_type = "answer_type"
       page.next_page = "next"
+      page.answer_settings = { allow_multiple_answers: true }.to_json
     end
     hashed_page = test_page.to_h
     expect(hashed_page[:question_text]).to eq("question_text")
@@ -17,5 +18,6 @@ describe Domain::Page do
     expect(hashed_page[:next_page]).to eq("next")
     expect(hashed_page[:form_id]).to eq("5678")
     expect(hashed_page[:id]).to eq("1234")
+    expect(hashed_page[:answer_settings]).to eq('{"allow_multiple_answers":true}')
   end
 end

--- a/spec/domain/page_spec.rb
+++ b/spec/domain/page_spec.rb
@@ -8,7 +8,7 @@ describe Domain::Page do
       page.hint_text = "hint_text"
       page.answer_type = "answer_type"
       page.next_page = "next"
-      page.answer_settings = { allow_multiple_answers: true }.to_json
+      page.answer_settings = { allow_multiple_answers: true, selection_options: [{ name: "option 1" }] }.to_json
     end
     hashed_page = test_page.to_h
     expect(hashed_page[:question_text]).to eq("question_text")
@@ -18,6 +18,6 @@ describe Domain::Page do
     expect(hashed_page[:next_page]).to eq("next")
     expect(hashed_page[:form_id]).to eq("5678")
     expect(hashed_page[:id]).to eq("1234")
-    expect(hashed_page[:answer_settings]).to eq('{"allow_multiple_answers":true}')
+    expect(hashed_page[:answer_settings]).to eq('{"allow_multiple_answers":true,"selection_options":[{"name":"option 1"}]}')
   end
 end

--- a/spec/repositories/pages_repository_spec.rb
+++ b/spec/repositories/pages_repository_spec.rb
@@ -110,7 +110,7 @@ describe Repositories::PagesRepository do
       page.answer_type = "answer_type2"
       page.next_page = 3
       page.is_optional = true
-      page.answer_settings = { allow_multiple_answers: true }.to_json
+      page.answer_settings = { allow_multiple_answers: true, selection_options: [{ name: "option 1" }] }.to_json
       update_result = subject.update(page)
 
       page = subject.get(page_id)
@@ -122,7 +122,7 @@ describe Repositories::PagesRepository do
       expect(page.next_page).to eq(3)
       expect(page.form_id).to eq(form_id)
       expect(page.is_optional).to be true
-      expect(page.answer_settings).to eq({ "allow_multiple_answers" => true })
+      expect(page.answer_settings).to eq({ "allow_multiple_answers" => true, "selection_options" => [{ "name" => "option 1" }] })
 
       repository = Repositories::FormsRepository.new(@database)
       form = repository.get(form_id)

--- a/spec/repositories/pages_repository_spec.rb
+++ b/spec/repositories/pages_repository_spec.rb
@@ -99,6 +99,7 @@ describe Repositories::PagesRepository do
     end
   end
 
+  # rubocop:disable Metrics/BlockLength
   context "updating a page" do
     it "updates a page" do
       page_id = subject.create(page)
@@ -129,6 +130,7 @@ describe Repositories::PagesRepository do
       expect(form[:updated_at].to_i).to be_within(0).of(Time.now.to_i)
     end
   end
+  # rubocop:enable Metrics/BlockLength
 
   context "updating a page, resets form attributes" do
     it "resets forms 'question_section_completed' value" do

--- a/spec/repositories/pages_repository_spec.rb
+++ b/spec/repositories/pages_repository_spec.rb
@@ -19,6 +19,7 @@ describe Repositories::PagesRepository do
       page.answer_type = "answer_type"
       page.next_page = nil
       page.is_optional = nil
+      page.answer_settings = nil
     end
   end
 
@@ -31,6 +32,7 @@ describe Repositories::PagesRepository do
       page.answer_type = "answer_type"
       page.next_page = nil
       page.is_optional = nil
+      page.answer_settings = nil
     end
   end
 
@@ -47,6 +49,7 @@ describe Repositories::PagesRepository do
       expect(created_page[:form_id]).to eq(form_id)
       expect(created_page[:next_page]).to be_nil
       expect(created_page[:is_optional]).to be_nil
+      expect(created_page[:answer_settings]).to be_nil
     end
 
     it "resets forms 'question_section_completed' value" do
@@ -92,6 +95,7 @@ describe Repositories::PagesRepository do
       expect(found_page.answer_type).to eq("answer_type")
       expect(found_page.form_id).to eq(form_id)
       expect(found_page.is_optional).to be_nil
+      expect(found_page.answer_settings).to be_nil
     end
   end
 
@@ -105,6 +109,7 @@ describe Repositories::PagesRepository do
       page.answer_type = "answer_type2"
       page.next_page = 3
       page.is_optional = true
+      page.answer_settings = { allow_multiple_answers: true }.to_json
       update_result = subject.update(page)
 
       page = subject.get(page_id)
@@ -116,6 +121,7 @@ describe Repositories::PagesRepository do
       expect(page.next_page).to eq(3)
       expect(page.form_id).to eq(form_id)
       expect(page.is_optional).to be true
+      expect(page.answer_settings).to eq({ "allow_multiple_answers" => true })
 
       repository = Repositories::FormsRepository.new(@database)
       form = repository.get(form_id)


### PR DESCRIPTION
#### What problem does the pull request solve?
Adds an `answer_settings` JSON column to the pages object. When returned from the API it will look something like this:

```json
"answer_settings": {
  "allow_multiple_answers": true,
  "selection_options": [
    {"name": "Option 1"},
    {"name": "Option 2"},
  ]
}
```

The intent is for this field to be flexible for different answer types - for example, this field will likely end up containing flags for autofill related settings for other fields.  

Trello card: https://trello.com/c/bSqKTDu8/224-add-selection-question-type-to-api


#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
