### PR TITLE
Add warning_answer_doesnt_exist to condition model

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -16,7 +16,10 @@ class Condition < ApplicationRecord
   end
 
   def validation_errors
-    [warning_goto_page_doesnt_exist].compact
+    [
+      warning_goto_page_doesnt_exist,
+      warning_answer_doesnt_exist,
+    ].compact
   end
 
   def warning_goto_page_doesnt_exist
@@ -24,6 +27,13 @@ class Condition < ApplicationRecord
     return nil if page.present?
 
     { name: "goto_page_doesnt_exist" }
+  end
+
+  def warning_answer_doesnt_exist
+    answer_options = check_page&.answer_settings&.dig("selection_options")&.pluck("name")
+    return nil if answer_options.blank? || answer_options.include?(answer_value)
+
+    { name: "answer_value_doesnt_exist" }
   end
 
   def as_json(options = {})

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -1,3 +1,13 @@
+# When an OpenStruct is converted to json, it inludes @table.
+# We inherit and overide as_json here to use to contain answer_settings, which
+# is a json hash converted into an object by ActiveResource. Using a plain hash
+# for answer_settings means there is no .access to attributes.
+class DataStruct < OpenStruct
+  def as_json(*args)
+    super.as_json["table"]
+  end
+end
+
 FactoryBot.define do
   factory :page do
     association :form
@@ -11,6 +21,16 @@ FactoryBot.define do
 
     trait :with_hints do
       hint_text { Faker::Quote.yoda }
+    end
+
+    trait :with_selections_settings do
+      transient do
+        only_one_option { "true" }
+        selection_options { [{ name: "Option 1" }, { name: "Option 2" }] }
+      end
+
+      answer_type { "selection" }
+      answer_settings { DataStruct.new(only_one_option:, selection_options:) }
     end
   end
 end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -73,4 +73,33 @@ RSpec.describe Condition, type: :model do
       end
     end
   end
+
+  describe "#warning_answer_doesnt_exist" do
+    let(:form) { create :form }
+    let(:check_page) { create :page, :with_selections_settings, form: }
+    let(:goto_page) { create :page, form: }
+    let(:condition) do
+      new_condition = create :condition, routing_page_id: check_page.id, check_page_id: check_page.id, goto_page_id: goto_page.id
+      new_condition.answer_value = check_page.answer_settings["selection_options"].first["name"]
+      new_condition
+    end
+
+    it "returns nil if answer exists" do
+      expect(condition.warning_answer_doesnt_exist).to be_nil
+    end
+
+    context "when answer has been deleted from page" do
+      it "returns object with error short name code " do
+        condition.check_page.answer_settings["selection_options"].shift
+        expect(condition.warning_answer_doesnt_exist).to eq({ name: "answer_value_doesnt_exist" })
+      end
+    end
+
+    context "when answer on the page has been updated" do
+      it "returns object with error short name code " do
+        condition.check_page.answer_settings["selection_options"].first["name"] = "Option 1.2"
+        expect(condition.warning_answer_doesnt_exist).to eq({ name: "answer_value_doesnt_exist" })
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?
Return a validation error if the page selection options are edited/removed and the conditions answer value is no longer a valid option for the user to select from

Trello card: https://trello.com/c/dGvEYmsk/712-add-answer-does-not-exist-error-to-conditions-in-api

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
