### PR TITLE
Add show-draft endpoint

### DIFF
--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -50,6 +50,10 @@ class Api::V1::FormsController < ApplicationController
     render json: form.live_version, status: :ok
   end
 
+  def show_draft
+    render json: form.draft_version, status: :ok
+  end
+
 private
 
   def form

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
       member do
         post "/make-live", to: "api/v1/forms#make_live"
         get "/live", to: "api/v1/forms#show_live"
+        get "/draft", to: "api/v1/forms#show_draft"
       end
 
       resources :pages, controller: "api/v1/pages", param: :page_id

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -271,4 +271,24 @@ describe Api::V1::FormsController, type: :request do
       expect(response.headers["Content-Type"]).to eq("application/json")
     end
   end
+
+  describe "#show_draft" do
+    it "returns the draft version which includes pages" do
+      draft_form = create :form, :ready_for_live
+
+      get draft_form_path(draft_form), as: :json
+
+      expect(response.status).to eq(200)
+      expect(response.headers["Content-Type"]).to eq("application/json")
+
+      expect(json_body.to_json).to eq draft_form.to_json(include: :pages)
+    end
+
+    it "returns 404 if draft form doesn't exist" do
+      get draft_form_path(1), as: :json
+
+      expect(response.status).to eq(404)
+      expect(response.headers["Content-Type"]).to eq("application/json")
+    end
+  end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?

we wanted an easy way to return a draft form and its pages in one request. This is almost identical show_live except instead of returning a live form and its pages, it returns a draft form and its pages.

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
