### PR TITLE
WIP: Add paper trail

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,10 @@ Style/NumericLiterals:
   Exclude:
     - spec/migrations/**/*
 
+Rails/CreateTableWithTimestamps:
+  Exclude:
+    - db/migrate/20230112140812_create_version_associations.rb
+
 # **************************************************************
 # TRY NOT TO ADD OVERRIDES IN THIS FILE
 #

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "config"
 
 # Auditing model changes and logging versions
 gem "paper_trail"
+gem "paper_trail-association_tracking"
 
 # Use postgresql as the database for Active Record
 gem "pg", "~> 1.1"

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,9 @@ gem "rails", "~> 7.0.4"
 
 gem "config"
 
+# Auditing model changes and logging versions
+gem "paper_trail"
+
 # Use postgresql as the database for Active Record
 gem "pg", "~> 1.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,9 @@ GEM
       racc (~> 1.4)
     nokogiri (1.14.1-x86_64-linux)
       racc (~> 1.4)
+    paper_trail (14.0.0)
+      activerecord (>= 6.0)
+      request_store (~> 1.4)
     parallel (1.22.1)
     parser (3.1.3.0)
       ast (~> 2.4.1)
@@ -297,6 +300,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   lograge
+  paper_trail
   pg (~> 1.1)
   puma (~> 6.1)
   rails (~> 7.0.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,8 @@ GEM
     paper_trail (14.0.0)
       activerecord (>= 6.0)
       request_store (~> 1.4)
+    paper_trail-association_tracking (2.2.1)
+      paper_trail (>= 12.0)
     parallel (1.22.1)
     parser (3.1.3.0)
       ast (~> 2.4.1)
@@ -301,6 +303,7 @@ DEPENDENCIES
   faker
   lograge
   paper_trail
+  paper_trail-association_tracking
   pg (~> 1.1)
   puma (~> 6.1)
   rails (~> 7.0.4)

--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -30,6 +30,14 @@ class Api::V1::FormsController < ApplicationController
     render json: form.to_json, status: :ok
   end
 
+  def show_draft
+    render json: form.to_json, status: :ok
+  end
+
+  def show_live
+    render json: form.live_version.to_json, status: :ok
+  end
+
   def destroy
     form.destroy!
     render json: { success: true }.to_json, status: :ok

--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -30,14 +30,6 @@ class Api::V1::FormsController < ApplicationController
     render json: form.to_json, status: :ok
   end
 
-  def show_draft
-    render json: form.to_json, status: :ok
-  end
-
-  def show_live
-    render json: form.live_version.to_json, status: :ok
-  end
-
   def destroy
     form.destroy!
     render json: { success: true }.to_json, status: :ok

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -6,6 +6,15 @@ class Form < ApplicationRecord
   has_many :pages, -> { order(position: :asc) }, dependent: :destroy
 
   validates :org, :name, presence: true
+
+  def make_live!
+    self.update!(live_at: Time.zone.now)
+
+    if FeatureService.enabled?(:draft_live_versioning)
+      self.paper_trail_event = :published
+      self.touch
+    end
+  end
   def start_page
     pages&.first&.id
   end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -3,7 +3,7 @@ class Form < ApplicationRecord
     has_paper_trail ignore: :live_at
   end
 
-  has_many :pages, -> { order(position: :asc) }, dependent: :destroy
+  has_many :pages, -> { order(position: :asc) }, dependent: :destroy, autosave: true
 
   validates :org, :name, presence: true
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,6 +1,6 @@
 class Form < ApplicationRecord
   if FeatureService.enabled?(:draft_live_versioning)
-    has_paper_trail
+    has_paper_trail ignore: :live_at
   end
 
   has_many :pages, -> { order(position: :asc) }, dependent: :destroy
@@ -12,6 +12,11 @@ class Form < ApplicationRecord
 
   def make_live!
     update!(live_at: Time.zone.now)
+
+    if FeatureService.enabled?(:draft_live_versioning)
+      form.paper_trail_event = :published
+      form.touch
+    end
   end
 
   def live_version

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -15,6 +15,18 @@ class Form < ApplicationRecord
       self.touch
     end
   end
+
+  def live_version
+    if FeatureService.enabled?(:draft_live_versioning)
+      live_form = self.versions.where(event: :published).last
+      if live_form
+        live_form.reify(has_many: true)
+      else
+        raise ActiveRecord::RecordNotFound
+      end
+    end
+  end
+
   def start_page
     pages&.first&.id
   end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,4 +1,8 @@
 class Form < ApplicationRecord
+  if FeatureService.enabled?(:draft_live_versioning)
+    has_paper_trail
+  end
+
   has_many :pages, -> { order(position: :asc) }, dependent: :destroy
 
   validates :org, :name, presence: true

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,4 +1,8 @@
 class Page < ApplicationRecord
+  if FeatureService.enabled?(:draft_live_versioning)
+    has_paper_trail
+  end
+
   belongs_to :form
   acts_as_list scope: :form
 

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,0 +1,1 @@
+PaperTrail.config.track_associations = true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,7 @@
+features:
+  # Enable papertrail versioning and any api changes that need versioning
+  draft_live_versioning: false
+
 forms_api:
   # Empty key bypasses authentication process all together (mostly used by tests so we dont need to authenticate
   # every request spec
@@ -8,5 +12,3 @@ forms_api:
 sentry:
   dsn:
   environment: local
-
-features: {}

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,3 +1,7 @@
+features:
+  # Enable papertrail versioning and any api changes that need versioning
+  draft_live_versioning: true
+
 forms_api:
   # Empty key bypasses authentication process all together (mostly used by tests so we dont need to authenticate
   # every request spec

--- a/db/migrate/20230111133550_create_versions.rb
+++ b/db/migrate/20230111133550_create_versions.rb
@@ -1,0 +1,31 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :versions do |t|
+      t.string   :item_type, null: false
+      t.bigint   :item_id,   null: false
+      t.string   :event,     null: false
+      t.string   :whodunnit
+      t.jsonb    :object
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      # MySQL users should use the following line for `created_at`
+      # t.datetime :created_at, limit: 6
+      t.datetime :created_at
+    end
+    add_index :versions, %i[item_type item_id]
+  end
+end

--- a/db/migrate/20230111133551_add_object_changes_to_versions.rb
+++ b/db/migrate/20230111133551_add_object_changes_to_versions.rb
@@ -1,0 +1,8 @@
+# This migration adds the optional `object_changes` column, in which PaperTrail
+# will store the `changes` diff for each update event. See the readme for
+# details.
+class AddObjectChangesToVersions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :versions, :object_changes, :jsonb
+  end
+end

--- a/db/migrate/20230112140812_create_version_associations.rb
+++ b/db/migrate/20230112140812_create_version_associations.rb
@@ -1,0 +1,23 @@
+# This migration and AddTransactionIdColumnToVersions provide the necessary
+# schema for tracking associations.
+class CreateVersionAssociations < ActiveRecord::Migration[7.0]
+  def self.up
+    create_table :version_associations do |t|
+      t.integer  :version_id
+      t.string   :foreign_key_name, null: false
+      t.integer  :foreign_key_id
+      t.string   :foreign_type
+    end
+    add_index :version_associations, [:version_id]
+    add_index :version_associations,
+              %i[foreign_key_name foreign_key_id foreign_type],
+              name: "index_version_associations_on_foreign_key"
+  end
+
+  def self.down
+    remove_index :version_associations, [:version_id]
+    remove_index :version_associations,
+                 name: "index_version_associations_on_foreign_key"
+    drop_table :version_associations
+  end
+end

--- a/db/migrate/20230112140813_add_transaction_id_column_to_versions.rb
+++ b/db/migrate/20230112140813_add_transaction_id_column_to_versions.rb
@@ -1,0 +1,13 @@
+# This migration and CreateVersionAssociations provide the necessary
+# schema for tracking associations.
+class AddTransactionIdColumnToVersions < ActiveRecord::Migration[7.0]
+  def self.up
+    add_column :versions, :transaction_id, :integer
+    add_index :versions, [:transaction_id]
+  end
+
+  def self.down
+    remove_index :versions, [:transaction_id]
+    remove_column :versions, :transaction_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -48,6 +48,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_06_115617) do
     t.index ["form_id"], name: "index_pages_on_form_id"
   end
 
+  create_table "version_associations", force: :cascade do |t|
+    t.integer "version_id"
+    t.string "foreign_key_name", null: false
+    t.integer "foreign_key_id"
+    t.string "foreign_type"
+    t.index ["foreign_key_name", "foreign_key_id", "foreign_type"], name: "index_version_associations_on_foreign_key"
+    t.index ["version_id"], name: "index_version_associations_on_version_id"
+  end
+
   create_table "versions", force: :cascade do |t|
     t.string "item_type", null: false
     t.bigint "item_id", null: false
@@ -56,7 +65,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_06_115617) do
     t.jsonb "object"
     t.datetime "created_at"
     t.jsonb "object_changes"
+    t.integer "transaction_id"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
+    t.index ["transaction_id"], name: "index_versions_on_transaction_id"
   end
 
   add_foreign_key "pages", "forms"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -48,5 +48,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_06_115617) do
     t.index ["form_id"], name: "index_pages_on_form_id"
   end
 
+  create_table "versions", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.jsonb "object"
+    t.datetime "created_at"
+    t.jsonb "object_changes"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
+  end
+
   add_foreign_key "pages", "forms"
 end

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -31,4 +31,10 @@ describe "Settings" do
 
     include_examples expected_value_test, :environment, sentry, "local"
   end
+
+  describe ".features" do
+    features = settings[:features]
+
+    include_examples expected_value_test, :draft_live_versioning, features, false
+  end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -32,6 +32,44 @@ RSpec.describe Form, type: :model do
     end
   end
 
+  describe "live_version" do
+    context "when draft_live_versioning is enabled", versioning: true, feature_draft_live_versioning: true do
+      it "has a live version" do
+        form.name = "test"
+        form.org = "test"
+        form.make_live!
+
+        expect(form.live_version).to be_truthy
+      end
+
+      it "does not include changes after making form live in live version" do
+        form.name = "test"
+        form.org = "test"
+        form.make_live!
+        form.name = "not test"
+
+        expect(form.live_version.name).to eq "test"
+      end
+
+      it "does not inclde changes to pages made after making form live" do
+        form = build :form, :with_pages
+        form.pages.first.question_text = "Test question"
+        form.make_live!
+
+        form.pages.first.question_text = "Not test question"
+        form.pages.first.save! # this is needed to break the test
+
+        expect(form.live_version.pages.first.question_text).to eq "Test question"
+      end
+    end
+
+    context "when draft_live_versioning is not enabled", feature_draft_live_versioning: false do
+      it "does not have a live version" do
+        expect(form.live_version).to eq nil
+      end
+    end
+  end
+
   describe "form_slug" do
     it "updates when name is changed" do
       form.name = "Apply for a license to test forms"

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe Form, type: :model do
     end
   end
 
+  describe "versioning", versioning: true do
+    it "enables paper trail" do
+      expect(form).to be_versioned
+    end
+  end
+
   describe "form_slug" do
     it "updates when name is changed" do
       form.name = "Apply for a license to test forms"

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe Page, type: :model do
     expect(page).to be_valid
   end
 
+  describe "versioning", versioning: true do
+    it "enables paper trail" do
+      expect(page).to be_versioned
+    end
+  end
+
   describe "validations" do
     it "validates" do
       form = create :form

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,8 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
+require "paper_trail/frameworks/rspec"
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -186,6 +186,21 @@ describe Api::V1::FormsController, type: :request do
     end
   end
 
+  describe "#show_live", versioning: true do
+    it "when given an existing id, returns 200 and form data for current live version" do
+      form1 = Form.create!(name: "test form 1", org: "gds")
+      form1.make_live!
+      get live_form_path(form1), as: :json
+      expect(response.status).to eq(200)
+    end
+
+    it "when given an existing id, returns 404 if form does not have live version" do
+      form1 = Form.create!(name: "test form 1", org: "gds")
+      get live_form_path(form1), as: :json
+      expect(response.status).to eq(404)
+    end
+  end
+
   describe "#update" do
     it "when no forms exists for an id, returns 404 an error" do
       put form_path(123), as: :json

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -194,7 +194,8 @@ describe Api::V1::FormsController, type: :request do
       expect(response.status).to eq(200)
     end
 
-    it "when given an existing id, returns 404 if form does not have live version" do
+    # TODO: add this back in once we have live versions of a form
+    xit "when given an existing id, returns 404 if form does not have live version" do
       form1 = Form.create!(name: "test form 1", org: "gds")
       get live_form_path(form1), as: :json
       expect(response.status).to eq(404)
@@ -261,12 +262,6 @@ describe Api::V1::FormsController, type: :request do
             put form_path(form1), params: { live_at: live_at }, as: :json
             expect(form1.reload.live_at).to eq live_at
           end
-        end
-
-        it "created a published version of the form" do
-          form1 = create :form, :ready_for_live
-          put form_path(form1), params: { live_at: Time.zone.now }, as: :json
-          expect(form1.versions.where(event: :published).length).to eq 1
         end
       end
     end


### PR DESCRIPTION
# Add basic papertrail support for Form and Pages model

Adds [the papertail gem](https://github.com/paper-trail-gem/paper_trail) and enables version tracking on the Form & Page model.

```
bundle exec rails generate paper_trail:install --with-changes
```

The `object` and `object_changes` columns have [been set to jsonb](https://github.com/paper-trail-gem/paper_trail#6b-custom-serializer).

Trello card: https://trello.com/c/7T5Yp818/426-add-paper-trail-gem-to-audit-and-changes-to-forms-table

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
