### PR TITLE
fix db schema which hadn't been updated after adding column comments

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,9 +25,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_31_141402) do
   end
 
   create_table "conditions", force: :cascade do |t|
-    t.bigint "check_page_id"
-    t.bigint "routing_page_id"
-    t.bigint "goto_page_id"
+    t.bigint "check_page_id", comment: "The question page this condition looks at to compare answers"
+    t.bigint "routing_page_id", comment: "The question page at which this conditional route takes place"
+    t.bigint "goto_page_id", comment: "The question page which this conditions will skip forwards to"
     t.string "answer_value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
#### What problem does the pull request solve?

db schema wasn't in sync with the db but `rails db:migrate` wasn't run after comments were added to migration.  https://github.com/alphagov/forms-api/pull/231/files#diff-9dfba9f77e4f88d15e2e6cca412a17b4079d455b7990f2e7f0b27c92402d418bR4-R6

Trello card:

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
