### PR TITLE
Refactors to draft/live functionality and associated tests

### DIFF
--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -9,8 +9,7 @@ class Api::V1::PagesController < ApplicationController
   def create
     new_page = form.pages.new(page_params)
 
-    if new_page.save
-      form.update!(question_section_completed: false)
+    if new_page.save_and_update_form
       render json: { id: new_page.id }, status: :created
     else
       render json: new_page.errors.to_json, status: :bad_request
@@ -24,8 +23,7 @@ class Api::V1::PagesController < ApplicationController
   def update
     page.assign_attributes(page_params)
 
-    if page.save
-      form.update!(question_section_completed: false)
+    if page.save_and_update_form
       render json: { success: true }.to_json, status: :ok
     else
       render json: page.errors.to_json, status: :bad_request
@@ -33,8 +31,7 @@ class Api::V1::PagesController < ApplicationController
   end
 
   def destroy
-    page.destroy!
-    form.update!(question_section_completed: false)
+    page.destroy_and_update_form!
     render json: { success: true }.to_json, status: :ok
   end
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -11,13 +11,17 @@ class Form < ApplicationRecord
 
   def make_live!(live_at = nil)
     live_at ||= Time.zone.now
-    update!(live_at: live_at, updated_at: live_at)
+    touch(time: live_at)
 
     made_live_forms.create!(json_form_blob: snapshot.to_json, created_at: live_at)
   end
 
   def draft_version
     snapshot.to_json
+  end
+
+  def live_at
+    return made_live_forms.last.created_at if made_live_forms.present?
   end
 
   def live_version
@@ -32,7 +36,7 @@ class Form < ApplicationRecord
   end
 
   def as_json(options = {})
-    options[:methods] ||= [:start_page]
+    options[:methods] ||= %i[live_at start_page]
     super(options)
   end
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -12,17 +12,17 @@ class Form < ApplicationRecord
   def make_live!
     update!(live_at: Time.zone.now)
 
-    made_live_forms.create!(json_form_blob: to_json(include: [:pages]))
+    made_live_forms.create!(json_form_blob: snapshot.to_json)
+  end
+
+  def draft_version
+    snapshot.to_json
   end
 
   def live_version
     return draft_version if made_live_forms.blank?
 
     made_live_forms.last.json_form_blob
-  end
-
-  def draft_version
-    to_json(include: [:pages])
   end
 
   def name=(val)
@@ -33,6 +33,11 @@ class Form < ApplicationRecord
   def as_json(options = {})
     options[:methods] ||= [:start_page]
     super(options)
+  end
+
+  def snapshot
+    # override methods so it doesn't include things we don't want
+    as_json(include: [:pages], methods: [:start_page])
   end
 
   # form_slug is always set based on name. This is here to allow Form

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -9,10 +9,11 @@ class Form < ApplicationRecord
     pages&.first&.id
   end
 
-  def make_live!
-    update!(live_at: Time.zone.now)
+  def make_live!(live_at = nil)
+    live_at ||= Time.zone.now
+    update!(live_at: live_at, updated_at: live_at)
 
-    made_live_forms.create!(json_form_blob: snapshot.to_json)
+    made_live_forms.create!(json_form_blob: snapshot.to_json, created_at: live_at)
   end
 
   def draft_version

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -9,6 +9,15 @@ class Page < ApplicationRecord
   validates :question_text, presence: true
   validates :answer_type, presence: true, inclusion: { in: ANSWER_TYPES }
 
+  def destroy_and_update_form!
+    form = self.form
+    destroy! && form.update!(question_section_completed: false)
+  end
+
+  def save_and_update_form
+    save && form.update!(question_section_completed: false)
+  end
+
   def next_page
     lower_item&.id
   end

--- a/db/migrate/20230324113043_update_live_at_date_times.rb
+++ b/db/migrate/20230324113043_update_live_at_date_times.rb
@@ -1,0 +1,7 @@
+class UpdateLiveAtDateTimes < ActiveRecord::Migration[7.0]
+  def up
+    Form.where.not(live_at: nil).find_each do |form|
+      form.made_live_forms.last.update!(created_at: form.live_at)
+    end
+  end
+end

--- a/db/migrate/20230324120801_remove_live_at_from_forms.rb
+++ b/db/migrate/20230324120801_remove_live_at_from_forms.rb
@@ -1,0 +1,15 @@
+class RemoveLiveAtFromForms < ActiveRecord::Migration[7.0]
+  def up
+    remove_column :forms, :live_at, :datetime
+  end
+
+  def down
+    add_column :forms, :live_at, :datetime
+
+    Form.find_each do |form|
+      if form.made_live_forms.present?
+        form.update!(live_at: form.made_live_forms.last.created_at)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_24_113043) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_24_120801) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,7 +28,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_24_113043) do
     t.text "name"
     t.text "submission_email"
     t.text "org"
-    t.datetime "live_at"
     t.text "privacy_policy_url"
     t.text "form_slug"
     t.text "what_happens_next_text"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_17_103613) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_24_113043) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     submission_email { Faker::Internet.email(domain: "example.gov.uk") }
     privacy_policy_url { Faker::Internet.url(host: "gov.uk") }
     org { "test-org" }
-    live_at { nil }
     support_email { nil }
     support_phone { nil }
     support_url { nil }
@@ -51,8 +50,6 @@ FactoryBot.define do
 
     trait :live do
       ready_for_live
-      # TODO: remove live_at
-      live_at { Time.zone.now }
     end
 
     trait :with_support do

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
       end
 
       pages do
-        Array.new(pages_count) { build(:page) }
+        Array.new(pages_count) { association(:page) }
       end
 
       question_section_completed { true }
@@ -36,7 +36,7 @@ FactoryBot.define do
 
     trait :with_text_page do
       pages do
-        Array.new(1) { build(:page, answer_type: "text", answer_settings: { input_type: %w[single_line long_text].sample }) }
+        Array.new(1) { association(:page, answer_type: "text", answer_settings: { input_type: %w[single_line long_text].sample }) }
       end
 
       question_section_completed { true }
@@ -51,6 +51,7 @@ FactoryBot.define do
 
     trait :live do
       ready_for_live
+      # TODO: remove live_at
       live_at { Time.zone.now }
     end
 

--- a/spec/factories/made_live_forms.rb
+++ b/spec/factories/made_live_forms.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :made_live_form do
-    form { create :form, :with_pages, :live }
+    association :form, :with_pages, :live
     json_form_blob { form.to_json(include: [:pages]) }
   end
 end

--- a/spec/factories/made_live_forms.rb
+++ b/spec/factories/made_live_forms.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :made_live_form do
     association :form, :with_pages, :live
-    json_form_blob { form.to_json(include: [:pages]) }
+    json_form_blob { form.snapshot.to_json }
   end
 end

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -1,10 +1,11 @@
 FactoryBot.define do
   factory :page do
+    association :form
+
     question_text { Faker::Lorem.question }
     answer_type { Page::ANSWER_TYPES.sample }
     is_optional { nil }
     answer_settings { nil }
-    form { build :form }
     sequence(:position)
 
     trait :with_hints do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Form, type: :model do
     end
 
     it "does create a made live version" do
-      expect(form_to_be_made_live.made_live_forms.last.json_form_blob).to eq form_to_be_made_live.to_json(include: [:pages])
+      expect(form_to_be_made_live.made_live_forms.last.json_form_blob).to eq form_to_be_made_live.snapshot.to_json
     end
   end
 
@@ -101,15 +101,44 @@ RSpec.describe Form, type: :model do
     let(:made_live_form) { create :made_live_form }
 
     it "returns json version of the LIVE form and includes pages" do
-      expect(made_live_form.form.live_version).to eq(made_live_form.form.to_json(include: [:pages]))
+      expect(made_live_form.form.live_version).to eq(made_live_form.form.snapshot.to_json)
     end
 
     context "when a form has never been made live before" do
       let(:form) { create :form, :ready_for_live }
 
       it "returns the draft version of the form" do
-        expect(form.live_version).to eq(form.to_json(include: [:pages]))
+        expect(form.live_version).to eq(form.snapshot.to_json)
       end
+    end
+  end
+
+  describe "#snapshot" do
+    let(:snapshot) { create(:form).snapshot }
+
+    it "creates a version of a form with its pages" do
+      expect(snapshot.keys).to contain_exactly(
+        "id",
+        "name",
+        "submission_email",
+        "org",
+        "created_at",
+        "live_at",
+        "updated_at",
+        "privacy_policy_url",
+        "form_slug",
+        "start_page",
+        "what_happens_next_text",
+        "support_email",
+        "support_phone",
+        "support_url",
+        "support_url_text",
+        "declaration_text",
+        "question_section_completed",
+        "declaration_section_completed",
+        "pages",
+        "page_order",
+      )
     end
   end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -95,6 +95,15 @@ RSpec.describe Form, type: :model do
     it "does create a made live version" do
       expect(form_to_be_made_live.made_live_forms.last.json_form_blob).to eq form_to_be_made_live.snapshot.to_json
     end
+
+    it "makes timestamps consistent" do
+      form = create :form
+      form.make_live!
+      made_live_form = form.made_live_forms.last
+
+      expect(form.live_at).to eq(made_live_form.created_at)
+      expect(form.updated_at).to eq(made_live_form.created_at)
+    end
   end
 
   describe "#live_version" do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Form, type: :model do
   end
 
   describe "#make_live!" do
-    let(:form_to_be_made_live) { build :form }
+    let(:form_to_be_made_live) { create :form }
     let(:time_now) { Time.zone.now }
 
     before do
@@ -103,6 +103,18 @@ RSpec.describe Form, type: :model do
 
       expect(form.live_at).to eq(made_live_form.created_at)
       expect(form.updated_at).to eq(made_live_form.created_at)
+    end
+  end
+
+  describe "#live_at" do
+    it "returns nil if form has not been made live" do
+      form = create :form
+      expect(form.live_at).to be_nil
+    end
+
+    it "returns the time when the form was made live" do
+      made_live_form = create :made_live_form
+      expect(made_live_form.form.live_at).to eq made_live_form.created_at
     end
   end
 
@@ -132,7 +144,6 @@ RSpec.describe Form, type: :model do
         "submission_email",
         "org",
         "created_at",
-        "live_at",
         "updated_at",
         "privacy_policy_url",
         "form_slug",

--- a/spec/models/made_live_form_spec.rb
+++ b/spec/models/made_live_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe MadeLiveForm, type: :model do
     expect(made_live_form).to be_valid
   end
 
-  it "contains a version of a form with its pages" do
-    expect(made_live_form.json_form_blob).to eq made_live_form.form.to_json(include: [:pages])
+  it "contains a snapshot of a form" do
+    expect(made_live_form.json_form_blob).to eq made_live_form.form.snapshot.to_json
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -44,4 +44,29 @@ RSpec.describe Page, type: :model do
       expect(page.errors[:answer_type]).to include("is not included in the list")
     end
   end
+
+  describe "#destroy_and_update_form!" do
+    let(:page) { create :page }
+    let(:form) { page.form }
+
+    it "sets form.question_section_completed to false" do
+      form.update!(question_section_completed: true)
+
+      page.destroy_and_update_form!
+      expect(form.question_section_completed).to be false
+    end
+  end
+
+  describe "#save_and_update_form" do
+    let(:page) { create :page }
+    let(:form) { page.form }
+
+    it "sets form.question_section_completed to false" do
+      form.update!(question_section_completed: true)
+
+      page.question_text = "Edited question"
+      page.save_and_update_form
+      expect(form.question_section_completed).to be false
+    end
+  end
 end

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -281,7 +281,7 @@ describe Api::V1::FormsController, type: :request do
       expect(response.status).to eq(200)
       expect(response.headers["Content-Type"]).to eq("application/json")
 
-      expect(json_body.to_json).to eq draft_form.to_json(include: :pages)
+      expect(json_body.to_json).to eq draft_form.snapshot.to_json
     end
 
     it "returns 404 if draft form doesn't exist" do


### PR DESCRIPTION
While working on https://trello.com/c/845sNCtW I found there were a bunch of things that it would be good to clean up in our models to make it easy to tell when a form had a draft version and/or a live version.

I've split those changes out into a separate PR, to break things up a bit.

#### What problem does the pull request solve?

- It was hard to write model specs that change a form or a page while doing the same bookkeeping as the controllers, we move that business logic into a new `FormUpdateService`
- The datetime stamps for live_at and made_live_forms.last weren't consistent with the updated_at of the form, so we couldn't compare reliably
- The logic for creating a JSON form blob was scattered all over in our code and in our specs, we restore the `snapshot` method to bring it all into one place

Those are the major ones, there are also some small tweaks I snuck in as well ;)