### PR TITLE
Add support for multiple authentication keys

### DIFF
--- a/app/controllers/api/v1/access_tokens_controller.rb
+++ b/app/controllers/api/v1/access_tokens_controller.rb
@@ -1,4 +1,9 @@
 class Api::V1::AccessTokensController < ApplicationController
+  def index
+    @access_tokens = AccessToken.all
+    render json: @access_tokens.as_json(except: [:token]).to_json, status: :ok
+  end
+
   def create
     @access_token = AccessToken.new(token_params)
     if @access_token.save

--- a/app/controllers/api/v1/access_tokens_controller.rb
+++ b/app/controllers/api/v1/access_tokens_controller.rb
@@ -1,0 +1,16 @@
+class Api::V1::AccessTokensController < ApplicationController
+  def create
+    @access_token = AccessToken.new(token_params)
+    if @access_token.save
+      render json: { token: @access_token.users_token }.to_json, status: :created
+    else
+      render json: @access_token.errors.to_json, status: :bad_request
+    end
+  end
+
+private
+
+  def token_params
+    params.permit(:owner)
+  end
+end

--- a/app/controllers/api/v1/access_tokens_controller.rb
+++ b/app/controllers/api/v1/access_tokens_controller.rb
@@ -6,8 +6,9 @@ class Api::V1::AccessTokensController < ApplicationController
 
   def create
     @access_token = AccessToken.new(token_params)
+    users_token = @access_token.generate_token
     if @access_token.save
-      render json: { token: @access_token.users_token }.to_json, status: :created
+      render json: { token: users_token }.to_json, status: :created
     else
       render json: @access_token.errors.to_json, status: :bad_request
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::API
   end
 
   def authenticate_request
-    return nil if Settings.forms_api.authentication_key.blank?
+    return nil unless Settings.forms_api.enabled_auth
 
     unless authenticate_using_old_env_vars || authenticate_using_access_tokens
       render json: { status: "unauthorised" }, status: :unauthorized

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,9 +31,20 @@ private
   end
 
   def authenticate_using_access_tokens
-    authenticate_with_http_token do |token|
+    if request.headers["X-Api-Token"].present?
+      token = request.headers["X-Api-Token"]
       @user = AccessToken.active.find_by_token(Digest::SHA256.hexdigest(token))
-      @user.update!(last_accessed_at: Time.zone.now) if @user.present?
+      if @user.present?
+        @user.update!(last_accessed_at: Time.zone.now)
+        true
+      else
+        false
+      end
+    else
+      authenticate_with_http_token do |token|
+        @user = AccessToken.active.find_by_token(Digest::SHA256.hexdigest(token))
+        @user.update!(last_accessed_at: Time.zone.now) if @user.present?
+      end
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,12 +25,15 @@ class ApplicationController < ActionController::API
 private
 
   def authenticate_using_old_env_vars
+    return false if request.headers["X-Api-Token"].blank? || Settings.forms_api.authentication_key.blank?
+
     request.headers["X-Api-Token"] == Settings.forms_api.authentication_key
   end
 
   def authenticate_using_access_tokens
     authenticate_with_http_token do |token|
       @user = AccessToken.active.find_by_token(Digest::SHA256.hexdigest(token))
+      @user.update!(last_accessed_at: Time.zone.now) if @user.present?
     end
   end
 end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,0 +1,2 @@
+class AccessToken < ApplicationRecord
+end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -14,6 +14,6 @@ private
   end
 
   def set_token
-    self.token = Digest::SHA2.new(256).hexdigest(users_token)
+    self.token = Digest::SHA256.hexdigest(users_token)
   end
 end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,2 +1,3 @@
 class AccessToken < ApplicationRecord
+  validates :token, :owner, presence: true
 end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,5 +1,19 @@
 class AccessToken < ApplicationRecord
   validates :token, :owner, presence: true
 
+  attr_accessor :users_token
+
   scope :active, -> { where(deactivated_at: nil) }
+
+  before_validation :generate_users_token, :set_token
+
+private
+
+  def generate_users_token
+    self.users_token = SecureRandom.uuid if users_token.blank?
+  end
+
+  def set_token
+    self.token = Digest::SHA2.new(256).hexdigest(users_token)
+  end
 end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,19 +1,11 @@
 class AccessToken < ApplicationRecord
   validates :token, :owner, presence: true
 
-  attr_accessor :users_token
-
   scope :active, -> { where(deactivated_at: nil) }
 
-  before_validation :generate_users_token, :set_token
-
-private
-
-  def generate_users_token
-    self.users_token = SecureRandom.uuid if users_token.blank?
-  end
-
-  def set_token
+  def generate_token
+    users_token = SecureRandom.uuid
     self.token = Digest::SHA256.hexdigest(users_token)
+    users_token
   end
 end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,3 +1,5 @@
 class AccessToken < ApplicationRecord
   validates :token, :owner, presence: true
+
+  scope :active, -> { where(deactivated_at: nil) }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,5 +16,7 @@ Rails.application.routes.draw do
       put "/pages/:page_id/down", to: "api/v1/pages#move_down"
       put "/pages/:page_id/up", to: "api/v1/pages#move_up"
     end
+
+    resources :access_tokens, path: "access-tokens", controller: "api/v1/access_tokens", only: %i[index create]
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,7 @@
 forms_api:
-  # Empty key bypasses authentication process all together (mostly used by tests so we dont need to authenticate
-  # every request spec
-  authentication_key: changeme
+  enabled_auth: true
+  authentication_key:
+
 
 # Configuration for Sentry
 # Sentry will only initialise if dsn is set to some other value

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,4 +1,3 @@
 forms_api:
-  # Empty key bypasses authentication process all together (mostly used by tests so we dont need to authenticate
-  # every request spec
+  enabled_auth: false
   authentication_key:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,4 +1,3 @@
 forms_api:
-  # Empty key bypasses authentication process all together (mostly used by tests so we dont need to authenticate
-  # every request spec
+  enabled_auth: false
   authentication_key:

--- a/db/migrate/20230309213951_create_access_tokens.rb
+++ b/db/migrate/20230309213951_create_access_tokens.rb
@@ -1,0 +1,10 @@
+class CreateAccessTokens < ActiveRecord::Migration[7.0]
+  def change
+    create_table :access_tokens do |t|
+      t.string :token
+      t.string :owner
+      t.datetime :deactivated_at
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230315130919_add_last_accessed_at_to_access_tokens.rb
+++ b/db/migrate/20230315130919_add_last_accessed_at_to_access_tokens.rb
@@ -1,0 +1,5 @@
+class AddLastAccessedAtToAccessTokens < ActiveRecord::Migration[7.0]
+  def change
+    add_column :access_tokens, :last_accessed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_09_213951) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_15_130919) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,6 +20,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_09_213951) do
     t.datetime "deactivated_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "last_accessed_at"
   end
 
   create_table "forms", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_03_132811) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_09_213951) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "access_tokens", force: :cascade do |t|
+    t.string "token"
+    t.string "owner"
+    t.datetime "deactivated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "forms", force: :cascade do |t|
     t.text "name"

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -21,7 +21,8 @@ describe "Settings" do
   describe "forms api settings" do
     forms_api = settings[:forms_api]
 
-    include_examples expected_value_test, :authentication_key, forms_api, "changeme"
+    include_examples expected_value_test, :enabled_auth, forms_api, true
+    include_examples expected_value_test, :authentication_key, forms_api, nil
   end
 
   describe "sentry" do

--- a/spec/factories/access_tokens.rb
+++ b/spec/factories/access_tokens.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     token { Faker::Crypto.sha256 }
     owner { Faker::Name.first_name.underscore }
     deactivated_at { nil }
+    last_accessed_at { nil }
   end
 end

--- a/spec/factories/access_tokens.rb
+++ b/spec/factories/access_tokens.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :access_token do
+    token { Faker::Crypto.sha256 }
+    owner { Faker::Name.first_name.underscore }
+    deactivated_at { nil }
+  end
+end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -19,4 +19,24 @@ RSpec.describe AccessToken, type: :model do
       expect(access_token.errors[:owner]).to include("can't be blank")
     end
   end
+
+  describe "scopes" do
+    describe "#active" do
+      let(:active_tokens) { create_list :access_token, 3 }
+      let(:deactivated_tokens) { create_list :access_token, 3, deactivated_at: Time.zone.now }
+
+      before do
+        active_tokens
+        deactivated_tokens
+      end
+
+      it "returns active tokens" do
+        expect(described_class.active).to eq(active_tokens)
+      end
+
+      it "does not return deactivated tokens" do
+        expect(described_class.active).not_to eq(deactivated_tokens)
+      end
+    end
+  end
 end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -14,14 +14,6 @@ RSpec.describe AccessToken, type: :model do
     expect(results).to be_valid
   end
 
-  it "generates a user token before validation" do
-    expect(new_access_token.users_token).to eq("testing-123")
-  end
-
-  it "generates a sha-256 token before validation" do
-    expect(new_access_token.token).to eq("8d9754db9759ab1785644440dbf19f88ab45ae326e421da6c1cb6e45140d534f")
-  end
-
   describe "validations" do
     it "requires an owner" do
       expect(access_token).to be_invalid
@@ -46,6 +38,19 @@ RSpec.describe AccessToken, type: :model do
       it "does not include deactivated tokens" do
         expect(described_class.active).not_to eq(deactivated_tokens)
       end
+    end
+  end
+
+  describe "#generate_token" do
+    let(:result) { access_token.generate_token }
+
+    it "generates a user token before validation" do
+      expect(result).to eq("testing-123")
+    end
+
+    it "generates a sha-256 token before validation" do
+      result
+      expect(access_token.token).to eq("8d9754db9759ab1785644440dbf19f88ab45ae326e421da6c1cb6e45140d534f")
     end
   end
 end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -7,4 +7,16 @@ RSpec.describe AccessToken, type: :model do
     access_token = create :access_token
     expect(access_token).to be_valid
   end
+
+  describe "validations" do
+    it "requires a token" do
+      expect(access_token).to be_invalid
+      expect(access_token.errors[:token]).to include("can't be blank")
+    end
+
+    it "requires an owner" do
+      expect(access_token).to be_invalid
+      expect(access_token.errors[:owner]).to include("can't be blank")
+    end
+  end
 end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe AccessToken, type: :model do
+  subject(:access_token) { described_class.new }
+
+  it "has a valid factory" do
+    access_token = create :access_token
+    expect(access_token).to be_valid
+  end
+end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -3,17 +3,26 @@ require "rails_helper"
 RSpec.describe AccessToken, type: :model do
   subject(:access_token) { described_class.new }
 
+  let(:new_access_token) { described_class.create!(owner: "joe_bloggs") }
+
+  before do
+    allow(SecureRandom).to receive(:uuid).and_return("testing-123")
+  end
+
   it "has a valid factory" do
-    access_token = create :access_token
-    expect(access_token).to be_valid
+    results = create :access_token
+    expect(results).to be_valid
+  end
+
+  it "generates a user token before validation" do
+    expect(new_access_token.users_token).to eq("testing-123")
+  end
+
+  it "generates a sha-256 token before validation" do
+    expect(new_access_token.token).to eq("8d9754db9759ab1785644440dbf19f88ab45ae326e421da6c1cb6e45140d534f")
   end
 
   describe "validations" do
-    it "requires a token" do
-      expect(access_token).to be_invalid
-      expect(access_token.errors[:token]).to include("can't be blank")
-    end
-
     it "requires an owner" do
       expect(access_token).to be_invalid
       expect(access_token.errors[:owner]).to include("can't be blank")
@@ -34,7 +43,7 @@ RSpec.describe AccessToken, type: :model do
         expect(described_class.active).to eq(active_tokens)
       end
 
-      it "does not return deactivated tokens" do
+      it "does not include deactivated tokens" do
         expect(described_class.active).not_to eq(deactivated_tokens)
       end
     end

--- a/spec/request/api/v1/access_tokens_controller_spec.rb
+++ b/spec/request/api/v1/access_tokens_controller_spec.rb
@@ -25,7 +25,7 @@ describe Api::V1::AccessTokensController, type: :request do
 
   describe "#create" do
     before do
-      allow(AccessToken).to receive(:new).and_return(OpenStruct.new(save: true, users_token: "test-token"))
+      allow(AccessToken).to receive(:new).and_return(OpenStruct.new(save: true, generate_token: "test-token"))
       post access_tokens_path, params: { owner: "testing user" }, as: :json
     end
 

--- a/spec/request/api/v1/access_tokens_controller_spec.rb
+++ b/spec/request/api/v1/access_tokens_controller_spec.rb
@@ -17,6 +17,7 @@ describe Api::V1::AccessTokensController, type: :request do
           :deactivated_at,
           :created_at,
           :updated_at,
+          :last_accessed_at,
         )
       end
     end

--- a/spec/request/api/v1/access_tokens_controller_spec.rb
+++ b/spec/request/api/v1/access_tokens_controller_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+describe Api::V1::AccessTokensController, type: :request do
+  let(:json_body) { JSON.parse(response.body, symbolize_names: true) }
+
+  describe "#create" do
+    before do
+      allow(AccessToken).to receive(:new).and_return(OpenStruct.new(save: true, users_token: "test-token"))
+      post access_tokens_path, params: { owner: "testing user" }, as: :json
+    end
+
+    it "returns a user token" do
+      expect(response.body).to eq({ token: "test-token" }.to_json)
+    end
+
+    it "returns 201 if its saved" do
+      expect(response.status).to eq(201)
+    end
+
+    it "returns json" do
+      expect(response.headers["Content-Type"]).to eq("application/json")
+    end
+  end
+end

--- a/spec/request/api/v1/access_tokens_controller_spec.rb
+++ b/spec/request/api/v1/access_tokens_controller_spec.rb
@@ -3,6 +3,25 @@ require "rails_helper"
 describe Api::V1::AccessTokensController, type: :request do
   let(:json_body) { JSON.parse(response.body, symbolize_names: true) }
 
+  describe "#index" do
+    let(:list_of_access_tokens) { create_list :access_token, 3 }
+
+    it "returns a list of access tokens (excluding the token" do
+      list_of_access_tokens
+      get access_tokens_path
+
+      json_body.each do |token|
+        expect(token.keys).to contain_exactly(
+          :id,
+          :owner,
+          :deactivated_at,
+          :created_at,
+          :updated_at,
+        )
+      end
+    end
+  end
+
   describe "#create" do
     before do
       allow(AccessToken).to receive(:new).and_return(OpenStruct.new(save: true, users_token: "test-token"))

--- a/spec/request/application_controller_spec.rb
+++ b/spec/request/application_controller_spec.rb
@@ -11,8 +11,20 @@ describe ApplicationController, type: :request do
       }
     end
 
+    context "when authentication is turned off" do
+      before do
+        Settings.forms_api.enabled_auth = false
+      end
+
+      it "returns 200" do
+        get forms_path, params: { org: "gds" }, headers: req_headers
+        expect(response.status).to eq(200)
+      end
+    end
+
     context "when valid header and token passed" do
       it "returns 200" do
+        Settings.forms_api.enabled_auth = true
         Settings.forms_api.authentication_key = 123_456
         get forms_path, params: { org: "gds" }, headers: req_headers
         expect(response.status).to eq(200)
@@ -27,6 +39,8 @@ describe ApplicationController, type: :request do
       end
 
       it "returns 401" do
+        Settings.forms_api.enabled_auth = true
+        Settings.forms_api.authentication_key = 123_456
         get forms_path, params: { org: "gds" }, headers: req_headers
         expect(response.status).to eq(401)
       end
@@ -53,6 +67,7 @@ describe ApplicationController, type: :request do
       let(:token) { access_token.users_token }
 
       before do
+        Settings.forms_api.enabled_auth = true
         Settings.forms_api.authentication_key = 1234
       end
 

--- a/spec/request/application_controller_spec.rb
+++ b/spec/request/application_controller_spec.rb
@@ -65,16 +65,24 @@ describe ApplicationController, type: :request do
       end
       let(:access_token) { AccessToken.create!(owner: "test-owner") }
       let(:token) { access_token.users_token }
+      let(:time_now) { Time.zone.now }
 
       before do
         Settings.forms_api.enabled_auth = true
         Settings.forms_api.authentication_key = 1234
+        token
+        freeze_time do
+          time_now
+          get forms_path, params: { org: "gds" }, headers: req_headers
+        end
       end
 
       it "returns 200" do
-        token
-        get forms_path, params: { org: "gds" }, headers: req_headers
         expect(response.status).to eq(200)
+      end
+
+      it "updates the tokens 'last_accessed_at' attribute" do
+        expect(access_token.reload.last_accessed_at).to eq time_now
       end
 
       context "when token has been deactivated" do

--- a/spec/request/application_controller_spec.rb
+++ b/spec/request/application_controller_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe ApplicationController, type: :request do
   describe "#authentication" do
     let(:token) { Settings.forms_api.authentication_key }
+    let(:json_body) { JSON.parse(response.body, symbolize_names: true) }
     let(:req_headers) do
       {
         "X-API-Token" => token,
@@ -38,6 +39,44 @@ describe ApplicationController, type: :request do
         Settings.forms_api.authentication_key = 123_456
         get forms_path, params: { org: "gds" }, headers: req_headers
         expect(response.status).to eq(401)
+      end
+    end
+
+    context "when passing in an authorization token" do
+      let(:req_headers) do
+        {
+          "Authorization" => "Token #{token}",
+          "Accept" => "application/json",
+        }
+      end
+      let(:access_token) { AccessToken.create!(owner: "test-owner") }
+      let(:token) { access_token.users_token }
+
+      before do
+        Settings.forms_api.authentication_key = 1234
+      end
+
+      it "returns 200" do
+        token
+        get forms_path, params: { org: "gds" }, headers: req_headers
+        expect(response.status).to eq(200)
+      end
+
+      context "when token has been deactivated" do
+        let(:access_token) { AccessToken.create!(owner: "test-owner", deactivated_at: Time.zone.now) }
+
+        before do
+          token
+          get forms_path, params: { org: "gds" }, headers: req_headers
+        end
+
+        it "returns 401" do
+          expect(response.status).to eq(401)
+        end
+
+        it "returns an error message" do
+          expect(json_body[:status]).to eq("unauthorised")
+        end
       end
     end
   end

--- a/spec/request/application_controller_spec.rb
+++ b/spec/request/application_controller_spec.rb
@@ -63,14 +63,16 @@ describe ApplicationController, type: :request do
           "Accept" => "application/json",
         }
       end
-      let(:access_token) { AccessToken.create!(owner: "test-owner") }
-      let(:token) { access_token.users_token }
+      let(:access_token) { AccessToken.new(owner: "test-owner") }
+      let(:token) { access_token.generate_token }
       let(:time_now) { Time.zone.now }
 
       before do
         Settings.forms_api.enabled_auth = true
         Settings.forms_api.authentication_key = 1234
+        access_token
         token
+        access_token.save!
         freeze_time do
           time_now
           get forms_path, params: { org: "gds" }, headers: req_headers
@@ -86,10 +88,12 @@ describe ApplicationController, type: :request do
       end
 
       context "when token has been deactivated" do
-        let(:access_token) { AccessToken.create!(owner: "test-owner", deactivated_at: Time.zone.now) }
+        let(:access_token) { AccessToken.new(owner: "test-owner", deactivated_at: Time.zone.now) }
 
         before do
+          access_token
           token
+          access_token.save!
           get forms_path, params: { org: "gds" }, headers: req_headers
         end
 
@@ -110,14 +114,16 @@ describe ApplicationController, type: :request do
           "Accept" => "application/json",
         }
       end
-      let(:access_token) { AccessToken.create!(owner: "test-owner") }
-      let(:token) { access_token.users_token }
+      let(:access_token) { AccessToken.new(owner: "test-owner") }
+      let(:token) { access_token.generate_token }
       let(:time_now) { Time.zone.now }
 
       before do
         Settings.forms_api.enabled_auth = true
         Settings.forms_api.authentication_key = 1234
+        access_token
         token
+        access_token.save!
         freeze_time do
           time_now
           get forms_path, params: { org: "gds" }, headers: req_headers
@@ -133,10 +139,12 @@ describe ApplicationController, type: :request do
       end
 
       context "when token has been deactivated" do
-        let(:access_token) { AccessToken.create!(owner: "test-owner", deactivated_at: Time.zone.now) }
+        let(:access_token) { AccessToken.new(owner: "test-owner", deactivated_at: Time.zone.now) }
 
         before do
+          access_token
           token
+          access_token.save!
           get forms_path, params: { org: "gds" }, headers: req_headers
         end
 


### PR DESCRIPTION
#### What problem does the pull request solve?

Currently we only support one single key that is a set environment variable secret. This makes it harder for us to create keys for different use cases eg. different keys for each client that might use it or tech support devs needing to call endpoints.

This PR adds the following:

- Adds a new setting to toggle authentication. Its enabled by default for rails production environments but disabled for local development or testing. It can be enabled in local dev or specific tests depending on the needs of the developer.
- Adds a new database table to store a list of tokens. Tokens can be disabled and we will record the last time a specific token  was used
- Refactors the authentication mechanism so that that requests can be authorised either using the older header request method or if that fails then to look up the authorisation header token in the database to see if one active token exists before blocking the request completely.

Trello card: https://trello.com/c/9HfUTlzL/579-firebreak-refactor-forms-api-authentication-feature-to-accept-other-keys

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
