### PR TITLE
set rackup bind host to 0.0.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ setup:
 	bundle install
 
 serve: setup
-	bundle exec rackup
+	bundle exec rackup -o 0.0.0.0
 
 serve-watch: setup
 	bundle exec guard -i --notify false -P rack


### PR DESCRIPTION
A simple tweak so that the dockerised admin and runner can connect to our local API