### PR TITLE
Add sorting to list of forms by organisation

### DIFF
--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::FormsController < ApplicationController
 
   def index
     org = params.require(:org)
-    render json: Form.where(org:).to_json
+    render json: Form.where(org:).order(:name).to_json
   end
 
   def create

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -6,9 +6,15 @@ headers = {
 
 describe Api::V1::FormsController, type: :request do
   let(:json_body) { JSON.parse(response.body, symbolize_names: true) }
+  let(:gds_forms) do
+    [
+      create(:form, name: "Fill me in", org: "gds"),
+      create(:form, name: "Can you answer my questions?", org: "gds"),
+    ]
+  end
 
   before do
-    create_list :form, 2, org: "gds"
+    gds_forms
     create :form, org: "not-gds"
   end
 
@@ -56,6 +62,15 @@ describe Api::V1::FormsController, type: :request do
           :declaration_section_completed,
           :page_order,
         )
+      end
+    end
+
+    describe "ordering of forms" do
+      it "returns a list of forms sorted in alphabetical order" do
+        get forms_path, params: { org: "gds" }, headers: headers
+        expect(response.status).to eq(200)
+        expect(response.headers["Content-Type"]).to eq("application/json")
+        expect(json_body.pluck(:name)).to eq(gds_forms.sort_by(&:name).pluck(:name))
       end
     end
   end


### PR DESCRIPTION
#### What problem does the pull request solve?

Currently this sorting is done on the forms-admin. This is not great especially when we come to adding pagination to this list of forms it could cause a problem and its better for the
api to serve data is a consistent order.

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
