### PR TITLE
Creating made_live_forms

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -2,7 +2,7 @@ class Form < ApplicationRecord
   has_paper_trail
 
   has_many :pages, -> { order(position: :asc) }, dependent: :destroy
-  has_many :made_live_forms
+  has_many :made_live_forms, dependent: :restrict_with_exception
 
   validates :org, :name, presence: true
   def start_page

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -11,10 +11,14 @@ class Form < ApplicationRecord
 
   def make_live!
     update!(live_at: Time.zone.now)
+
+    made_live_forms.create!(json_form_blob: to_json(include: [:pages])) if FeatureService.enabled?(:draft_live_versioning)
   end
 
   def live_version
-    snapshot
+    return snapshot unless FeatureService.enabled?(:draft_live_versioning)
+
+    made_live_forms.last.json_form_blob
   end
 
   def snapshot

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -2,6 +2,7 @@ class Form < ApplicationRecord
   has_paper_trail
 
   has_many :pages, -> { order(position: :asc) }, dependent: :destroy
+  has_many :made_live_forms
 
   validates :org, :name, presence: true
   def start_page

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -12,17 +12,11 @@ class Form < ApplicationRecord
   def make_live!
     update!(live_at: Time.zone.now)
 
-    made_live_forms.create!(json_form_blob: to_json(include: [:pages])) if FeatureService.enabled?(:draft_live_versioning)
+    made_live_forms.create!(json_form_blob: to_json(include: [:pages]))
   end
 
   def live_version
-    return snapshot unless FeatureService.enabled?(:draft_live_versioning)
-
     made_live_forms.last.json_form_blob
-  end
-
-  def snapshot
-    to_json(include: [:pages])
   end
 
   def name=(val)

--- a/app/models/made_live_form.rb
+++ b/app/models/made_live_form.rb
@@ -1,0 +1,3 @@
+class MadeLiveForm < ApplicationRecord
+  belongs_to :form
+end

--- a/db/migrate/20230302161521_create_made_live_forms.rb
+++ b/db/migrate/20230302161521_create_made_live_forms.rb
@@ -1,0 +1,10 @@
+class CreateMadeLiveForms < ActiveRecord::Migration[7.0]
+  def change
+    create_table :made_live_forms do |t|
+      t.references :form, index: true, foreign_key: true
+      t.json :json_form_blob
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230303132811_add_initial_made_live_forms.rb
+++ b/db/migrate/20230303132811_add_initial_made_live_forms.rb
@@ -1,0 +1,21 @@
+class AddInitialMadeLiveForms < ActiveRecord::Migration[7.0]
+  def up
+    Form.where.not(live_at: nil).find_each do |form|
+      # Form creators may have made changes to their form after making it live.
+      # In future changes will need to be made live separately, and the live
+      # version of a form will always have updated_at equal to live_at.
+      # To avoid any forwards compatibility issues, let's enforce that now.
+      live_at = form.updated_at
+      form.live_at = live_at
+
+      made_live_form = form.to_json(include: [:pages])
+      form.restore_attributes # don't save change to original form object
+
+      form.made_live_forms.create!(json_form_blob: made_live_form, created_at: live_at)
+    end
+  end
+
+  def down
+    MadeLiveForm.delete_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_02_161521) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_03_132811) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_27_143428) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_02_161521) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,6 +32,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_27_143428) do
     t.integer "page_order", array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "made_live_forms", force: :cascade do |t|
+    t.bigint "form_id"
+    t.json "json_form_blob"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["form_id"], name: "index_made_live_forms_on_form_id"
   end
 
   create_table "pages", force: :cascade do |t|
@@ -59,5 +67,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_27_143428) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  add_foreign_key "made_live_forms", "forms"
   add_foreign_key "pages", "forms"
 end

--- a/spec/factories/made_live_forms.rb
+++ b/spec/factories/made_live_forms.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :made_live_form do
+    form { create :form, :with_pages, :live }
+    json_form_blob { form.to_json(include: [:pages]) }
+  end
+end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -79,41 +79,20 @@ RSpec.describe Form, type: :model do
       end
     end
 
-    context "when draft/live feature disabled", feature_draft_live_versioning: false do
-      it "sets a forms live_at to make the form live" do
-        expect(form_to_be_made_live.live_at).to eq(time_now)
-      end
-
-      it "does not create a made live version" do
-        expect(form_to_be_made_live.made_live_forms).to be_empty
-      end
+    it "sets a forms live_at to make the form live" do
+      expect(form_to_be_made_live.live_at).to eq(time_now)
     end
 
-    context "when draft/live feature enabled", feature_draft_live_versioning: true do
-      it "sets a forms live_at to make the form live" do
-        expect(form_to_be_made_live.live_at).to eq(time_now)
-      end
-
-      it "does create a made live version" do
-        expect(form_to_be_made_live.made_live_forms.last.json_form_blob).to eq form_to_be_made_live.to_json(include: [:pages])
-      end
+    it "does create a made live version" do
+      expect(form_to_be_made_live.made_live_forms.last.json_form_blob).to eq form_to_be_made_live.to_json(include: [:pages])
     end
   end
 
   describe "#live_version" do
-    let(:form) { create :form, :with_pages }
+    let(:made_live_form) { create :made_live_form }
 
     it "returns json version of the LIVE form and includes pages" do
-      expect(form.live_version).to eq(form.to_json(include: [:pages]))
-    end
-
-    context "when draft/live feature enabled", feature_draft_live_versioning: true do
-      it "returns json version of the LIVE form" do
-        made_live_form = create :made_live_form
-        made_live_form.form.update!(name: "Updated form")
-
-        expect(made_live_form.form.live_version).to eq(made_live_form.json_form_blob)
-      end
+      expect(made_live_form.form.live_version).to eq(made_live_form.form.to_json(include: [:pages]))
     end
   end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -14,6 +14,15 @@ RSpec.describe Form, type: :model do
     end
   end
 
+  describe "made_live_form" do
+    let(:made_live_form) { create :made_live_form }
+    let(:form) { made_live_form.form }
+
+    it "does not allow form creators to delete a live form" do
+      expect { form.destroy! }.to raise_error(ActiveRecord::DeleteRestrictionError)
+    end
+  end
+
   describe "validations" do
     it "validates" do
       form.name = "test"

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -69,19 +69,51 @@ RSpec.describe Form, type: :model do
   end
 
   describe "#make_live!" do
-    it "sets a forms live_at to make the form live" do
+    let(:form_to_be_made_live) { build :form }
+    let(:time_now) { Time.zone.now }
+
+    before do
       freeze_time do
-        form_to_be_made_live = build :form
+        time_now
         form_to_be_made_live.make_live!
-        expect(form_to_be_made_live.live_at).to eq(Time.zone.now)
+      end
+    end
+
+    context "when draft/live feature disabled", feature_draft_live_versioning: false do
+      it "sets a forms live_at to make the form live" do
+        expect(form_to_be_made_live.live_at).to eq(time_now)
+      end
+
+      it "does not create a made live version" do
+        expect(form_to_be_made_live.made_live_forms).to be_empty
+      end
+    end
+
+    context "when draft/live feature enabled", feature_draft_live_versioning: true do
+      it "sets a forms live_at to make the form live" do
+        expect(form_to_be_made_live.live_at).to eq(time_now)
+      end
+
+      it "does create a made live version" do
+        expect(form_to_be_made_live.made_live_forms.last.json_form_blob).to eq form_to_be_made_live.to_json(include: [:pages])
       end
     end
   end
 
   describe "#live_version" do
+    let(:form) { create :form, :with_pages }
+
     it "returns json version of the LIVE form and includes pages" do
-      form = create :form, :with_pages
       expect(form.live_version).to eq(form.to_json(include: [:pages]))
+    end
+
+    context "when draft/live feature enabled", feature_draft_live_versioning: true do
+      it "returns json version of the LIVE form" do
+        made_live_form = create :made_live_form
+        made_live_form.form.update!(name: "Updated form")
+
+        expect(made_live_form.form.live_version).to eq(made_live_form.json_form_blob)
+      end
     end
   end
 end

--- a/spec/models/made_live_form_spec.rb
+++ b/spec/models/made_live_form_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe MadeLiveForm, type: :model do
+  let(:made_live_form) { create :made_live_form }
+
+  it "has a valid factory" do
+    expect(made_live_form).to be_valid
+  end
+
+  it "contains a version of a form with its pages" do
+    expect(made_live_form.json_form_blob).to eq made_live_form.form.to_json(include: [:pages])
+  end
+end

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -250,18 +250,7 @@ describe Api::V1::FormsController, type: :request do
   end
 
   describe "#show_live" do
-    it "returns a form with all its pages" do
-      form = create :form, :with_pages, :live
-
-      get live_form_path(form), as: :json
-
-      expect(response.status).to eq(200)
-      expect(response.headers["Content-Type"]).to eq("application/json")
-
-      expect(json_body[:pages].pluck(:question_text)).to match form.pages.select(:question_text).pluck(:question_text)
-    end
-
-    it "does not return the actual made live version" do
+    it "returns the actual made live version which includes pages" do
       made_live_form = create :made_live_form
       made_live_form.form.update!(name: "Updated form")
 
@@ -270,22 +259,7 @@ describe Api::V1::FormsController, type: :request do
       expect(response.status).to eq(200)
       expect(response.headers["Content-Type"]).to eq("application/json")
 
-      expect(json_body.to_json).not_to eq made_live_form.json_form_blob
-      expect(json_body.to_json).to eq made_live_form.form.to_json(include: [:pages])
-    end
-
-    context "when draft/live feature flag is enabled", feature_draft_live_versioning: true do
-      it "returns the actual made live version" do
-        made_live_form = create :made_live_form
-        made_live_form.form.update!(name: "Updated form")
-
-        get live_form_path(made_live_form.form), as: :json
-
-        expect(response.status).to eq(200)
-        expect(response.headers["Content-Type"]).to eq("application/json")
-
-        expect(json_body.to_json).to eq made_live_form.json_form_blob
-      end
+      expect(json_body.to_json).to eq made_live_form.json_form_blob
     end
 
     it "returns 404 if live form doesn't exist" do

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -261,6 +261,33 @@ describe Api::V1::FormsController, type: :request do
       expect(json_body[:pages].pluck(:question_text)).to match form.pages.select(:question_text).pluck(:question_text)
     end
 
+    it "does not return the actual made live version" do
+      made_live_form = create :made_live_form
+      made_live_form.form.update!(name: "Updated form")
+
+      get live_form_path(made_live_form.form), as: :json
+
+      expect(response.status).to eq(200)
+      expect(response.headers["Content-Type"]).to eq("application/json")
+
+      expect(json_body.to_json).not_to eq made_live_form.json_form_blob
+      expect(json_body.to_json).to eq made_live_form.form.to_json(include: [:pages])
+    end
+
+    context "when draft/live feature flag is enabled", feature_draft_live_versioning: true do
+      it "returns the actual made live version" do
+        made_live_form = create :made_live_form
+        made_live_form.form.update!(name: "Updated form")
+
+        get live_form_path(made_live_form.form), as: :json
+
+        expect(response.status).to eq(200)
+        expect(response.headers["Content-Type"]).to eq("application/json")
+
+        expect(json_body.to_json).to eq made_live_form.json_form_blob
+      end
+    end
+
     it "returns 404 if live form doesn't exist" do
       get live_form_path(1), as: :json
 


### PR DESCRIPTION
#### What problem does the pull request solve?

Creates a new published form table to store a version of forms and pages as a single JSON blob.

Tweaks how make_live and live endpoints work to use the stored live version JSON blobs.

Trello card: https://trello.com/c/7T5Yp818/426-implement-draft-live-versioning-in-backend

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
