### PR TITLE
Fix live_at Time

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -2,7 +2,7 @@ class Form < ApplicationRecord
   has_paper_trail
 
   has_many :pages, -> { order(position: :asc) }, dependent: :destroy
-  has_many :made_live_forms, dependent: :destroy
+  has_many :made_live_forms, -> { order(created_at: :asc) }, dependent: :destroy
 
   validates :org, :name, presence: true
   def start_page

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -148,9 +148,13 @@ RSpec.describe Form, type: :model do
       expect(form.live_at).to be_nil
     end
 
-    it "returns the time when the form was made live" do
-      made_live_form = create :made_live_form
-      expect(made_live_form.form.live_at).to eq made_live_form.created_at
+    it "returns the created_at time of the latest live version" do
+      form = create :form
+      _first_live_version = form.make_live!
+      _second_live_version = form.make_live!
+      third_live_version = form.make_live!
+
+      expect(form.live_at).to eq third_live_version.created_at
     end
   end
 


### PR DESCRIPTION
Specifies the order for made_live_forms so that the ordering and selection of the latest version with ActiveRecord.last function correctly selects the latest version based on the created_at time. Without this the ordering is inconsistent because the resulting `SELECT` statement does not include an `ORDER BY` clause; postgres will varying the order of returned rows without an `ORDER BY` clause due to the `synchronize_seqscans` optimisation.

Updates the integration tests to create multiple live versions and ensure the returned `live_at` is based upon the created_at time of the latest version.


### NOTES ###
Tested this locally and by deploying the branch to AWS dev. The `live_at` times are now consistent and consistently reflect the latest live version (note that this inconsistency was also present against the same data base but was more prevalent when comparing results form different databases e.g. PaaS vs AWS). 

The resulting SQL statement correctly includes the `ORDER BY` clause
```
  MadeLiveForm Load (3.1ms)  SELECT "made_live_forms".* FROM "made_live_forms" WHERE "made_live_forms"."form_id" = $1 ORDER BY "made_live_forms"."created_at" ASC  [["form_id", 144]]
```
