### PR TITLE
Add auditing to our models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,9 @@ gem "rails", "~> 7.0.4"
 
 gem "config"
 
+# Auditing model changes and logging versions
+gem "paper_trail"
+
 # Use postgresql as the database for Active Record
 gem "pg", "~> 1.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,9 @@ GEM
       racc (~> 1.4)
     nokogiri (1.14.1-x86_64-linux)
       racc (~> 1.4)
+    paper_trail (14.0.0)
+      activerecord (>= 6.0)
+      request_store (~> 1.4)
     parallel (1.22.1)
     parser (3.1.3.0)
       ast (~> 2.4.1)
@@ -297,6 +300,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   lograge
+  paper_trail
   pg (~> 1.4)
   puma (~> 6.1)
   rails (~> 7.0.4)

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,4 +1,6 @@
 class Form < ApplicationRecord
+  has_paper_trail
+
   has_many :pages, -> { order(position: :asc) }, dependent: :destroy
 
   validates :org, :name, presence: true

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,4 +1,6 @@
 class Page < ApplicationRecord
+  has_paper_trail
+
   belongs_to :form
   acts_as_list scope: :form
 

--- a/db/migrate/20230227143427_create_versions.rb
+++ b/db/migrate/20230227143427_create_versions.rb
@@ -1,0 +1,31 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :versions do |t|
+      t.string   :item_type, null: false
+      t.bigint   :item_id,   null: false
+      t.string   :event,     null: false
+      t.string   :whodunnit
+      t.jsonb :object
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      # MySQL users should use the following line for `created_at`
+      # t.datetime :created_at, limit: 6
+      t.datetime :created_at
+    end
+    add_index :versions, %i[item_type item_id]
+  end
+end

--- a/db/migrate/20230227143428_add_object_changes_to_versions.rb
+++ b/db/migrate/20230227143428_add_object_changes_to_versions.rb
@@ -1,0 +1,8 @@
+# This migration adds the optional `object_changes` column, in which PaperTrail
+# will store the `changes` diff for each update event. See the readme for
+# details.
+class AddObjectChangesToVersions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :versions, :object_changes, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_06_115617) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_27_143428) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -46,6 +46,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_06_115617) do
     t.bigint "form_id"
     t.integer "position"
     t.index ["form_id"], name: "index_pages_on_form_id"
+  end
+
+  create_table "versions", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.jsonb "object"
+    t.datetime "created_at"
+    t.jsonb "object_changes"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
   add_foreign_key "pages", "forms"

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe Form, type: :model do
     expect(form).to be_valid
   end
 
+  describe "versioning", versioning: true do
+    it "enables paper trail" do
+      expect(form).to be_versioned
+    end
+  end
+
   describe "validations" do
     it "validates" do
       form.name = "test"

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe Page, type: :model do
     expect(page).to be_valid
   end
 
+  describe "versioning", versioning: true do
+    it "enables paper trail" do
+      expect(page).to be_versioned
+    end
+  end
+
   describe "validations" do
     it "validates" do
       form = create :form

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
+require "paper_trail/frameworks/rspec"
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
#### What problem does the pull request solve?

This is the outcome of https://github.com/alphagov/forms-api/pull/174 where we were initially thinking of using papertrail to snapshot draft/live versions but we ran into issues with associations records and when attempting to delete them.  We decided now to just use Papertrail for auditing purposes and for single record backup/restoration.

- Adds PaperTrail gem
- configures Form/Page to be versioned

This data isn't being surfaced to users at the moment but we can still use this for support queries and eventually it will be surfaced to users when we get to versioning. 


Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
