### PR TITLE
Add options for autocomplete work

### DIFF
--- a/lib/api_v1.rb
+++ b/lib/api_v1.rb
@@ -116,7 +116,7 @@ class APIv1 < Grape::API
           optional :question_short_name, type: String, desc: "Question short name."
           optional :hint_text, type: String, desc: "Hint text"
           requires :answer_type, type: String,
-                                 values: %w[single_line address date email national_insurance_number phone_number long_text number selection organisation_name], desc: "Answer type"
+                                 values: %w[single_line address date email national_insurance_number phone_number long_text number selection organisation_name name text], desc: "Answer type"
           optional :answer_settings, type: Hash do
             optional :title_needed, type: String, desc: "Title needed"
             optional :input_type, type: String, desc: "Input type"
@@ -179,7 +179,7 @@ class APIv1 < Grape::API
             optional :question_short_name, type: String, desc: "Question short name."
             optional :hint_text, type: String, desc: "Hint text"
             requires :answer_type, type: String,
-                                   values: %w[single_line address date email national_insurance_number phone_number long_text number selection organisation_name], desc: "Answer type"
+                                   values: %w[single_line address date email national_insurance_number phone_number long_text number selection organisation_name name text], desc: "Answer type"
             optional :answer_settings, type: Hash do
               optional :title_needed, type: String, desc: "Title needed"
               optional :input_type, type: String, desc: "Input type"

--- a/lib/api_v1.rb
+++ b/lib/api_v1.rb
@@ -118,6 +118,8 @@ class APIv1 < Grape::API
           requires :answer_type, type: String,
                                  values: %w[single_line address date email national_insurance_number phone_number long_text number selection organisation_name], desc: "Answer type"
           optional :answer_settings, type: Hash do
+            optional :title_needed, type: String, desc: "Title needed"
+            optional :input_type, type: String, desc: "Input type"
             optional :only_one_option, type: String, desc: "Allow multiple answers"
             optional :selection_options, type: Array[Hash], desc: "Selection options"
           end
@@ -179,6 +181,8 @@ class APIv1 < Grape::API
             requires :answer_type, type: String,
                                    values: %w[single_line address date email national_insurance_number phone_number long_text number selection organisation_name], desc: "Answer type"
             optional :answer_settings, type: Hash do
+              optional :title_needed, type: String, desc: "Title needed"
+              optional :input_type, type: String, desc: "Input type"
               optional :only_one_option, type: String, desc: "Allow multiple answers"
               optional :selection_options, type: Array[Hash], desc: "Selection options"
             end

--- a/spec/domain/page_spec.rb
+++ b/spec/domain/page_spec.rb
@@ -8,7 +8,7 @@ describe Domain::Page do
       page.hint_text = "hint_text"
       page.answer_type = "answer_type"
       page.next_page = "next"
-      page.answer_settings = { only_one_option: true, selection_options: [{ name: "option 1" }] }.to_json
+      page.answer_settings = { title_needed: false, input_type: "some_input",only_one_option: true, selection_options: [{ name: "option 1" }] }.to_json
     end
     hashed_page = test_page.to_h
     expect(hashed_page[:question_text]).to eq("question_text")
@@ -18,6 +18,6 @@ describe Domain::Page do
     expect(hashed_page[:next_page]).to eq("next")
     expect(hashed_page[:form_id]).to eq("5678")
     expect(hashed_page[:id]).to eq("1234")
-    expect(hashed_page[:answer_settings]).to eq('{"only_one_option":true,"selection_options":[{"name":"option 1"}]}')
+    expect(hashed_page[:answer_settings]).to eq('{"title_needed":false,"input_type":"some_input","only_one_option":true,"selection_options":[{"name":"option 1"}]}')
   end
 end

--- a/spec/domain/page_spec.rb
+++ b/spec/domain/page_spec.rb
@@ -8,7 +8,7 @@ describe Domain::Page do
       page.hint_text = "hint_text"
       page.answer_type = "answer_type"
       page.next_page = "next"
-      page.answer_settings = { title_needed: false, input_type: "some_input",only_one_option: true, selection_options: [{ name: "option 1" }] }.to_json
+      page.answer_settings = { title_needed: false, input_type: "some_input", only_one_option: true, selection_options: [{ name: "option 1" }] }.to_json
     end
     hashed_page = test_page.to_h
     expect(hashed_page[:question_text]).to eq("question_text")

--- a/spec/repositories/pages_repository_spec.rb
+++ b/spec/repositories/pages_repository_spec.rb
@@ -149,7 +149,7 @@ describe Repositories::PagesRepository do
       page.hint_text = "hint_text2"
       page.answer_type = "answer_type2"
       page.is_optional = true
-      page.answer_settings = { only_one_option: true, selection_options: [{ name: "option 1" }] }.to_json
+      page.answer_settings = { title_needed: false, input_type: "some_input", only_one_option: true, selection_options: [{ name: "option 1" }] }.to_json
       update_result = subject.update(page)
 
       page = subject.get(page_id)
@@ -161,7 +161,7 @@ describe Repositories::PagesRepository do
       expect(page.next_page).to eq(nil)
       expect(page.form_id).to eq(form_id)
       expect(page.is_optional).to be true
-      expect(page.answer_settings).to eq({ "only_one_option" => true, "selection_options" => [{ "name" => "option 1" }] })
+      expect(page.answer_settings).to eq({ "title_needed" => false, "input_type" => "some_input", "only_one_option" => true, "selection_options" => [{ "name" => "option 1" }] })
 
       repository = Repositories::FormsRepository.new(@database)
       form = repository.get(form_id)


### PR DESCRIPTION
#### What problem does the pull request solve?
Adds some options rewuired for the autocomplete changes:

- adds a 'name' answer type for the various ways of asking for a name
- adds a 'text' answer type (which will replace the existing short/long text options)
- adds a 'title needed' field to the answer_settings for the person's title
- adds an 'input type' field to the answer_settings - this will be used for:
  - determining which type of name input is displayed in the runner
  - determining which type of date field is displayed in the runner
  - determining which type of address field is displayed in the runner
  - determining which kind of text input to use in the runner.

Trello card: https://trello.com/c/efuBewje/391-persons-name-implementation-of-autofill-work-in-production

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
