### PR TITLE
Allow input type hash in strong params

### DIFF
--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -70,7 +70,7 @@ private
     if answer_settings_hash?
       # answer_types with answer_settings must be whitelisted to pass strong params
       if input_type_hash?
-        { answer_settings: [:only_one_option, { selection_options: [:name] }, { input_type: %i[uk_address international_address] }] }
+        { answer_settings: [:only_one_option, { selection_options: [:name] }, { input_type: {} }] }
       else
         { answer_settings: [:input_type, :only_one_option, { selection_options: [:name] }] }
       end

--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -58,13 +58,22 @@ private
 
   def answer_settings_hash?
     # these answer_types have an answer_settings value which is a hash
-    %w[selection text].include? params[:answer_type]
+    %w[selection text date address].include? params[:answer_type]
+  end
+
+  def input_type_hash?
+    # these answer_types have an input_type value which is a hash
+    %w[address].include? params[:answer_type]
   end
 
   def answer_setting_params
     if answer_settings_hash?
       # answer_types with answer_settings must be whitelisted to pass strong params
-      { answer_settings: [:input_type, :only_one_option, { selection_options: [:name] }] }
+      if input_type_hash?
+        { answer_settings: [:only_one_option, { selection_options: [:name] }, { input_type: %i[uk_address international_address] }] }
+      else
+        { answer_settings: [:input_type, :only_one_option, { selection_options: [:name] }] }
+      end
     else
       # answer_types with answer_settings will be passed nil, so we just whitelist that
       :answer_settings

--- a/spec/request/api/v1/pages_controller_spec.rb
+++ b/spec/request/api/v1/pages_controller_spec.rb
@@ -170,6 +170,26 @@ describe Api::V1::PagesController, type: :request do
         end
       end
     end
+
+    context "with nested answer_settings and input_type" do
+      let(:answer_type) { "address" }
+      let(:answer_settings) do
+        {
+          input_type: {
+            uk_address: "true",
+            international_address: "true",
+          },
+        }
+      end
+
+      it "returns correct response" do
+        expect(response.status).to eq(200)
+        expect(response.headers["Content-Type"]).to eq("application/json")
+        expect(json_body).to eq({ success: true })
+        page1.reload
+        expect(page1.answer_settings&.deep_symbolize_keys).to eq(answer_settings)
+      end
+    end
   end
 
   describe "#destroy" do


### PR DESCRIPTION
#### What problem does the pull request solve?
Edits the strong params to allow input type to be a hash for certain inputs - and enables this for the address input type.

Trello card: https://trello.com/c/zdoo448d/382-address-implementation-of-autofill-work-in-production

Related PRs:
- Admin: https://github.com/alphagov/forms-admin/pull/270
- Runner: https://github.com/alphagov/forms-runner/pull/229

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)