### PR TITLE
Reset pages complete

### DIFF
--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -10,6 +10,7 @@ class Api::V1::PagesController < ApplicationController
     page = form.pages.new(page_params)
 
     if page.save
+      form.update!(question_section_completed: false)
       render json: { id: page.id }, status: :created
     else
       render json: page.errors.to_json, status: :bad_request
@@ -23,6 +24,7 @@ class Api::V1::PagesController < ApplicationController
 
   def update
     if page.update(page_params)
+      form.update!(question_section_completed: false)
       render json: { success: true }.to_json, status: :ok
     else
       render json: page.errors.to_json, status: :bad_request
@@ -31,6 +33,7 @@ class Api::V1::PagesController < ApplicationController
 
   def destroy
     page.destroy!
+    form.update!(question_section_completed: false)
     render json: { success: true }.to_json, status: :ok
   end
 

--- a/spec/request/api/v1/pages_controller_spec.rb
+++ b/spec/request/api/v1/pages_controller_spec.rb
@@ -76,6 +76,14 @@ describe Api::V1::PagesController, type: :request do
         expect(page_count).to eq(0)
       end
     end
+
+    context "with a form with question_section_completed = true" do
+      let(:form) { create :form, question_section_completed: true }
+
+      it "marks sets the form's question_section_completed as false" do
+        expect(form.reload.question_section_completed).to be false
+      end
+    end
   end
 
   describe "#show" do
@@ -136,8 +144,8 @@ describe Api::V1::PagesController, type: :request do
       expect(response.status).to eq(200)
       expect(response.headers["Content-Type"]).to eq("application/json")
       expect(json_body).to eq({ success: true })
-      page1.reload
-      expect(page1.question_text).to eq("updated page title")
+      expect(page1.reload.question_text).to eq("updated page title")
+      expect(form.reload.question_section_completed).to be false
     end
 
     it "fields not in the params are cleared" do
@@ -189,6 +197,7 @@ describe Api::V1::PagesController, type: :request do
         expect(response.headers["Content-Type"]).to eq("application/json")
         expect(json_body).to eq({ success: true })
         expect(form.pages.count).to eq(1)
+        expect(form.reload.question_section_completed).to be false
       end
     end
 

--- a/spec/request/api/v1/pages_controller_spec.rb
+++ b/spec/request/api/v1/pages_controller_spec.rb
@@ -161,7 +161,6 @@ describe Api::V1::PagesController, type: :request do
         let(:answer_settings) { settings }
 
         it "returns correct response" do
-          # require 'pry'; binding.pry
           expect(response.status).to eq(200)
           expect(response.headers["Content-Type"]).to eq("application/json")
           expect(json_body).to eq({ success: true })


### PR DESCRIPTION
#  Update forms question_section_completed
When a form creator makes changes to a page, the question_section_completed value for a form should be reset to false. 
This is used to show the status in the tasklist.

This commit updates the value when pages are created, updated or deleted.


Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
