### PR TITLE
Change local API key to previous value

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,4 @@
+forms_api:
+  # Empty key bypasses authentication process all together (mostly used by tests so we dont need to authenticate
+  # every request spec
+  authentication_key:


### PR DESCRIPTION
Docker uses 'development_key' as the API key if there is not one set through the environment variables.

This commit changes the current default to 'development_key' to blank in development.