### PR TITLE
Add migrations for autofill answer types

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,9 @@ inherit_mode:
   merge:
     - Exclude
 
+Style/NumericLiterals:
+  Exclude:
+    - spec/migrations/**/*
 
 # **************************************************************
 # TRY NOT TO ADD OVERRIDES IN THIS FILE

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,7 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-21
   x86_64-linux

--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -123,19 +123,12 @@ private
     when "long_text"
       page.answer_settings = { input_type: "long_text" }
       page.answer_type = "text"
-    when "address"
-      page.answer_settings ||= { input_type: { uk_address: "true", international_address: "false" } }
-    when "date"
-      page.answer_settings ||= { input_type: "other_date" }
     end
   end
 
   def display_new_answer_types_in_old_format(page)
-    case page.answer_type
-    when "text"
+    if page.answer_type == "text"
       page.answer_type = page.answer_settings["input_type"]
-      page.answer_settings = nil
-    when "date", "address"
       page.answer_settings = nil
     end
   end

--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -115,21 +115,21 @@ private
     render json: { error: exception.message }, status: :bad_request
   end
 
-  def convert_old_answer_types_to_new_format(page)
-    case page.answer_type
+  def convert_old_answer_types_to_new_format(page_object)
+    case page_object.answer_type
     when "single_line"
-      page.answer_settings = { input_type: "single_line" }
-      page.answer_type = "text"
+      page_object.answer_settings = { input_type: "single_line" }
+      page_object.answer_type = "text"
     when "long_text"
-      page.answer_settings = { input_type: "long_text" }
-      page.answer_type = "text"
+      page_object.answer_settings = { input_type: "long_text" }
+      page_object.answer_type = "text"
     end
   end
 
-  def display_new_answer_types_in_old_format(page)
-    if page.answer_type == "text"
-      page.answer_type = page.answer_settings["input_type"]
-      page.answer_settings = nil
+  def display_new_answer_types_in_old_format(page_object)
+    if page_object.answer_type == "text"
+      page_object.answer_type = page_object.answer_settings["input_type"]
+      page_object.answer_settings = nil
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,6 +9,6 @@ sentry:
   dsn:
   environment: local
 
-# The feature service needs at least one feature in order to establish the pattern for features, this can be replaced with a real feature when we have one
 features:
-  example_feature: false
+  # accept_legacy_answer_types should be set to false when the autocomplete_answer_types flag in admin is set to true
+  accept_legacy_answer_types: true

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -2,3 +2,6 @@ forms_api:
   # Empty key bypasses authentication process all together (mostly used by tests so we dont need to authenticate
   # every request spec
   authentication_key:
+
+features:
+  accept_legacy_answer_types: false

--- a/db/migrate/20230126133557_convert_date_to_other_date.rb
+++ b/db/migrate/20230126133557_convert_date_to_other_date.rb
@@ -2,8 +2,4 @@ class ConvertDateToOtherDate < ActiveRecord::Migration[7.0]
   def up
     Page.where(answer_type: "date", answer_settings: nil).update_all(answer_settings: { input_type: "other_date" })
   end
-
-  def down
-    Page.where(answer_type: "date", answer_settings: { input_type: "other_date" }).update_all(answer_settings: nil)
-  end
 end

--- a/db/migrate/20230126133557_convert_date_to_other_date.rb
+++ b/db/migrate/20230126133557_convert_date_to_other_date.rb
@@ -4,6 +4,6 @@ class ConvertDateToOtherDate < ActiveRecord::Migration[7.0]
   end
 
   def down
-    Page.where(answer_type: "date").update_all(answer_settings: nil)
+    Page.where(answer_type: "date", answer_settings: { input_type: "other_date" }).update_all(answer_settings: nil)
   end
 end

--- a/db/migrate/20230126133557_convert_date_to_other_date.rb
+++ b/db/migrate/20230126133557_convert_date_to_other_date.rb
@@ -1,0 +1,9 @@
+class ConvertDateToOtherDate < ActiveRecord::Migration[7.0]
+  def up
+    Page.where(answer_type: "date", answer_settings: nil).update_all(answer_settings: { input_type: "other_date" })
+  end
+
+  def down
+    Page.where(answer_type: "date").update_all(answer_settings: nil)
+  end
+end

--- a/db/migrate/20230126135721_convert_address_to_uk_address.rb
+++ b/db/migrate/20230126135721_convert_address_to_uk_address.rb
@@ -2,8 +2,4 @@ class ConvertAddressToUkAddress < ActiveRecord::Migration[7.0]
   def up
     Page.where(answer_type: "address", answer_settings: nil).update_all(answer_settings: { input_type: { uk_address: "true", international_address: "false" } })
   end
-
-  def down
-    Page.where(answer_type: "address", answer_settings: { input_type: { uk_address: "true", international_address: "false" } }).update_all(answer_settings: nil)
-  end
 end

--- a/db/migrate/20230126135721_convert_address_to_uk_address.rb
+++ b/db/migrate/20230126135721_convert_address_to_uk_address.rb
@@ -4,6 +4,6 @@ class ConvertAddressToUkAddress < ActiveRecord::Migration[7.0]
   end
 
   def down
-    Page.where(answer_type: "address").update_all(answer_settings: nil)
+    Page.where(answer_type: "address", answer_settings: { input_type: { uk_address: "true", international_address: "false" } }).update_all(answer_settings: nil)
   end
 end

--- a/db/migrate/20230126135721_convert_address_to_uk_address.rb
+++ b/db/migrate/20230126135721_convert_address_to_uk_address.rb
@@ -1,0 +1,9 @@
+class ConvertAddressToUkAddress < ActiveRecord::Migration[7.0]
+  def up
+    Page.where(answer_type: "address", answer_settings: nil).update_all(answer_settings: { input_type: { uk_address: "true", international_address: "false" } })
+  end
+
+  def down
+    Page.where(answer_type: "address").update_all(answer_settings: nil)
+  end
+end

--- a/db/migrate/20230126141136_convert_old_text_fields_to_new_text_fields.rb
+++ b/db/migrate/20230126141136_convert_old_text_fields_to_new_text_fields.rb
@@ -1,0 +1,11 @@
+class ConvertOldTextFieldsToNewTextFields < ActiveRecord::Migration[7.0]
+  def up
+    Page.where(answer_type: "single_line", answer_settings: nil).update_all(answer_type: "text", answer_settings: { input_type: "single_line" })
+    Page.where(answer_type: "long_text", answer_settings: nil).update_all(answer_type: "text", answer_settings: { input_type: "long_text" })
+  end
+
+  def down
+    Page.where(answer_type: "text", answer_settings: { input_type: "long_text" }).update_all(answer_type: "long_text", answer_settings: nil)
+    Page.where(answer_type: "text", answer_settings: { input_type: "single_line" }).update_all(answer_type: "single_line", answer_settings: nil)
+  end
+end

--- a/db/migrate/20230126141136_convert_old_text_fields_to_new_text_fields.rb
+++ b/db/migrate/20230126141136_convert_old_text_fields_to_new_text_fields.rb
@@ -3,9 +3,4 @@ class ConvertOldTextFieldsToNewTextFields < ActiveRecord::Migration[7.0]
     Page.where(answer_type: "single_line", answer_settings: nil).update_all(answer_type: "text", answer_settings: { input_type: "single_line" })
     Page.where(answer_type: "long_text", answer_settings: nil).update_all(answer_type: "text", answer_settings: { input_type: "long_text" })
   end
-
-  def down
-    Page.where(answer_type: "text", answer_settings: { input_type: "long_text" }).update_all(answer_type: "long_text", answer_settings: nil)
-    Page.where(answer_type: "text", answer_settings: { input_type: "single_line" }).update_all(answer_type: "single_line", answer_settings: nil)
-  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,9 +49,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_26_141136) do
     t.index ["form_id"], name: "index_pages_on_form_id"
   end
 
-  create_table "schema_info", id: false, force: :cascade do |t|
-    t.integer "version", default: 0, null: false
-  end
-
   add_foreign_key "pages", "forms"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_22_115429) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_26_141136) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -47,6 +47,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_22_115429) do
     t.bigint "form_id"
     t.integer "position"
     t.index ["form_id"], name: "index_pages_on_form_id"
+  end
+
+  create_table "schema_info", id: false, force: :cascade do |t|
+    t.integer "version", default: 0, null: false
   end
 
   add_foreign_key "pages", "forms"

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -31,4 +31,10 @@ describe "Settings" do
 
     include_examples expected_value_test, :environment, sentry, "local"
   end
+
+  describe ".features" do
+    features = settings[:features]
+
+    include_examples expected_value_test, :accept_legacy_answer_types, features, true
+  end
 end

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -34,6 +34,14 @@ FactoryBot.define do
       question_section_completed { true }
     end
 
+    trait :with_text_page do
+      pages do
+        Array.new(1) { build(:page, answer_type: "text", answer_settings: { input_type: %w[single_line long_text].sample }) }
+      end
+
+      question_section_completed { true }
+    end
+
     trait :ready_for_live do
       support_email { Faker::Internet.email(domain: "example.gov.uk") }
       what_happens_next_text { "We usually respond to applications within 10 working days." }

--- a/spec/migrations/convert_address_to_uk_address_spec.rb
+++ b/spec/migrations/convert_address_to_uk_address_spec.rb
@@ -4,7 +4,6 @@ require Rails.root.join("db/migrate/20230126135721_convert_address_to_uk_address
 describe ConvertAddressToUkAddress do
   include MigrationHelpers
 
-  let(:current_version) { 20230126135721 }
   let(:previous_version) { 20230126133557 }
 
   describe "#up" do
@@ -16,28 +15,6 @@ describe ConvertAddressToUkAddress do
       described_class.new.up
 
       expect(page.reload.answer_settings).to eq({ "input_type" => { "uk_address" => "true", "international_address" => "false" } })
-    end
-  end
-
-  describe "#down" do
-    before { migrate_to(current_version) }
-
-    it "does not remove answer settings for ‘international_address‘ input types" do
-      page_with_both = create(:page, answer_type: "address", answer_settings: { input_type: { uk_address: "true", international_address: "true" } })
-      page_with_international_address = create(:page, answer_type: "address", answer_settings: { input_type: { uk_address: "false", international_address: "true" } })
-
-      described_class.new.down
-
-      expect(page_with_both.reload.answer_settings).to eq({ "input_type" => { "uk_address" => "true", "international_address" => "true" } })
-      expect(page_with_international_address.reload.answer_settings).to eq({ "input_type" => { "uk_address" => "false", "international_address" => "true" } })
-    end
-
-    it "removes answer settings for ‘uk_address‘ only input types" do
-      page = create(:page, answer_type: "address", answer_settings: { input_type: { uk_address: "true", international_address: "false" } })
-
-      described_class.new.down
-
-      expect(page.reload.answer_settings).to be_nil
     end
   end
 end

--- a/spec/migrations/convert_address_to_uk_address_spec.rb
+++ b/spec/migrations/convert_address_to_uk_address_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+require Rails.root.join('db/migrate/20230126135721_convert_address_to_uk_address.rb')
+
+describe ConvertAddressToUkAddress do
+  let(:migrations_paths) { ActiveRecord::Migrator.migrations_paths }
+  let(:migrations) { ActiveRecord::MigrationContext.new(migrations_paths).migrations }
+  let(:schema_migration) { ActiveRecord::SchemaMigration }
+  let(:current_version) { 20230126135721 }
+  let(:previous_version) { 20230126133557 }
+
+  describe "#up" do
+    before do
+      ActiveRecord::Migration.suppress_messages do
+        ActiveRecord::Migrator.new(:down, migrations, schema_migration, previous_version).migrate
+      end
+    end
+
+    it "converts existing ‘address‘ answer types to ‘uk_address‘ input types when nil" do
+      page = create(:page, answer_type: "address")
+
+      described_class.new.up
+
+      expect(page.reload.answer_settings).to eq({ "input_type" => { "uk_address" => "true", "international_address" => "false" } })
+    end
+  end
+
+  describe "#down" do
+    before do
+      ActiveRecord::Migration.suppress_messages do
+        ActiveRecord::Migrator.new(:up, migrations, schema_migration, current_version).migrate
+      end
+    end
+
+    it "does not remove answer settings for ‘international_address‘ input types" do
+      page_with_both = create(:page, answer_type: "address", answer_settings: { input_type: { uk_address: "true", international_address: "true" } })
+      page_with_international_address = create(:page, answer_type: "address", answer_settings: { input_type: { uk_address: "false", international_address: "true" } })
+
+      described_class.new.down
+
+      expect(page_with_both.reload.answer_settings).to eq({ "input_type" => { "uk_address" => "true", "international_address" => "true" } })
+      expect(page_with_international_address.reload.answer_settings).to eq({ "input_type" => { "uk_address" => "false", "international_address" => "true" } })
+    end
+
+    it "removes answer settings for ‘uk_address‘ only input types" do
+      page = create(:page, answer_type: "address", answer_settings: { input_type: { uk_address: "true", international_address: "false" } })
+
+      described_class.new.down
+
+      expect(page.reload.answer_settings).to be_nil
+    end
+  end
+end

--- a/spec/migrations/convert_address_to_uk_address_spec.rb
+++ b/spec/migrations/convert_address_to_uk_address_spec.rb
@@ -1,19 +1,14 @@
 require "rails_helper"
-require Rails.root.join('db/migrate/20230126135721_convert_address_to_uk_address.rb')
+require Rails.root.join("db/migrate/20230126135721_convert_address_to_uk_address.rb")
 
 describe ConvertAddressToUkAddress do
-  let(:migrations_paths) { ActiveRecord::Migrator.migrations_paths }
-  let(:migrations) { ActiveRecord::MigrationContext.new(migrations_paths).migrations }
-  let(:schema_migration) { ActiveRecord::SchemaMigration }
+  include MigrationHelpers
+
   let(:current_version) { 20230126135721 }
   let(:previous_version) { 20230126133557 }
 
   describe "#up" do
-    before do
-      ActiveRecord::Migration.suppress_messages do
-        ActiveRecord::Migrator.new(:down, migrations, schema_migration, previous_version).migrate
-      end
-    end
+    before { migrate_to(previous_version) }
 
     it "converts existing ‘address‘ answer types to ‘uk_address‘ input types when nil" do
       page = create(:page, answer_type: "address")
@@ -25,11 +20,7 @@ describe ConvertAddressToUkAddress do
   end
 
   describe "#down" do
-    before do
-      ActiveRecord::Migration.suppress_messages do
-        ActiveRecord::Migrator.new(:up, migrations, schema_migration, current_version).migrate
-      end
-    end
+    before { migrate_to(current_version) }
 
     it "does not remove answer settings for ‘international_address‘ input types" do
       page_with_both = create(:page, answer_type: "address", answer_settings: { input_type: { uk_address: "true", international_address: "true" } })

--- a/spec/migrations/convert_date_to_other_date_spec.rb
+++ b/spec/migrations/convert_date_to_other_date_spec.rb
@@ -4,38 +4,18 @@ require Rails.root.join("db/migrate/20230126133557_convert_date_to_other_date.rb
 describe ConvertDateToOtherDate do
   include MigrationHelpers
 
-  let(:current_version) { 20230126133557 }
   let(:previous_version) { 20221222115429 }
 
   describe "#up" do
-    before { migrate_to(previous_version) }
+    before do
+      migrate_to(previous_version)
+    end
 
     it "converts existing date input types to ‘other_date‘ when nil" do
       page = create(:page, answer_type: "date")
-
       described_class.new.up
 
       expect(page.reload.answer_settings).to eq({ "input_type" => "other_date" })
-    end
-  end
-
-  describe "#down" do
-    before { migrate_to(current_version) }
-
-    it "does not remove answer settings for ‘date_of_birth‘ input types" do
-      page = create(:page, answer_type: "date", answer_settings: { input_type: "date_of_birth" })
-
-      described_class.new.down
-
-      expect(page.reload.answer_settings).to eq({ "input_type" => "date_of_birth" })
-    end
-
-    it "removes answer settings for ‘other_date‘ input types" do
-      page = create(:page, answer_type: "date", answer_settings: { input_type: "other_date" })
-
-      described_class.new.down
-
-      expect(page.reload.answer_settings).to be_nil
     end
   end
 end

--- a/spec/migrations/convert_date_to_other_date_spec.rb
+++ b/spec/migrations/convert_date_to_other_date_spec.rb
@@ -1,19 +1,14 @@
 require "rails_helper"
-require Rails.root.join('db/migrate/20230126133557_convert_date_to_other_date.rb')
+require Rails.root.join("db/migrate/20230126133557_convert_date_to_other_date.rb")
 
 describe ConvertDateToOtherDate do
-  let(:migrations_paths) { ActiveRecord::Migrator.migrations_paths }
-  let(:migrations) { ActiveRecord::MigrationContext.new(migrations_paths).migrations }
-  let(:schema_migration) { ActiveRecord::SchemaMigration }
+  include MigrationHelpers
+
   let(:current_version) { 20230126133557 }
   let(:previous_version) { 20221222115429 }
 
   describe "#up" do
-    before do
-      ActiveRecord::Migration.suppress_messages do
-        ActiveRecord::Migrator.new(:down, migrations, schema_migration, previous_version).migrate
-      end
-    end
+    before { migrate_to(previous_version) }
 
     it "converts existing date input types to ‘other_date‘ when nil" do
       page = create(:page, answer_type: "date")
@@ -25,11 +20,7 @@ describe ConvertDateToOtherDate do
   end
 
   describe "#down" do
-    before do
-      ActiveRecord::Migration.suppress_messages do
-        ActiveRecord::Migrator.new(:up, migrations, schema_migration, current_version).migrate
-      end
-    end
+    before { migrate_to(current_version) }
 
     it "does not remove answer settings for ‘date_of_birth‘ input types" do
       page = create(:page, answer_type: "date", answer_settings: { input_type: "date_of_birth" })

--- a/spec/migrations/convert_date_to_other_date_spec.rb
+++ b/spec/migrations/convert_date_to_other_date_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+require Rails.root.join('db/migrate/20230126133557_convert_date_to_other_date.rb')
+
+describe ConvertDateToOtherDate do
+  let(:migrations_paths) { ActiveRecord::Migrator.migrations_paths }
+  let(:migrations) { ActiveRecord::MigrationContext.new(migrations_paths).migrations }
+  let(:schema_migration) { ActiveRecord::SchemaMigration }
+  let(:current_version) { 20230126133557 }
+  let(:previous_version) { 20221222115429 }
+
+  describe "#up" do
+    before do
+      ActiveRecord::Migration.suppress_messages do
+        ActiveRecord::Migrator.new(:down, migrations, schema_migration, previous_version).migrate
+      end
+    end
+
+    it "converts existing date input types to ‘other_date‘ when nil" do
+      page = create(:page, answer_type: "date")
+
+      described_class.new.up
+
+      expect(page.reload.answer_settings).to eq({ "input_type" => "other_date" })
+    end
+  end
+
+  describe "#down" do
+    before do
+      ActiveRecord::Migration.suppress_messages do
+        ActiveRecord::Migrator.new(:up, migrations, schema_migration, current_version).migrate
+      end
+    end
+
+    it "does not remove answer settings for ‘date_of_birth‘ input types" do
+      page = create(:page, answer_type: "date", answer_settings: { input_type: "date_of_birth" })
+
+      described_class.new.down
+
+      expect(page.reload.answer_settings).to eq({ "input_type" => "date_of_birth" })
+    end
+
+    it "removes answer settings for ‘other_date‘ input types" do
+      page = create(:page, answer_type: "date", answer_settings: { input_type: "other_date" })
+
+      described_class.new.down
+
+      expect(page.reload.answer_settings).to be_nil
+    end
+  end
+end

--- a/spec/migrations/convert_old_text_fields_to_new_text_fields_spec.rb
+++ b/spec/migrations/convert_old_text_fields_to_new_text_fields_spec.rb
@@ -4,7 +4,6 @@ require Rails.root.join("db/migrate/20230126141136_convert_old_text_fields_to_ne
 describe ConvertOldTextFieldsToNewTextFields do
   include MigrationHelpers
 
-  let(:current_version) { 20230126141136 }
   let(:previous_version) { 20230126135721 }
 
   describe "#up" do
@@ -26,28 +25,6 @@ describe ConvertOldTextFieldsToNewTextFields do
 
       expect(page.reload.answer_type).to eq("text")
       expect(page.reload.answer_settings).to eq({ "input_type" => "long_text" })
-    end
-  end
-
-  describe "#down" do
-    before { migrate_to(current_version) }
-
-    it "converts existing ‘single_line‘ input types to ‘single_line‘ answer types with no answer settings" do
-      page = create(:page, answer_type: "text", answer_settings: { input_type: "single_line" })
-
-      described_class.new.down
-
-      expect(page.reload.answer_type).to eq("single_line")
-      expect(page.reload.answer_settings).to be_nil
-    end
-
-    it "converts existing ‘long_text‘ input types to ‘long_text‘ answer types with no answer settings" do
-      page = create(:page, answer_type: "text", answer_settings: { input_type: "long_text" })
-
-      described_class.new.down
-
-      expect(page.reload.answer_type).to eq("long_text")
-      expect(page.reload.answer_settings).to be_nil
     end
   end
 end

--- a/spec/migrations/convert_old_text_fields_to_new_text_fields_spec.rb
+++ b/spec/migrations/convert_old_text_fields_to_new_text_fields_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+require Rails.root.join('db/migrate/20230126141136_convert_old_text_fields_to_new_text_fields.rb')
+
+describe ConvertOldTextFieldsToNewTextFields do
+  let(:migrations_paths) { ActiveRecord::Migrator.migrations_paths }
+  let(:migrations) { ActiveRecord::MigrationContext.new(migrations_paths).migrations }
+  let(:schema_migration) { ActiveRecord::SchemaMigration }
+  let(:current_version) { 20230126141136 }
+  let(:previous_version) { 20230126135721 }
+
+  describe "#up" do
+    before do
+      ActiveRecord::Migration.suppress_messages do
+        ActiveRecord::Migrator.new(:down, migrations, schema_migration, previous_version).migrate
+      end
+    end
+
+    it "converts existing ‘single_line‘ answer types to ‘text‘ answer types with ‘single_line‘ input types" do
+      page = create(:page, answer_type: "single_line")
+
+      described_class.new.up
+
+      expect(page.reload.answer_type).to eq("text")
+      expect(page.reload.answer_settings).to eq({ "input_type" => "single_line" })
+    end
+
+    it "converts existing ‘long_text‘ answer types to ‘text‘ answer types with ‘long_text‘ input types" do
+      page = create(:page, answer_type: "long_text")
+
+      described_class.new.up
+
+      expect(page.reload.answer_type).to eq("text")
+      expect(page.reload.answer_settings).to eq({ "input_type" => "long_text" })
+    end
+  end
+
+  describe "#down" do
+    before do
+      ActiveRecord::Migration.suppress_messages do
+        ActiveRecord::Migrator.new(:up, migrations, schema_migration, current_version).migrate
+      end
+    end
+
+    it "converts existing ‘single_line‘ input types to ‘single_line‘ answer types with no answer settings" do
+      page = create(:page, answer_type: "text", answer_settings: { input_type: "single_line" })
+
+      described_class.new.down
+
+      expect(page.reload.answer_type).to eq("single_line")
+      expect(page.reload.answer_settings).to be_nil
+    end
+
+    it "converts existing ‘long_text‘ input types to ‘long_text‘ answer types with no answer settings" do
+      page = create(:page, answer_type: "text", answer_settings: { input_type: "long_text" })
+
+      described_class.new.down
+
+      expect(page.reload.answer_type).to eq("long_text")
+      expect(page.reload.answer_settings).to be_nil
+    end
+  end
+end

--- a/spec/migrations/convert_old_text_fields_to_new_text_fields_spec.rb
+++ b/spec/migrations/convert_old_text_fields_to_new_text_fields_spec.rb
@@ -1,19 +1,14 @@
 require "rails_helper"
-require Rails.root.join('db/migrate/20230126141136_convert_old_text_fields_to_new_text_fields.rb')
+require Rails.root.join("db/migrate/20230126141136_convert_old_text_fields_to_new_text_fields.rb")
 
 describe ConvertOldTextFieldsToNewTextFields do
-  let(:migrations_paths) { ActiveRecord::Migrator.migrations_paths }
-  let(:migrations) { ActiveRecord::MigrationContext.new(migrations_paths).migrations }
-  let(:schema_migration) { ActiveRecord::SchemaMigration }
+  include MigrationHelpers
+
   let(:current_version) { 20230126141136 }
   let(:previous_version) { 20230126135721 }
 
   describe "#up" do
-    before do
-      ActiveRecord::Migration.suppress_messages do
-        ActiveRecord::Migrator.new(:down, migrations, schema_migration, previous_version).migrate
-      end
-    end
+    before { migrate_to(previous_version) }
 
     it "converts existing ‘single_line‘ answer types to ‘text‘ answer types with ‘single_line‘ input types" do
       page = create(:page, answer_type: "single_line")
@@ -35,11 +30,7 @@ describe ConvertOldTextFieldsToNewTextFields do
   end
 
   describe "#down" do
-    before do
-      ActiveRecord::Migration.suppress_messages do
-        ActiveRecord::Migrator.new(:up, migrations, schema_migration, current_version).migrate
-      end
-    end
+    before { migrate_to(current_version) }
 
     it "converts existing ‘single_line‘ input types to ‘single_line‘ answer types with no answer settings" do
       page = create(:page, answer_type: "text", answer_settings: { input_type: "single_line" })

--- a/spec/request/api/v1/pages_controller_spec.rb
+++ b/spec/request/api/v1/pages_controller_spec.rb
@@ -31,6 +31,7 @@ describe Api::V1::PagesController, type: :request do
         expect(response.headers["Content-Type"]).to eq("application/json")
         expect(json_body).to eq({ id: new_page.id })
       end
+
       it "creates DB row with the legacy answer type converted to a new one" do
         expect(new_page.as_json).to eq(new_page_params.merge(id: new_page[:id],
                                                              form_id: form[:id],

--- a/spec/request/api/v1/pages_controller_spec.rb
+++ b/spec/request/api/v1/pages_controller_spec.rb
@@ -31,9 +31,9 @@ describe Api::V1::PagesController, type: :request do
         question_text: "What is your first name?",
         question_short_name: "",
         hint_text: "Should be first/last name",
-        answer_type: "single_line",
+        answer_type: "text",
         is_optional: false,
-        answer_settings: nil,
+        answer_settings: { "input_type" => "single_line" },
       }
     end
     let(:new_page) { form.pages.first }

--- a/spec/request/api/v1/pages_controller_spec.rb
+++ b/spec/request/api/v1/pages_controller_spec.rb
@@ -3,6 +3,88 @@ require "rails_helper"
 describe Api::V1::PagesController, type: :request do
   let(:json_body) { JSON.parse(response.body, symbolize_names: true) }
 
+  context "when accepting legacy answer types", feature_accept_legacy_answer_types: true do
+    describe "#create" do
+      let(:form) { create :form }
+      let(:new_page_params) do
+        {
+          form_id: form.id,
+          question_text: "What is your first name?",
+          question_short_name: "",
+          hint_text: "Should be first/last name",
+          answer_type: %w[single_line long_text].sample,
+          is_optional: false,
+          answer_settings: nil,
+        }
+      end
+      let(:new_page) { form.pages.first }
+
+      before do
+        # fix the time here so we can test created_at and updated_at explicitly
+        travel_to Time.zone.local(2023, 1, 1, 12, 0, 0) do
+          post "/api/v1/forms/#{form.id}/pages", params: new_page_params, as: :json
+        end
+      end
+
+      it "returns page id, status code 201 when new page created" do
+        expect(response.status).to eq(201)
+        expect(response.headers["Content-Type"]).to eq("application/json")
+        expect(json_body).to eq({ id: new_page.id })
+      end
+      it "creates DB row with the legacy answer type converted to a new one" do
+        expect(new_page.as_json).to eq(new_page_params.merge(id: new_page[:id],
+                                                             form_id: form[:id],
+                                                             next_page: nil,
+                                                             position: 1,
+                                                             answer_type: "text",
+                                                             answer_settings: { "input_type" => new_page_params[:answer_type] },
+                                                             created_at: "2023-01-01T12:00:00.000Z",
+                                                             updated_at: "2023-01-01T12:00:00.000Z").as_json)
+      end
+    end
+
+    describe "#show" do
+      let(:form) { create :form, :with_text_page }
+      let(:page1) { form.pages.first }
+
+      let(:form_id) { form.id }
+      let(:page_id) { page1.id }
+
+      before do
+        get "/api/v1/forms/#{form_id}/pages/#{page_id}", as: :json
+      end
+
+      it "returns page, with new answer type displayed in legacy format" do
+        expect(response.status).to eq(200)
+        expect(response.headers["Content-Type"]).to eq("application/json")
+        expect(json_body[:answer_type]).to eq(page1.answer_settings["input_type"])
+        expect(json_body[:answer_settings]).to eq(nil)
+      end
+    end
+
+    describe "#update" do
+      let(:form) { create :form, :with_pages, pages_count: 2 }
+      let(:page1) { form.pages.first }
+      let(:page2) { form.pages[1] }
+
+      let(:answer_type) { "single_line" }
+      let(:answer_settings) { nil }
+      let(:params) { { question_text: "updated page title", answer_type:, answer_settings: } }
+
+      before do
+        put "/api/v1/forms/#{form.id}/pages/#{page1.id}", params:, as: :json
+      end
+
+      it "returns correct response" do
+        expect(response.status).to eq(200)
+        expect(response.headers["Content-Type"]).to eq("application/json")
+        expect(json_body).to eq({ success: true })
+        expect(page1.reload.answer_type).to eq("text")
+        expect(page1.reload.answer_settings).to eq({ "input_type" => "single_line" })
+      end
+    end
+  end
+
   describe "#index" do
     it "when no pages exist for a form, returns 200 and an empty json array" do
       form = create :form
@@ -23,7 +105,7 @@ describe Api::V1::PagesController, type: :request do
     end
   end
 
-  describe "#create" do
+  describe "#create", feature_accept_legacy_answer_types: false do
     let(:form) { create :form }
     let(:new_page_params) do
       {
@@ -86,7 +168,7 @@ describe Api::V1::PagesController, type: :request do
     end
   end
 
-  describe "#show" do
+  describe "#show", feature_accept_legacy_answer_types: false do
     let(:form) { create :form, :with_pages, pages_count: 2 }
     let(:page1) { form.pages.first }
     let(:page2) { form.pages[1] }
@@ -127,12 +209,12 @@ describe Api::V1::PagesController, type: :request do
     end
   end
 
-  describe "#update" do
+  describe "#update", feature_accept_legacy_answer_types: false do
     let(:form) { create :form, :with_pages, pages_count: 2 }
     let(:page1) { form.pages.first }
     let(:page2) { form.pages[1] }
 
-    let(:answer_type) { "single_line" }
+    let(:answer_type) { "national_insurance_number" }
     let(:answer_settings) { nil }
     let(:params) { { question_text: "updated page title", answer_type:, answer_settings: } }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "active_support/testing/time_helpers"
 require "simplecov"
 require_relative "support/features"
+require_relative "support/migration_helpers"
 
 SimpleCov.start "rails" do
   coverage_dir("coverage/backend")

--- a/spec/support/migration_helpers.rb
+++ b/spec/support/migration_helpers.rb
@@ -5,7 +5,7 @@ module MigrationHelpers
     schema_migration = ActiveRecord::SchemaMigration
 
     ActiveRecord::Migration.suppress_messages do
-      ActiveRecord::Migrator.new(:up, migrations, schema_migration, version).migrate
+      ActiveRecord::Migrator.new(:down, migrations, schema_migration, version).migrate
     end
   end
 end

--- a/spec/support/migration_helpers.rb
+++ b/spec/support/migration_helpers.rb
@@ -1,0 +1,11 @@
+module MigrationHelpers
+  def migrate_to(version)
+    migrations_paths = ActiveRecord::Migrator.migrations_paths
+    migrations = ActiveRecord::MigrationContext.new(migrations_paths).migrations
+    schema_migration = ActiveRecord::SchemaMigration
+
+    ActiveRecord::Migration.suppress_messages do
+      ActiveRecord::Migrator.new(:up, migrations, schema_migration, version).migrate
+    end
+  end
+end


### PR DESCRIPTION
#### What problem does the pull request solve?

Adds migrations for the pre-existing answer types (address, date, single line of text, multiple lines of text) that have had answer settings pages added.

Also includes some logic to allow the API to handle pages with the legacy `single_line` and `long_text` inputs in the `create`, `update` and `show` actions. This is behind a feature flag `accept_legacy_answer_types` - this will default to `true` and should be changed to `false` as soon as the `autofill_answer_types` feature flag in admin is set to `true`. We only need to add this for the text answer types - `address` and `date` are already sending `answer_settings` to the API. 

Still to do:

- [x] Consider whether to merge these into a single migration, rather than three separate ones
- [x] Add tests for the migration

Trello card: https://trello.com/c/RDzeLJqz/461-write-migrations-for-changed-autofill-fields

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
