### PR TITLE
Pin Docker Base Image to Manifest List SHA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-# NOTE: Before using in production we must consider the need to pin
-# images to a SHA
-FROM ruby:3.1.2-alpine3.16
+FROM ruby:3.1.2-alpine3.16@sha256:05b990dbaa3a118f96e9ddbf046f388b3c4953d5ef3d18908af96f42c0e138d9
 
 RUN apk update
 RUN apk upgrade --available


### PR DESCRIPTION
Specifying the manifest list digest in the FROM base image pins the image to specific immutable builds but allows Docker to select the correct image manifest for the host's architecture from the manifests included in the pinned manifest list.

#### What problem does the pull request solve?

Same implementation as https://github.com/alphagov/forms-admin/pull/242

Image tags are mutable in that they can be updated to point to different image manifests, this presents potential security and build reliability issues; the underlying FROM image could change without us updating our Dockerfile.

The normal solution is to pin to a particular image manifest SHA which is immutable. This is problematic when developers are using machines on different architectures such as x86 or arm64 because a particular image manifest is built for a single architecture. Pinning with the SHA to a manifest list has the desired immutable benefits but permits the Docker client to pull the most appropriate image manifest included within the list for the host architecture.

An example for the Ruby Alpine image we use. We specify the manifest list SHA in the Dockerfile which references the following image manifest SHAs built for various architectures.

```
GDS11321:forms-deploy dan.worth$ docker buildx imagetools inspect ruby:3.1.2-alpine3.16
Name:      docker.io/library/ruby:3.1.2-alpine3.16
MediaType: application/vnd.docker.distribution.manifest.list.v2+json
Digest:    sha256:05b990dbaa3a118f96e9ddbf046f388b3c4953d5ef3d18908af96f42c0e138d9

Manifests:
  Name:      docker.io/library/ruby:3.1.2-alpine3.16@sha256:bd399dfeff026836f146c784420b6299ede048510ade497230884e344bc55a53
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/amd64

  Name:      docker.io/library/ruby:3.1.2-alpine3.16@sha256:500bc68774827b28feabf68a72ffc985491989d2ae99034294c0d4c5089fb691
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm/v6

  Name:      docker.io/library/ruby:3.1.2-alpine3.16@sha256:defa557302369da8818c25ebd52a635a6e92af730a019e82a08ec69d932bf5f6
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm/v7

  Name:      docker.io/library/ruby:3.1.2-alpine3.16@sha256:2b67a90c792985cb5edb89dd50651d0ddf2ef942a25871b6031f5573c41d7fbc
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm64/v8

  Name:      docker.io/library/ruby:3.1.2-alpine3.16@sha256:543da04d44a129127a10e65c2e626b994285a8496cb7c6496ba7e8fa5c697808
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/386

  Name:      docker.io/library/ruby:3.1.2-alpine3.16@sha256:f748b4e57e0e3c5c0402c41bd7b1ec0c033325d323d26c02e4f08b1f30a83c5b
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/ppc64le

  Name:      docker.io/library/ruby:3.1.2-alpine3.16@sha256:39749a8307073d649049201b43b10290580a75a2c58603162e136ddfb5755c52
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/s390x
```

### How to review
I have built this commit on my M1 mac. If someone could try it on an x86 machine that would be great please.