### PR TITLE
Include conditions in json bundling api calls

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -53,7 +53,7 @@ class Form < ApplicationRecord
 
   def snapshot(**kwargs)
     # override methods so it doesn't include things we don't want
-    as_json(include: [:pages], methods: [:start_page]).merge(kwargs)
+    as_json(include: { pages: { include: :routing_conditions } }, methods: [:start_page]).merge(kwargs)
   end
 
   # form_slug is always set based on name. This is here to allow Form

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -28,6 +28,7 @@ class Page < ApplicationRecord
   def as_json(options = {})
     options[:except] ||= [:next_page]
     options[:methods] ||= [:next_page]
+    options[:include] ||= [:routing_conditions]
     super(options)
   end
 end

--- a/spec/request/api/v1/pages_controller_spec.rb
+++ b/spec/request/api/v1/pages_controller_spec.rb
@@ -55,6 +55,7 @@ describe Api::V1::PagesController, type: :request do
                                                            form_id: form[:id],
                                                            next_page: nil,
                                                            position: 1,
+                                                           routing_conditions: [],
                                                            created_at: "2023-01-01T12:00:00.000Z",
                                                            updated_at: "2023-01-01T12:00:00.000Z").as_json)
     end


### PR DESCRIPTION
Any conditions that are associated with a page via the "routing_conditions" associtation will now be included with the page.

The result is a new key being available on pages, `routing_conditions`, which will contain an array of all the page's associated routing conditions, or an empty array if there aren't any.

#### What problem does the pull request solve?

Trello card: https://trello.com/c/VZNwPF1R/622-coordinate-basic-routing-with-draft-live-work
