### PR TITLE
Return a list of forms across all organisations

### DIFF
--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -5,8 +5,14 @@ class Api::V1::FormsController < ApplicationController
   end
 
   def index
-    org = params.require(:org)
-    render json: Form.where(org:).order(:name).to_json
+    org = params[:org]
+    forms = if org.present?
+              Form.where(org:)
+            else
+              Form
+            end
+
+    render json: forms.order(:name).to_json
   end
 
   def create

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -12,10 +12,12 @@ describe Api::V1::FormsController, type: :request do
       create(:form, name: "Can you answer my questions?", org: "gds"),
     ]
   end
+  let(:other_forms) { create :form, org: "not-gds" }
+
+  let(:all_forms) { [gds_forms, other_forms] }
 
   before do
-    gds_forms
-    create :form, org: "not-gds"
+    all_forms
   end
 
   describe "#index" do
@@ -26,11 +28,11 @@ describe Api::V1::FormsController, type: :request do
       expect(json_body).to eq([])
     end
 
-    it "when not given an org, returns 200 and an empty json array" do
+    it "when not given an org, returns 200 forms and forms for all orgs." do
       get forms_path, headers: headers
-      expect(response.status).to eq(400)
+      expect(response.status).to eq(200)
       expect(response.headers["Content-Type"]).to eq("application/json")
-      expect(json_body).to eq({ error: "param is missing or the value is empty: org" })
+      expect(json_body.length).to eq 3
     end
 
     it "when given an org with forms, returns a json array of forms" do


### PR DESCRIPTION
#### What problem does the pull request solve?
The problem with making the org param required is that it stops us from searching for all forms across all organisations.

If you pass in `org` as a query param (which `forms-admin` and `forms-runner` already do), it will return a list of forms for that organisation. If you leave off the query param it will return a list of forms.

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
