### PR TITLE
Fix FK violation error when deleting forms that have pages

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,5 +1,5 @@
 class Form < ApplicationRecord
-  has_many :pages, -> { order(position: :asc) }
+  has_many :pages, -> { order(position: :asc) }, dependent: :destroy
 
   validates :org, :name, presence: true
 

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -189,5 +189,13 @@ describe Api::V1::FormsController, type: :request do
       expect(response.headers["Content-Type"]).to eq("application/json")
       expect(json_body).to eq({ success: true })
     end
+
+    it "when given an existing id, returns 200 and deletes the form and any existing pages from DB" do
+      form_to_be_deleted = create :form, :with_pages
+      delete "/api/v1/forms/#{form_to_be_deleted.id}", as: :json
+      expect(response.status).to eq(200)
+      expect(response.headers["Content-Type"]).to eq("application/json")
+      expect(json_body).to eq({ success: true })
+    end
   end
 end


### PR DESCRIPTION
Rails was not deleting the pages that existed for a form that was about to be deleted. This happened locally on my machine and on staging when testing out the rails api version.

Error message:

PG::ForeignKeyViolation: ERROR:  update or delete on table "forms" violates foreign key constraint "fk_rails_ffa7b626f0" on table "pages" DETAIL:  Key (id)=(256) is still referenced from table "pages".

#### What problem does the pull request solve?

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
