### PR TITLE
Allow live forms to be deleted

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -2,7 +2,7 @@ class Form < ApplicationRecord
   has_paper_trail
 
   has_many :pages, -> { order(position: :asc) }, dependent: :destroy
-  has_many :made_live_forms, dependent: :restrict_with_exception
+  has_many :made_live_forms, dependent: :destroy
 
   validates :org, :name, presence: true
   def start_page

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Form, type: :model do
     let(:made_live_form) { create :made_live_form }
     let(:form) { made_live_form.form }
 
-    it "does not allow form creators to delete a live form" do
-      expect { form.destroy! }.to raise_error(ActiveRecord::DeleteRestrictionError)
+    it "does delete a live form" do
+      expect { form.destroy }.to change { MadeLiveForm.exists?(made_live_form.id) }.to(false)
     end
   end
 


### PR DESCRIPTION
#### What problem does the pull request solve?

This is a temporary fix for the time being. We have a ticket to look at deleting forms in general and we will need to think how we delete forms in general. Also from an e2e POV, we go through the whole process of creating a form, making it live, filling it in and then after a form submission we try to delete the live form. Without this temporary fix our e2e tests will continue to fail when trying to delete the live form.

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
