### PR TITLE
Add organisation name answer type

### DIFF
--- a/lib/api_v1.rb
+++ b/lib/api_v1.rb
@@ -116,7 +116,7 @@ class APIv1 < Grape::API
           optional :question_short_name, type: String, desc: "Question short name."
           optional :hint_text, type: String, desc: "Hint text"
           requires :answer_type, type: String,
-                                 values: %w[single_line address date email national_insurance_number phone_number long_text number selection], desc: "Answer type"
+                                 values: %w[single_line address date email national_insurance_number phone_number long_text number selection organisation_name], desc: "Answer type"
           optional :answer_settings, type: Hash do
             optional :only_one_option, type: String, desc: "Allow multiple answers"
             optional :selection_options, type: Array[Hash], desc: "Selection options"
@@ -177,7 +177,7 @@ class APIv1 < Grape::API
             optional :question_short_name, type: String, desc: "Question short name."
             optional :hint_text, type: String, desc: "Hint text"
             requires :answer_type, type: String,
-                                   values: %w[single_line address date email national_insurance_number phone_number long_text number selection], desc: "Answer type"
+                                   values: %w[single_line address date email national_insurance_number phone_number long_text number selection organisation_name], desc: "Answer type"
             optional :answer_settings, type: Hash do
               optional :only_one_option, type: String, desc: "Allow multiple answers"
               optional :selection_options, type: Array[Hash], desc: "Selection options"


### PR DESCRIPTION
#### What problem does the pull request solve?
Allows `organisation_name` as a value for `answer_type`.

Trello card: https://trello.com/c/jRKIbnBl/369-org-name-implementation-of-autofill-work-in-production

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [n/a] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
