### PR TITLE
Fix form-runner

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -13,7 +13,8 @@ class Form < ApplicationRecord
     live_at ||= Time.zone.now
     touch(time: live_at)
 
-    made_live_forms.create!(json_form_blob: snapshot.to_json, created_at: live_at)
+    form_blob = snapshot(live_at:)
+    made_live_forms.create!(json_form_blob: form_blob.to_json, created_at: live_at)
   end
 
   def has_draft_version
@@ -50,9 +51,9 @@ class Form < ApplicationRecord
     super(options)
   end
 
-  def snapshot
+  def snapshot(**kwargs)
     # override methods so it doesn't include things we don't want
-    as_json(include: [:pages], methods: [:start_page])
+    as_json(include: [:pages], methods: [:start_page]).merge(kwargs)
   end
 
   # form_slug is always set based on name. This is here to allow Form

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -92,8 +92,18 @@ RSpec.describe Form, type: :model do
       expect(form_to_be_made_live.live_at).to eq(time_now)
     end
 
-    it "does create a made live version" do
-      expect(form_to_be_made_live.made_live_forms.last.json_form_blob).to eq form_to_be_made_live.snapshot.to_json
+    it "creates a made live version" do
+      expect(form_to_be_made_live.made_live_forms.last.json_form_blob)
+        .to eq(form_to_be_made_live.snapshot(live_at: time_now).to_json)
+    end
+
+    it "the made live version has a live_at datetime" do
+      form_blob = JSON.parse(
+        form_to_be_made_live.made_live_forms.last.json_form_blob,
+        symbolize_names: true,
+      )
+
+      expect(Time.zone.parse(form_blob[:live_at])).to eq time_now
     end
 
     it "makes timestamps consistent" do


### PR DESCRIPTION
Commit 38b3a2c broke the forms-runner for newly made live forms, as form blob did not include the live_at attribute required for validation of the form [[1]], [[2]].

For backwards-compatibilty, this commit adds the live_at datetime back into the form blob for made live forms. For draft form versions, live_at is not needed, so we leave it out.

[1]: https://github.com/alphagov/forms-runner/blob/main/app/models/form.rb#L25-L30
[2]: https://github.com/alphagov/forms-runner/blob/31a0d62dab8a950d0df59e9a652c5006d9362d63/app/controllers/forms/base_controller.rb#L66


#### What problem does the pull request solve?

Fixes `invalid live_at time` errors seen in https://govuk-forms.sentry.io/issues/4034044478/