### PR TITLE
New /live endpoint

### DIFF
--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -40,6 +40,10 @@ class Api::V1::FormsController < ApplicationController
     render json: { success: true }.to_json, status: :ok
   end
 
+  def show_live
+    render json: form.to_json(include: [:pages]), status: :ok
+  end
+
 private
 
   def form

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,12 @@ Rails.application.routes.draw do
   # root "articles#index"
   scope "api/v1" do
     resources :forms, controller: "api/v1/forms" do
-      post "/make-live", on: :member, to: "api/v1/forms#make_live"
-      resources :pages, controller: "api/v1/pages", param: :page_id do
+      member do
+        post "/make-live", to: "api/v1/forms#make_live"
+        get "/live", to: "api/v1/forms#show_live"
       end
+
+      resources :pages, controller: "api/v1/pages", param: :page_id
       put "/pages/:page_id/down", to: "api/v1/pages#move_down"
       put "/pages/:page_id/up", to: "api/v1/pages#move_up"
     end

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -50,11 +50,8 @@ FactoryBot.define do
     end
 
     trait :live do
+      ready_for_live
       live_at { Time.zone.now }
-      support_email { Faker::Internet.email(domain: "example.gov.uk") }
-      what_happens_next_text { "We usually respond to applications within 10 working days." }
-      question_section_completed { true }
-      declaration_section_completed { true }
     end
 
     trait :with_support do

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -236,4 +236,24 @@ describe Api::V1::FormsController, type: :request do
       end
     end
   end
+
+  describe "#show_live" do
+    it "returns a form with all its pages" do
+      form = create :form, :with_pages, :live
+
+      get live_form_path(form), as: :json
+
+      expect(response.status).to eq(200)
+      expect(response.headers["Content-Type"]).to eq("application/json")
+
+      expect(json_body[:pages].pluck(:question_text)).to match form.pages.select(:question_text).pluck(:question_text)
+    end
+
+    it "returns 404 if live form doesn't exist" do
+      get live_form_path(1), as: :json
+
+      expect(response.status).to eq(404)
+      expect(response.headers["Content-Type"]).to eq("application/json")
+    end
+  end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?

This new endpoint will have all the information a client would need to produce the specific form
i.e Form info and all pages included in the JSON response. 
This helps where our services are making two calls for every web page request. one to get
the form and another to get all the pages for that form.

For the time being, this will use existing Form records but once we have draft/live versions implemented
this would return whatever version is live for the existing form.

New endpoint is `api/v1/forms/:form_id/live` 

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
