### PR TITLE
New end point to return details of current token being used for the request

### DIFF
--- a/app/controllers/api/v1/access_tokens_controller.rb
+++ b/app/controllers/api/v1/access_tokens_controller.rb
@@ -27,7 +27,7 @@ class Api::V1::AccessTokensController < ApplicationController
 
   def caller_identity
     if @access_token
-      render json: @access_token.as_json(except: [:token_digest]).to_json, status: :ok
+      render json: @access_token.to_json, status: :ok
     else
       render json: { error: "Not found - No token used." }.to_json, status: :not_found
     end

--- a/app/controllers/api/v1/access_tokens_controller.rb
+++ b/app/controllers/api/v1/access_tokens_controller.rb
@@ -25,6 +25,14 @@ class Api::V1::AccessTokensController < ApplicationController
     render json: { status: "`#{@access_token.owner}` has been deactivated" }.to_json, status: :ok
   end
 
+  def caller_identity
+    if @access_token
+      render json: @access_token.as_json(except: [:token_digest]).to_json, status: :ok
+    else
+      render json: { error: "Not found - No token used." }.to_json, status: :not_found
+    end
+  end
+
 private
 
   def token_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,9 @@ Rails.application.routes.draw do
       member do
         put "/deactivate", to: "api/v1/access_tokens#deactivate"
       end
+      collection do
+        get "/caller-identity", to: "api/v1/access_tokens#caller_identity", as: :show_details_for
+      end
     end
   end
 end

--- a/spec/request/api/v1/access_tokens_controller_spec.rb
+++ b/spec/request/api/v1/access_tokens_controller_spec.rb
@@ -113,6 +113,7 @@ describe Api::V1::AccessTokensController, type: :request do
 
       expect(json_body).to match(
         id: access_token.id,
+        token_digest: access_token.token_digest,
         owner: access_token.owner,
         description: nil,
         deactivated_at: nil,


### PR DESCRIPTION
#### What problem does the pull request solve?

using an existing active token making  a GET request to `api/v1/access-tokens/caller-identity` will return the details for token that's being used in the existing request.

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
