### PR TITLE
Create forms endpoints

### DIFF
--- a/.github/workflows/ruby-on-rails.yml
+++ b/.github/workflows/ruby-on-rails.yml
@@ -1,0 +1,60 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Ruby on Rails (API)
+
+on:
+  push:
+    branches: [ rails-api ]
+  pull_request:
+    branches: [ rails-api ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['3.1.2']
+
+    services:
+      postgres:
+        image: postgres:11-alpine
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+    env:
+      ENV: "test"
+      DATABASE_URL: "postgres://postgres:postgres@localhost:5432/postgres"
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+        # change this to (see https://github.com/ruby/setup-ruby#versioning):
+        # uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@ee2113536afb7f793eed4ce60e8d3b26db912da4
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      # Add or replace database setup steps here
+      - name: Create db
+        run: bin/rails db:migrate
+      - name: Set up database schema
+        run: bin/rails db:schema:load
+      # Add or replace test runners here
+      - name: Run lint
+        run: bundle exec rubocop
+      - name: Run tests
+        run: bundle exec rspec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,9 +9,9 @@ name: Ruby
 
 on:
   push:
-    branches: [ main, rails-api ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, rails-api ]
+    branches: [ main ]
 
 permissions:
   contents: read

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ group :development, :test do
 
   gem "factory_bot_rails"
 
+  gem "faker"
+
   gem "rubocop-govuk", require: false
 
   gem "rspec-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,8 @@ group :development, :test do
   gem "rubocop-govuk", require: false
 
   gem "rspec-rails"
+
+  gem "pry"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,8 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faker (2.23.0)
+      i18n (>= 1.8.11, < 2)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -222,6 +224,7 @@ DEPENDENCIES
   bootsnap
   debug
   factory_bot_rails
+  faker
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
     bootsnap (1.15.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     date (3.3.2)
@@ -118,12 +119,17 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.10-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.10-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
     parser (3.1.3.0)
       ast (~> 2.4.1)
     pg (1.4.5)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     puma (5.6.5)
       nio4r (~> 2.0)
     racc (1.6.1)
@@ -218,6 +224,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -226,6 +233,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   pg (~> 1.1)
+  pry
   puma (~> 5.0)
   rails (~> 7.0.4)
   rspec-rails

--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -1,0 +1,12 @@
+class Api::V1::FormsController < ApplicationController
+  rescue_from ActionController::ParameterMissing do |_exception|
+    # We need to decide if we use the grape error messages, or new ones?
+    # render json: { error: exception.message }, status: :bad_request
+    render json: [{ messages: ["is missing"], params: %w[org] }], status: :bad_request
+  end
+
+  def index
+    org = params.require(:org)
+    render json: Form.where(org:).to_json
+  end
+end

--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -9,4 +9,21 @@ class Api::V1::FormsController < ApplicationController
     org = params.require(:org)
     render json: Form.where(org:).to_json
   end
+
+  def create
+    @form = Form.new(form_params)
+    if @form.save
+      render json: { id: @form.id }, status: :created # Fixup - just returning id here, could we return whole object?
+    else
+      render json: @form.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def form_params
+    # FIXUP -  how to best list all params which form can take? List explicitly or take from model?
+    # params.permit(:org, :name, :submission_email)
+    params.permit(Form.attribute_names) # how to best list all params which form can take?
+  end
 end

--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -19,7 +19,18 @@ class Api::V1::FormsController < ApplicationController
     end
   end
 
-  private
+  def destroy
+    @form = Form.find_by_id(params[:id])
+
+    if @form
+      @form.destroy!
+      render json: { success: true }.to_json, status: :ok
+    else
+      render json: { error: "not_found" }.to_json, status: :not_found
+    end
+  end
+
+private
 
   def form_params
     # FIXUP -  how to best list all params which form can take? List explicitly or take from model?

--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -15,7 +15,31 @@ class Api::V1::FormsController < ApplicationController
     if @form.save
       render json: { id: @form.id }, status: :created # Fixup - just returning id here, could we return whole object?
     else
-      render json: @form.errors, status: :unprocessable_entity
+      render json: @form.errors.to_json, status: :bad_request
+    end
+  end
+
+  def update
+    @form = Form.find_by_id(params[:id])
+
+    if @form
+      if @form.update(form_params)
+        render json: { success: true }.to_json, status: :ok
+      else
+        render json: @form.errors.to_json, status: :bad_request
+      end
+    else
+      render json: { error: "not_found" }.to_json, status: :not_found
+    end
+  end
+
+  def show
+    @form = Form.find_by_id(params[:id])
+
+    if @form
+      render json: @form.to_json, status: :ok
+    else
+      render json: { error: "not_found" }.to_json, status: :not_found
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,7 @@
 class ApplicationController < ActionController::API
+  before_action :set_content_type
+
+  def set_content_type
+    response.headers["Content-Type"] = "application/json"
+  end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,0 +1,2 @@
+class Form < ApplicationRecord
+end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,3 +1,11 @@
 class Form < ApplicationRecord
   validates :org, :name, presence: true
+
+  def created_at
+    attributes["created_at"].to_time.iso8601
+  end
+
+  def updated_at
+    attributes["updated_at"].to_time.iso8601
+  end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,2 +1,3 @@
 class Form < ApplicationRecord
+  validates :org, :name, presence: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,7 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
+  scope "api/v1" do
+    resources :forms, controller: "api/v1/forms"
+  end
 end

--- a/db/migrate/20221216112945_create_forms.rb
+++ b/db/migrate/20221216112945_create_forms.rb
@@ -1,0 +1,23 @@
+class CreateForms < ActiveRecord::Migration[7.0]
+  def change
+    create_table :forms, if_not_exists: true do |t|
+      t.text :name
+      t.text :submission_email
+      t.text :org
+      t.datetime :live_at
+      t.text :privacy_policy_url
+      t.text :form_slug
+      t.text :what_happens_next_text
+      t.text :support_email
+      t.text :support_phone
+      t.text :support_url
+      t.text :support_url_text
+      t.text :declaration_text
+      t.boolean :question_section_completed, default: false
+      t.boolean :declaration_section_completed, default: false
+      t.integer :page_order, array: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,13 +14,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_16_112945) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "forms", id: :bigint, default: nil, force: :cascade do |t|
+  create_table "forms", force: :cascade do |t|
     t.text "name"
     t.text "submission_email"
     t.text "org"
-    t.datetime "created_at", precision: nil
-    t.datetime "live_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "live_at"
     t.text "privacy_policy_url"
     t.text "form_slug"
     t.text "what_happens_next_text"
@@ -32,9 +30,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_16_112945) do
     t.boolean "question_section_completed", default: false
     t.boolean "declaration_section_completed", default: false
     t.integer "page_order", array: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "schema_info", id: false, force: :cascade do |t|
     t.integer "version", default: 0, null: false
   end
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,40 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2022_12_16_112945) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "forms", id: :bigint, default: nil, force: :cascade do |t|
+    t.text "name"
+    t.text "submission_email"
+    t.text "org"
+    t.datetime "created_at", precision: nil
+    t.datetime "live_at", precision: nil
+    t.datetime "updated_at", precision: nil
+    t.text "privacy_policy_url"
+    t.text "form_slug"
+    t.text "what_happens_next_text"
+    t.text "support_email"
+    t.text "support_phone"
+    t.text "support_url"
+    t.text "support_url_text"
+    t.text "declaration_text"
+    t.boolean "question_section_completed", default: false
+    t.boolean "declaration_section_completed", default: false
+    t.integer "page_order", array: true
+  end
+
+  create_table "schema_info", id: false, force: :cascade do |t|
+    t.integer "version", default: 0, null: false
+  end
+end

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -1,18 +1,47 @@
 FactoryBot.define do
-  factory :form do
-    name { "MyText" }
-    submission_email { "MyText" }
-    org { "MyText" }
-    live_at { "2022-12-16 11:29:45" }
-    privacy_policy_url { "MyText" }
-    form_slug { "MyText" }
-    what_happens_next_text { "MyText" }
-    support_email { "MyText" }
-    support_phone { "MyText" }
-    support_url_text { "MyText" }
-    declaration_text { "MyText" }
+  factory :form, class: "Form" do
+    sequence(:name) { |n| "Form #{n}" }
+    sequence(:form_slug) { |n| "form-#{n}" }
+    submission_email { Faker::Internet.email(domain: "example.gov.uk") }
+    privacy_policy_url { Faker::Internet.url(host: "gov.uk") }
+    org { "test-org" }
+    live_at { nil }
+    support_email { nil }
+    support_phone { nil }
+    support_url { nil }
+    support_url_text { nil }
+    what_happens_next_text { nil }
+    declaration_text { nil }
     question_section_completed { false }
     declaration_section_completed { false }
-    page_order { 1 }
+    page_order { nil }
+
+    trait :new_form do
+      submission_email { "" }
+      privacy_policy_url { "" }
+      pages { [] }
+    end
+
+    trait :ready_for_live do
+      support_email { Faker::Internet.email(domain: "example.gov.uk") }
+      what_happens_next_text { "We usually respond to applications within 10 working days." }
+      question_section_completed { true }
+      declaration_section_completed { true }
+    end
+
+    trait :live do
+      live_at { Time.zone.now }
+      support_email { Faker::Internet.email(domain: "example.gov.uk") }
+      what_happens_next_text { "We usually respond to applications within 10 working days." }
+      question_section_completed { true }
+      declaration_section_completed { true }
+    end
+
+    trait :with_support do
+      support_email { Faker::Internet.email(domain: "example.gov.uk") }
+      support_phone { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }
+      support_url { Faker::Internet.url(host: "gov.uk") }
+      support_url_text { Faker::Lorem.sentence(word_count: 1, random_words_to_add: 4) }
+    end
   end
 end

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :form do
+    name { "MyText" }
+    submission_email { "MyText" }
+    org { "MyText" }
+    live_at { "2022-12-16 11:29:45" }
+    privacy_policy_url { "MyText" }
+    form_slug { "MyText" }
+    what_happens_next_text { "MyText" }
+    support_email { "MyText" }
+    support_phone { "MyText" }
+    support_url_text { "MyText" }
+    declaration_text { "MyText" }
+    question_section_completed { false }
+    declaration_section_completed { false }
+    page_order { 1 }
+  end
+end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Form, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -1,5 +1,28 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Form, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  subject(:form) { described_class.new }
+
+  it "has a valid factory" do
+    form = create :form
+    expect(form).to be_valid
+  end
+
+  describe "validations" do
+    it "validates" do
+      form.name = "test"
+      form.org = "test-org"
+      expect(form).to be_valid
+    end
+
+    it "requires name" do
+      expect(form).to be_invalid
+      expect(form.errors[:name]).to include("can't be blank")
+    end
+
+    it "requires org" do
+      expect(form).to be_invalid
+      expect(form.errors[:org]).to include("can't be blank")
+    end
+  end
 end

--- a/spec/request/forms_spec.rb
+++ b/spec/request/forms_spec.rb
@@ -200,19 +200,19 @@ describe "/api/v1/forms", type: :request do
     end
   end
 
-  describe "delete a form" do
+  describe "#destroy" do
     it "when no forms exists for an id, returns 404 an error" do
-      delete "/api/v1/forms/123", {}
-      expect(last_response.status).to eq(404)
-      expect(last_response.headers["Content-Type"]).to eq("application/json")
+      delete "/api/v1/forms/123"
+      expect(response.status).to eq(404)
+      expect(response.headers["Content-Type"]).to eq("application/json")
       expect(json_body).to eq(error: "not_found")
     end
 
     it "when given an existing id, returns 200 and deletes the form from DB" do
-      form1_id = @database[:forms].where(name: "test form 1").get(:id)
-      delete "/api/v1/forms/#{form1_id}", {}
-      expect(last_response.status).to eq(200)
-      expect(last_response.headers["Content-Type"]).to eq("application/json")
+      form_to_be_deleted = create :form
+      delete "/api/v1/forms/#{form_to_be_deleted.id}"
+      expect(response.status).to eq(200)
+      expect(response.headers["Content-Type"]).to eq("application/json")
       expect(json_body).to eq({ success: true })
     end
   end

--- a/spec/request/forms_spec.rb
+++ b/spec/request/forms_spec.rb
@@ -8,7 +8,7 @@ describe "/api/v1/forms", type: :request do
     create :form, org: "not-gds"
   end
 
-  describe "get all forms" do
+  describe "#index" do
     it "when no forms exist for an org, returns 200 and an empty json array" do
       get "/api/v1/forms", params: { org: "unknown-org" }
       expect(response.status).to eq(200)
@@ -55,7 +55,7 @@ describe "/api/v1/forms", type: :request do
     end
   end
 
-  describe "creating a form" do
+  describe "#create" do
     let(:created_form) { Form.find_by(name: "test form one") }
     let(:new_form_params) { { org: "gds", name: "test form one", submission_email: "test@example.gov.uk" } }
 
@@ -106,7 +106,7 @@ describe "/api/v1/forms", type: :request do
     end
   end
 
-  describe "get single form" do
+  describe "#show" do
     it "when no forms exists for an id, returns 404 and an empty json array" do
       get "/api/v1/forms/987"
       expect(response.status).to eq(404)
@@ -151,7 +151,7 @@ describe "/api/v1/forms", type: :request do
     end
   end
 
-  describe "update single form" do
+  describe "#update" do
     it "when no forms exists for an id, returns 404 an error" do
       put "/api/v1/forms/123"
       expect(response.status).to eq(404)

--- a/spec/request/forms_spec.rb
+++ b/spec/request/forms_spec.rb
@@ -1,24 +1,12 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe "/api/v1/forms", type: :request do
-
   let(:json_body) { JSON.parse(response.body, symbolize_names: true) }
 
   before do
-    # create_list :form, 2, org:"gds"
-    create :form, org: "gds", name: 'test form 1'
-    create :form, org: "gds", name: 'test form 2'
+    create_list :form, 2, org: "gds"
     create :form, org: "not-gds"
   end
-
-  # around(:each) do |example|
-  #   @database.transaction(rollback: :always) do
-  #     @database[:forms].insert(name: "test form 1", submission_email: "", org: "gds")
-  #     @database[:forms].insert(name: "test form 2", submission_email: "", org: "gds")
-  #     @database[:forms].insert(name: "test form 3", submission_email: "", org: "not-gds")
-  #     example.run
-  #   end
-  # end
 
   describe "get all forms" do
     it "when no forms exist for an org, returns 200 and an empty json array" do
@@ -32,7 +20,7 @@ describe "/api/v1/forms", type: :request do
       get "/api/v1/forms"
       expect(response.status).to eq(400)
       expect(response.headers["Content-Type"]).to eq("application/json")
-      expect(json_body).to eq([{ messages: ["is missing"], params: ["org"] }])
+      expect(json_body).to eq([{ messages: ["is missing"], params: %w[org] }])
     end
 
     it "when given an org with forms, returns a json array of forms" do
@@ -61,13 +49,14 @@ describe "/api/v1/forms", type: :request do
           :declaration_text,
           :question_section_completed,
           :declaration_section_completed,
-          :page_order)
+          :page_order,
+        )
       end
     end
   end
 
   describe "creating a form" do
-    let(:created_form) { Form.find_by(name: "test form one")}
+    let(:created_form) { Form.find_by(name: "test form one") }
     let(:new_form_params) { { org: "gds", name: "test form one", submission_email: "test@example.gov.uk" } }
 
     before do
@@ -88,30 +77,23 @@ describe "/api/v1/forms", type: :request do
       end
     end
 
-    context "with invalid form params" do
-      let(:new_form_params) {  }
-      it "returns a status code 400" do
-        expect(response.status).to eq(400)
-        expect(response.headers["Content-Type"]).to eq("application/json")
-      end
-    end
-
     context "with no params" do
       let(:new_form_params) { {} }
-      it "returns a status code 400" do
-        expect(last_response.status).to eq(400)
-        expect(last_response.headers["Content-Type"]).to eq("application/json")
-        expect(json_body).to eq([{ messages: ["is missing"], params: ["name"] },
-                                 { messages: ["is missing"], params: ["submission_email"] },
-                                 { messages: ["is missing"], params: ["org"] }])
+
+      it "returns a status code 400 and validation messages" do
+        expect(response.status).to eq(400)
+        expect(response.headers["Content-Type"]).to eq("application/json")
+        expect(json_body).to eq({ name: ["can't be blank"],
+                                  org: ["can't be blank"] })
       end
     end
 
     context "with extra params" do
       let(:new_form_params) { { org: "gds", name: "test form one", submission_email: "test@example.gov.uk", support_url: "http://example.org" } }
+
       it "returns a status code 201" do
-        expect(last_response.status).to eq(201)
-        expect(last_response.headers["Content-Type"]).to eq("application/json")
+        expect(response.status).to eq(201)
+        expect(response.headers["Content-Type"]).to eq("application/json")
         expect(json_body).to eq(id: created_form[:id])
       end
 
@@ -119,7 +101,7 @@ describe "/api/v1/forms", type: :request do
         expect(created_form[:name]).to eq("test form one")
         expect(created_form[:submission_email]).to eq("test@example.gov.uk")
         expect(created_form[:org]).to eq("gds")
-        expect(created_form[:support_url]).to eq(nil)
+        expect(created_form[:support_url]).to eq("http://example.org")
       end
     end
   end
@@ -127,76 +109,63 @@ describe "/api/v1/forms", type: :request do
   describe "get single form" do
     it "when no forms exists for an id, returns 404 and an empty json array" do
       get "/api/v1/forms/987"
-      expect(last_response.status).to eq(404)
-      expect(last_response.headers["Content-Type"]).to eq("application/json")
+      expect(response.status).to eq(404)
+      expect(response.headers["Content-Type"]).to eq("application/json")
       expect(json_body).to eq(error: "not_found")
     end
 
     # This test is for documenting Grape API only
     it "when given an invalid id, returns 500 and an empty json array" do
       get "/api/v1/forms/invalid_id"
-      expect(last_response.status).to eq(500)
-      expect(last_response.headers["Content-Type"]).to eq("application/json")
+      expect(response.status).to eq(404)
+      expect(response.headers["Content-Type"]).to eq("application/json")
+      expect(json_body).to eq(error: "not_found")
     end
 
     it "when given an existing id, returns 200 and form data" do
-      form1_id = @database[:forms].where(name: "test form 1").get(:id)
-      get "/api/v1/forms/#{form1_id}"
-      expect(last_response.status).to eq(200)
-      expect(last_response.headers["Content-Type"]).to eq("application/json")
-      expect(json_body).to eq({
-                                id: form1_id,
-                                name: "test form 1",
-                                submission_email: "",
-                                org: "gds",
-                                created_at: nil,
-                                live_at: nil,
-                                updated_at: nil,
-                                privacy_policy_url: nil,
-                                form_slug: nil,
-                                what_happens_next_text: nil,
-                                support_email: nil,
-                                support_phone: nil,
-                                support_url: nil,
-                                support_url_text: nil,
-                                declaration_text: nil,
-                                question_section_completed: false,
-                                declaration_section_completed: false,
-                                page_order: [],
-                                start_page: nil
-                              })
+      form1 = Form.create!(name: "test form 1", org: "gds")
+      get "/api/v1/forms/#{form1.id}"
+      expect(response.status).to eq(200)
+      expect(response.headers["Content-Type"]).to eq("application/json")
+
+      expect(json_body).to match(
+        id: form1.id,
+        name: "test form 1",
+        submission_email: nil,
+        org: "gds",
+        live_at: nil,
+        privacy_policy_url: nil,
+        form_slug: nil,
+        what_happens_next_text: nil,
+        support_email: nil,
+        support_phone: nil,
+        support_url: nil,
+        support_url_text: nil,
+        declaration_text: nil,
+        question_section_completed: false,
+        declaration_section_completed: false,
+        page_order: nil,
+        created_at: form1.created_at.to_s,
+        updated_at: form1.updated_at.to_s,
+      )
     end
   end
 
   describe "update single form" do
     it "when no forms exists for an id, returns 404 an error" do
-      put "/api/v1/forms/123", {}
-      expect(last_response.status).to eq(404)
-      expect(last_response.headers["Content-Type"]).to eq("application/json")
+      put "/api/v1/forms/123"
+      expect(response.status).to eq(404)
+      expect(response.headers["Content-Type"]).to eq("application/json")
       expect(json_body).to eq(error: "not_found")
     end
 
-    it "when given an invalid key, returns 400 and an array of messages" do
-      form1_id = @database[:forms].where(name: "test form 1").get(:id)
-      put "/api/v1/forms/#{form1_id}", { invalid: "invalid key" }
-      expect(last_response.status).to eq(400)
-      expect(last_response.headers["Content-Type"]).to eq("application/json")
-      expect(json_body).to eq([
-                                { messages: ["is missing"], params: ["name"] },
-                                { messages: ["is missing"], params: ["submission_email"] },
-                                { messages: ["is missing"], params: ["org"] },
-                                { messages: ["is missing"], params: ["live_at"] }
-                              ])
-    end
-
     it "when given an valid id and params, updates DB and returns 200" do
-      form1_id = @database[:forms].where(name: "test form 1").get(:id)
-      put "/api/v1/forms/#{form1_id}", { name: "test1", org: "gds", live_at: nil, submission_email: "test@example.gov.uk" }
-      expect(last_response.status).to eq(200)
-      expect(last_response.headers["Content-Type"]).to eq("application/json")
+      form1 = create :form
+      put "/api/v1/forms/#{form1.id}", params: { submission_email: "test@example.gov.uk" }
+      expect(response.status).to eq(200)
+      expect(response.headers["Content-Type"]).to eq("application/json")
       expect(json_body).to eq(success: true)
-      form = database[:forms].where(id: form1_id).get(:submission_email)
-      expect(form).to eq("test@example.gov.uk")
+      expect(form1.reload.submission_email).to eq("test@example.gov.uk")
     end
   end
 

--- a/spec/request/forms_spec.rb
+++ b/spec/request/forms_spec.rb
@@ -40,7 +40,6 @@ describe "/api/v1/forms", type: :request do
       expect(response.headers["Content-Type"]).to eq("application/json")
       expect(json_body.count).to eq(2)
       expect(response).to be_successful
-      expect(json_body.size).to eq(2) # new expectation for rails
       # FIXUP could be stronger?
       # changed from grape version
       json_body.each do |form|
@@ -68,7 +67,7 @@ describe "/api/v1/forms", type: :request do
   end
 
   describe "creating a form" do
-    let(:created_form) { database[:forms].where(name: "test form one").all.last }
+    let(:created_form) { Form.find_by(name: "test form one")}
     let(:new_form_params) { { org: "gds", name: "test form one", submission_email: "test@example.gov.uk" } }
 
     before do
@@ -89,12 +88,11 @@ describe "/api/v1/forms", type: :request do
       end
     end
 
-    context "with no org" do
-      let(:new_form_params) { { name: "test form one", submission_email: "test@example.gov.uk" } }
+    context "with invalid form params" do
+      let(:new_form_params) {  }
       it "returns a status code 400" do
-        expect(last_response.status).to eq(400)
-        expect(last_response.headers["Content-Type"]).to eq("application/json")
-        expect(json_body).to eq([{ messages: ["is missing"], params: ["org"] }])
+        expect(response.status).to eq(400)
+        expect(response.headers["Content-Type"]).to eq("application/json")
       end
     end
 

--- a/spec/request/forms_spec.rb
+++ b/spec/request/forms_spec.rb
@@ -1,96 +1,70 @@
-require "rack/test"
+require 'rails_helper'
 
-describe "/api/v1/forms" do
-  include Rack::Test::Methods
-  include_context "with database"
+describe "/api/v1/forms", type: :request do
 
-  def app
-    Server::Server
+  let(:json_body) { JSON.parse(response.body, symbolize_names: true) }
+
+  before do
+    # create_list :form, 2, org:"gds"
+    create :form, org: "gds", name: 'test form 1'
+    create :form, org: "gds", name: 'test form 2'
+    create :form, org: "not-gds"
   end
 
-  let(:json_body) { JSON.parse(last_response.body, symbolize_names: true) }
-
-  before(:each) do
-    stub_const("ENV", ENV.to_hash.merge("API_KEY" => "an-api-key"))
-    allow(Database).to receive(:existing_database).and_return(@database)
-    header "X-Api-Token", ENV["API_KEY"]
-  end
-
-  around(:each) do |example|
-    @database.transaction(rollback: :always) do
-      @database[:forms].insert(name: "test form 1", submission_email: "", org: "gds")
-      @database[:forms].insert(name: "test form 2", submission_email: "", org: "gds")
-      @database[:forms].insert(name: "test form 3", submission_email: "", org: "not-gds")
-      example.run
-    end
-  end
+  # around(:each) do |example|
+  #   @database.transaction(rollback: :always) do
+  #     @database[:forms].insert(name: "test form 1", submission_email: "", org: "gds")
+  #     @database[:forms].insert(name: "test form 2", submission_email: "", org: "gds")
+  #     @database[:forms].insert(name: "test form 3", submission_email: "", org: "not-gds")
+  #     example.run
+  #   end
+  # end
 
   describe "get all forms" do
     it "when no forms exist for an org, returns 200 and an empty json array" do
-      get "/api/v1/forms", { org: "unknown-org" }
-      expect(last_response.status).to eq(200)
-      expect(last_response.headers["Content-Type"]).to eq("application/json")
+      get "/api/v1/forms", params: { org: "unknown-org" }
+      expect(response.status).to eq(200)
+      expect(response.headers["Content-Type"]).to eq("application/json")
       expect(json_body).to eq([])
     end
 
     it "when not given an org, returns 200 and an empty json array" do
-      get "/api/v1/forms", {}
-      expect(last_response.status).to eq(400)
-      expect(last_response.headers["Content-Type"]).to eq("application/json")
+      get "/api/v1/forms"
+      expect(response.status).to eq(400)
+      expect(response.headers["Content-Type"]).to eq("application/json")
       expect(json_body).to eq([{ messages: ["is missing"], params: ["org"] }])
     end
 
-    # rubocop:disable Metrics/BlockLength
     it "when given an org with forms, returns a json array of forms" do
-      get "/api/v1/forms", { org: "gds" }
-      expect(last_response.headers["Content-Type"]).to eq("application/json")
+      get "/api/v1/forms", params: { org: "gds" }
+      expect(response.headers["Content-Type"]).to eq("application/json")
       expect(json_body.count).to eq(2)
-      form1_id = @database[:forms].where(name: "test form 1").get(:id)
-      form2_id = @database[:forms].where(name: "test form 2").get(:id)
-      expect(json_body).to eq([
-                                {
-                                  id: form1_id,
-                                  name: "test form 1",
-                                  submission_email: "",
-                                  org: "gds",
-                                  created_at: nil,
-                                  live_at: nil,
-                                  updated_at: nil,
-                                  privacy_policy_url: nil,
-                                  form_slug: nil,
-                                  what_happens_next_text: nil,
-                                  support_email: nil,
-                                  support_phone: nil,
-                                  support_url: nil,
-                                  support_url_text: nil,
-                                  declaration_text: nil,
-                                  question_section_completed: false,
-                                  declaration_section_completed: false,
-                                  page_order: []
-                                },
-                                {
-                                  id: form2_id,
-                                  name: "test form 2",
-                                  submission_email: "",
-                                  org: "gds",
-                                  created_at: nil,
-                                  live_at: nil,
-                                  updated_at: nil,
-                                  privacy_policy_url: nil,
-                                  form_slug: nil,
-                                  what_happens_next_text: nil,
-                                  support_email: nil,
-                                  support_phone: nil,
-                                  support_url: nil,
-                                  support_url_text: nil,
-                                  declaration_text: nil,
-                                  question_section_completed: false,
-                                  declaration_section_completed: false,
-                                  page_order: []
-                                }
-                              ])
+      expect(response).to be_successful
+      expect(json_body.size).to eq(2) # new expectation for rails
+      # FIXUP could be stronger?
+      # changed from grape version
+      json_body.each do |form|
+        expect(form.keys).to contain_exactly(
+          :id,
+          :name,
+          :submission_email,
+          :org,
+          :created_at,
+          :live_at,
+          :updated_at,
+          :privacy_policy_url,
+          :form_slug,
+          :what_happens_next_text,
+          :support_email,
+          :support_phone,
+          :support_url,
+          :support_url_text,
+          :declaration_text,
+          :question_section_completed,
+          :declaration_section_completed,
+          :page_order)
+      end
     end
-    # rubocop:enable Metrics/BlockLength
   end
 
   describe "creating a form" do
@@ -98,13 +72,13 @@ describe "/api/v1/forms" do
     let(:new_form_params) { { org: "gds", name: "test form one", submission_email: "test@example.gov.uk" } }
 
     before do
-      post "/api/v1/forms", new_form_params
+      post "/api/v1/forms", params: new_form_params
     end
 
     context "with valid params" do
       it "returns a status code 201 when new form created" do
-        expect(last_response.status).to eq(201)
-        expect(last_response.headers["Content-Type"]).to eq("application/json")
+        expect(response.status).to eq(201)
+        expect(response.headers["Content-Type"]).to eq("application/json")
         expect(json_body).to eq(id: created_form[:id])
       end
 


### PR DESCRIPTION
#### What problem does the pull request solve?

Adds RESTful endpoints for forms model:
- GET `api/v1/forms?org=xxx` - get a list of forms for a specific organisation
- GET `api/v1/forms/:id` - shows an existing form
- POST `api/v1/forms` - creates a new form
- PUT `api/v1/forms/:id` - updates an existing form
- DESTROY `api/v1/forms/:id` - deletes an existing form


You should be able to run this locally in place of your existing forms-api. You should be able to see a list of forms on the home page and be able to create a new form but the form (i.e task list page) itself will not display until we have added pages model.

Trello card: https://trello.com/c/Lltmxkb6/365-migrate-forms-to-rails-api

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
