### PR TITLE
Rename 'allow multiple answers'

### DIFF
--- a/lib/api_v1.rb
+++ b/lib/api_v1.rb
@@ -118,7 +118,7 @@ class APIv1 < Grape::API
           requires :answer_type, type: String,
                                  values: %w[single_line address date email national_insurance_number phone_number long_text number selection], desc: "Answer type"
           optional :answer_settings, type: Hash do
-            optional :allow_multiple_answers, type: String, desc: "Allow multiple answers"
+            optional :only_one_option, type: String, desc: "Allow multiple answers"
             optional :selection_options, type: Array[Hash], desc: "Selection options"
           end
           optional :is_optional, type: String, desc: "Optional question?"
@@ -179,7 +179,7 @@ class APIv1 < Grape::API
             requires :answer_type, type: String,
                                    values: %w[single_line address date email national_insurance_number phone_number long_text number selection], desc: "Answer type"
             optional :answer_settings, type: Hash do
-              optional :allow_multiple_answers, type: String, desc: "Allow multiple answers"
+              optional :only_one_option, type: String, desc: "Allow multiple answers"
               optional :selection_options, type: Array[Hash], desc: "Selection options"
             end
             optional :next_page, type: String, desc: "The ID of the next page"

--- a/spec/db/migration_018_spec.rb
+++ b/spec/db/migration_018_spec.rb
@@ -13,7 +13,7 @@ describe "migration 18" do
 
     migrator.migrate_to(database, 18)
 
-    answer_settings = { allow_multiple_answers: true }.to_json
+    answer_settings = { only_one_option: true }.to_json
     database[:pages].where(id: page1_id).update(answer_settings:)
 
     page1 = database[:pages].where(id: page1_id).first

--- a/spec/domain/page_spec.rb
+++ b/spec/domain/page_spec.rb
@@ -8,7 +8,7 @@ describe Domain::Page do
       page.hint_text = "hint_text"
       page.answer_type = "answer_type"
       page.next_page = "next"
-      page.answer_settings = { allow_multiple_answers: true, selection_options: [{ name: "option 1" }] }.to_json
+      page.answer_settings = { only_one_option: true, selection_options: [{ name: "option 1" }] }.to_json
     end
     hashed_page = test_page.to_h
     expect(hashed_page[:question_text]).to eq("question_text")
@@ -18,6 +18,6 @@ describe Domain::Page do
     expect(hashed_page[:next_page]).to eq("next")
     expect(hashed_page[:form_id]).to eq("5678")
     expect(hashed_page[:id]).to eq("1234")
-    expect(hashed_page[:answer_settings]).to eq('{"allow_multiple_answers":true,"selection_options":[{"name":"option 1"}]}')
+    expect(hashed_page[:answer_settings]).to eq('{"only_one_option":true,"selection_options":[{"name":"option 1"}]}')
   end
 end

--- a/spec/repositories/pages_repository_spec.rb
+++ b/spec/repositories/pages_repository_spec.rb
@@ -149,7 +149,7 @@ describe Repositories::PagesRepository do
       page.hint_text = "hint_text2"
       page.answer_type = "answer_type2"
       page.is_optional = true
-      page.answer_settings = { allow_multiple_answers: true, selection_options: [{ name: "option 1" }] }.to_json
+      page.answer_settings = { only_one_option: true, selection_options: [{ name: "option 1" }] }.to_json
       update_result = subject.update(page)
 
       page = subject.get(page_id)
@@ -161,7 +161,7 @@ describe Repositories::PagesRepository do
       expect(page.next_page).to eq(nil)
       expect(page.form_id).to eq(form_id)
       expect(page.is_optional).to be true
-      expect(page.answer_settings).to eq({ "allow_multiple_answers" => true, "selection_options" => [{ "name" => "option 1" }] })
+      expect(page.answer_settings).to eq({ "only_one_option" => true, "selection_options" => [{ "name" => "option 1" }] })
 
       repository = Repositories::FormsRepository.new(@database)
       form = repository.get(form_id)


### PR DESCRIPTION
#### What problem does the pull request solve?
This renames a field to make life slightly easier in the admin part of this work.

Shouldn't require a migration because this is part of a JSON column, so the table doesn't need to change, and no forms exist yet with this setting applied.

Trello card: https://trello.com/c/9AKruIBG/321-add-selection-question-type-to-admin-radio-buttons-only
Related runner PR: https://github.com/alphagov/forms-runner/pull/203 

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
