### PR TITLE
return draft version of form if form hasn't been made live

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -16,7 +16,13 @@ class Form < ApplicationRecord
   end
 
   def live_version
+    return draft_version if made_live_forms.blank?
+
     made_live_forms.last.json_form_blob
+  end
+
+  def draft_version
+    to_json(include: [:pages])
   end
 
   def name=(val)

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -103,5 +103,13 @@ RSpec.describe Form, type: :model do
     it "returns json version of the LIVE form and includes pages" do
       expect(made_live_form.form.live_version).to eq(made_live_form.form.to_json(include: [:pages]))
     end
+
+    context "when a form has never been made live before" do
+      let(:form) { create :form, :ready_for_live }
+
+      it "returns the draft version of the form" do
+        expect(form.live_version).to eq(form.to_json(include: [:pages]))
+      end
+    end
   end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?

This is a temporary fix until we update the runner to detect whether the user is expecting a live form,
a preview of a live form or previewing of a draft form.

Trello card: https://trello.com/c/XWWK67qQ/595-bug-draft-forms-cannot-be-previewed

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
