### PR TITLE
Include rails-api branch in ruby spec/linting workflow 

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,9 +9,9 @@ name: Ruby
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, rails-api ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, rails-api ]
 
 permissions:
   contents: read
@@ -26,7 +26,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13-alpine
+        image: postgres:11-alpine
         ports:
           - "5432:5432"
         env:


### PR DESCRIPTION
- includes rails-api branch in the ruby workflow
- I noticed that we were not using the same version of postgres and instead should be using v11

#### What problem does the pull request solve?

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
