### PR TITLE
Rename development database to be more consistent

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -23,7 +23,7 @@ default: &default
 
 development:
   <<: *default
-  database: forms_api
+  database: forms_api_development
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.


### PR DESCRIPTION
Suffix `_development` to the name of the development database to match the pattern used on other databases in this app and the forms-admin app.

#### What problem does the pull request solve?

The name of the development database is currently a little surprising.

#### Checklist

- [x] I've used the pull request template
- [ ] ~I've linked this PR to the relevant issue (if mission work)~
- [ ] ~I've written unit tests for these changes (if code change)~
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)