### PR TITLE
Add routing warnings - Go To page doesn't exist

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -14,4 +14,16 @@ class Condition < ApplicationRecord
   def destroy_and_update_form!
     destroy! && form.update!(question_section_completed: false)
   end
+
+  def validation_errors
+    [warning_goto_page_doesnt_exist].compact
+  end
+
+  def warning_goto_page_doesnt_exist
+    page = form.pages.find_by(id: goto_page_id)
+    return nil if page.present?
+
+    { name: "goto_page_doesnt_exist" }
+  end
+
 end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -26,4 +26,10 @@ class Condition < ApplicationRecord
     { name: "goto_page_doesnt_exist" }
   end
 
+  def as_json(options = {})
+    super(options.reverse_merge(
+      except: [:next_page],
+      methods: [:validation_errors],
+    ))
+  end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -53,7 +53,13 @@ class Form < ApplicationRecord
 
   def snapshot(**kwargs)
     # override methods so it doesn't include things we don't want
-    as_json(include: { pages: { include: :routing_conditions } }, methods: [:start_page]).merge(kwargs)
+    as_json(include: {
+      pages: {
+        include: {
+          routing_conditions: { methods: :validation_errors },
+        },
+      },
+    }, methods: [:start_page]).merge(kwargs)
   end
 
   # form_slug is always set based on name. This is here to allow Form

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -28,7 +28,7 @@ class Page < ApplicationRecord
   def as_json(options = {})
     options[:except] ||= [:next_page]
     options[:methods] ||= [:next_page]
-    options[:include] ||= [:routing_conditions]
+    options[:include] ||= { routing_conditions: { methods: :validation_errors } }
     super(options)
   end
 end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -26,4 +26,51 @@ RSpec.describe Condition, type: :model do
       expect(condition.errors[:routing_page]).to include("must exist")
     end
   end
+
+  describe "#validation_errors" do
+    let(:form) { create :form }
+    let(:routing_page) { create :page, form: }
+    let(:goto_page) { nil }
+    let(:condition) { create :condition, routing_page_id: routing_page.id, goto_page_id: nil }
+
+    it "returns array of validation error objects" do
+      expect(condition.validation_errors).to eq([{ name: "goto_page_doesnt_exist" }])
+    end
+
+    context "when no validation errors" do
+      let(:goto_page) { create :page, form: }
+      let(:condition) { create :condition, routing_page_id: routing_page.id, goto_page_id: goto_page.id }
+
+      it "returns empty array if there are no validation errors" do
+        expect(condition.validation_errors).to be_empty
+      end
+    end
+  end
+
+  describe "#warning_goto_page_doesnt_exist" do
+    let(:form) { create :form }
+    let(:routing_page) { create :page, form: }
+    let(:goto_page) { create :page, form: }
+    let(:condition) { create :condition, routing_page_id: routing_page.id, goto_page_id: goto_page.id }
+
+    it "returns nil if goto page exists" do
+      expect(condition.warning_goto_page_doesnt_exist).to be_nil
+    end
+
+    context "when goto page has been deleted" do
+      let(:condition) { create :condition, routing_page_id: routing_page.id, goto_page_id: 999 }
+
+      it "returns object with error short name code " do
+        expect(condition.warning_goto_page_doesnt_exist).to eq({ name: "goto_page_doesnt_exist" })
+      end
+    end
+
+    context "when goto page may belong to another form" do
+      let(:goto_page) { create :page }
+
+      it "returns object with error short name code " do
+        expect(condition.warning_goto_page_doesnt_exist).to eq({ name: "goto_page_doesnt_exist" })
+      end
+    end
+  end
 end

--- a/spec/request/api/v1/conditions_controller_spec.rb
+++ b/spec/request/api/v1/conditions_controller_spec.rb
@@ -5,7 +5,7 @@ describe Api::V1::ConditionsController, type: :request do
   let(:form) { create :form }
   let(:routing_page) { create :page, form:, routing_conditions: [condition] }
   let(:goto_page) { create :page, form: }
-  let(:condition) { create :condition }
+  let(:condition) { create :condition, goto_page_id: goto_page.id }
   let(:condition_id) { condition.id }
 
   describe "#index" do

--- a/spec/request/api/v1/pages_controller_spec.rb
+++ b/spec/request/api/v1/pages_controller_spec.rb
@@ -21,6 +21,19 @@ describe Api::V1::PagesController, type: :request do
         expect(json_body[i]).to eq(JSON.parse(p.to_json).symbolize_keys)
       end
     end
+
+    context "when a page routing condition is invalid" do
+      let(:form) { create :form, id: 1, pages: [routing_page] }
+      let(:routing_page) { create :page, routing_conditions: [condition] }
+      let(:condition) { create :condition, goto_page_id: nil }
+
+      it "returns validation_errors" do
+        get form_pages_path(form), as: :json
+        expect(response.status).to eq(200)
+        expect(response.headers["Content-Type"]).to eq("application/json")
+        expect(json_body.first[:routing_conditions].first[:validation_errors]).to eq([{ name: "goto_page_doesnt_exist" }])
+      end
+    end
   end
 
   describe "#create" do


### PR DESCRIPTION
#### What problem does the pull request solve?

This is the first time that `forms-api` will be returning custom errors for the client to handle.  This PR adds a new method called `validation_errors` which dynamically evaluates the data when it is called to check if the route is valid. If it is not then it returns an object with a shorthand human readable error. `forms-admin` will use this value to look up the full user friendly error description. We did this because `forms-api` would not know what language the `forms-admin` is using without us also including the language in every request. 



```json
  {
      "id": 33,
      "check_page_id": 4,
      "routing_page_id": 4,
      "goto_page_id": 12,
      "answer_value": "Cat",
      "created_at": "2023-04-25T09:14:55.978Z",
      "updated_at": "2023-04-28T10:49:27.283Z",
      "skip_to_end": false,
      "validation_errors": [
          {
              "name": "goto_page_doesnt_exist"
          }
      ]
  }

```

Trello card: https://trello.com/c/tcKng6uH/694-add-go-to-page-does-not-exist-error-to-conditions-in-api

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
