### PR TITLE
Create conditions table and model

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -1,0 +1,7 @@
+class Condition < ApplicationRecord
+  has_paper_trail
+
+  belongs_to :routing_page, class_name: "Page"
+  belongs_to :check_page, class_name: "Page", optional: true
+  belongs_to :goto_page, class_name: "Page", optional: true
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -2,6 +2,9 @@ class Page < ApplicationRecord
   has_paper_trail
 
   belongs_to :form
+  has_many :routing_conditions, class_name: "Condition", foreign_key: "routing_page_id", dependent: :destroy
+  has_many :check_conditions, class_name: "Condition", foreign_key: "check_page_id", dependent: :nullify
+  has_many :goto_conditions, class_name: "Condition", foreign_key: "goto_page_id", dependent: :nullify
   acts_as_list scope: :form
 
   ANSWER_TYPES = %w[number address date email national_insurance_number phone_number selection organisation_name text name].freeze

--- a/db/migrate/20230324091733_create_conditions_table.rb
+++ b/db/migrate/20230324091733_create_conditions_table.rb
@@ -1,0 +1,11 @@
+class CreateConditionsTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :conditions do |t|
+      t.references :check_page
+      t.references :routing_page
+      t.references :goto_page
+      t.string :answer_value
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230324091733_create_conditions_table.rb
+++ b/db/migrate/20230324091733_create_conditions_table.rb
@@ -1,9 +1,9 @@
 class CreateConditionsTable < ActiveRecord::Migration[7.0]
   def change
     create_table :conditions do |t|
-      t.references :check_page
-      t.references :routing_page
-      t.references :goto_page
+      t.references :check_page, comment: "The question page this condition looks at to compare answers"
+      t.references :routing_page, comment: "The question page at which this conditional route takes place"
+      t.references :goto_page, comment: "The question page which this conditions will skip forwards to"
       t.string :answer_value
       t.timestamps
     end

--- a/db/migrate/20230331141402_add_skip_to_end_to_conditions.rb
+++ b/db/migrate/20230331141402_add_skip_to_end_to_conditions.rb
@@ -1,0 +1,5 @@
+class AddSkipToEndToConditions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :conditions, :skip_to_end, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,6 +24,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_24_120801) do
     t.string "description"
   end
 
+  create_table "conditions", force: :cascade do |t|
+    t.bigint "check_page_id"
+    t.bigint "routing_page_id"
+    t.bigint "goto_page_id"
+    t.string "answer_value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["check_page_id"], name: "index_conditions_on_check_page_id"
+    t.index ["goto_page_id"], name: "index_conditions_on_goto_page_id"
+    t.index ["routing_page_id"], name: "index_conditions_on_routing_page_id"
+  end
+
   create_table "forms", force: :cascade do |t|
     t.text "name"
     t.text "submission_email"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_24_120801) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_31_141402) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,6 +31,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_24_120801) do
     t.string "answer_value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "skip_to_end", default: false
     t.index ["check_page_id"], name: "index_conditions_on_check_page_id"
     t.index ["goto_page_id"], name: "index_conditions_on_goto_page_id"
     t.index ["routing_page_id"], name: "index_conditions_on_routing_page_id"

--- a/spec/factories/conditions.rb
+++ b/spec/factories/conditions.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :condition do
+    routing_page { build :page }
+    check_page { nil }
+    goto_page { nil }
+    answer_value { nil }
+  end
+end

--- a/spec/factories/conditions.rb
+++ b/spec/factories/conditions.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     check_page { nil }
     goto_page { nil }
     answer_value { nil }
+    skip_to_end { false }
   end
 end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe Condition, type: :model do
+  subject(:condition) { described_class.new }
+
+  it "has a valid factory" do
+    condition = create :condition
+    expect(condition).to be_valid
+  end
+
+  describe "versioning", versioning: true do
+    it "enables paper trail" do
+      expect(condition).to be_versioned
+    end
+  end
+
+  describe "validations" do
+    it "validates" do
+      page = create :page
+      condition.routing_page_id = page.id
+      expect(condition).to be_valid
+    end
+
+    it "requires routing_page_id" do
+      expect(condition).to be_invalid
+      expect(condition.errors[:routing_page]).to include("must exist")
+    end
+  end
+end


### PR DESCRIPTION
#### What problem does the pull request solve?

Trello card: https://trello.com/c/FbZxLSWp/561-api-migration-for-simple-routing

This adds a Conditions table, which contains a set of references to the Pages table. 

There's a bit of complexity around which references are necessary and which are optional. The idea is that a Condition has to be attached to a specific page, which is the `routing_page`. This is a mandatory relationship, and deleting the page destroys this condition. 

There are also two other page references, one to the page whose answer will be checked, the `check_page`, and the other to whom the user will skip to if the condition is met, the `goto_page`. If the user deletes the associated page, the reference is simply removed, while the condition remains.

Updating comment for trello testing!

31/03/23 **Update**: I've added a commit to add an additional column which keeps track of whether the condition should skip _past_ the last page of the form, and bring the user to the check your answers page. We can't track this using the `goto_page` foreign key column, as there isn't a page object to key to! We did consider making use of the fact that the `goto_page` column could be `null` which could represent skipping to the last page, but then we have a bit of an issue with deciding whether a user has actively set the condition to skip to the last page, or if they just didn't notice that they skip to the last page by default. 