### PR TITLE
Strong params changes for name input

### DIFF
--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -58,7 +58,7 @@ private
 
   def answer_settings_hash?
     # these answer_types have an answer_settings value which is a hash
-    %w[selection text date address].include? params[:answer_type]
+    %w[selection text date address name].include? params[:answer_type]
   end
 
   def input_type_hash?
@@ -72,7 +72,7 @@ private
       if input_type_hash?
         { answer_settings: [:only_one_option, { selection_options: [:name] }, { input_type: {} }] }
       else
-        { answer_settings: [:input_type, :only_one_option, { selection_options: [:name] }] }
+        { answer_settings: [:input_type, :title_needed, :only_one_option, { selection_options: [:name] }] }
       end
     else
       # answer_types with answer_settings will be passed nil, so we just whitelist that

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -2,7 +2,7 @@ class Page < ApplicationRecord
   belongs_to :form
   acts_as_list scope: :form
 
-  ANSWER_TYPES = %w[single_line number address date email national_insurance_number phone_number long_text selection organisation_name text].freeze
+  ANSWER_TYPES = %w[single_line number address date email national_insurance_number phone_number long_text selection organisation_name text name].freeze
 
   validates :question_text, presence: true
   validates :answer_type, presence: true, inclusion: { in: ANSWER_TYPES }


### PR DESCRIPTION
#### What problem does the pull request solve?
Adds the new name type to the list of allowed answer types, and allows it to send an `answer_settings` hash in the strong params.

Trello card: https://trello.com/c/efuBewje/384-persons-name-implementation-of-autofill-work-in-production

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [n/a] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
