### PR TITLE
Return 404 if not live form exists

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -36,7 +36,7 @@ class Form < ApplicationRecord
   end
 
   def live_version
-    return draft_version if made_live_forms.blank?
+    raise ActiveRecord::RecordNotFound if made_live_forms.blank?
 
     made_live_forms.last.json_form_blob
   end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -177,14 +177,6 @@ RSpec.describe Form, type: :model do
     it "returns json version of the LIVE form and includes pages" do
       expect(made_live_form.form.live_version).to eq(made_live_form.form.snapshot.to_json)
     end
-
-    context "when a form has never been made live before" do
-      let(:form) { create :form, :ready_for_live }
-
-      it "returns the draft version of the form" do
-        expect(form.live_version).to eq(form.snapshot.to_json)
-      end
-    end
   end
 
   describe "#snapshot" do

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -274,6 +274,14 @@ describe Api::V1::FormsController, type: :request do
       expect(response.status).to eq(404)
       expect(response.headers["Content-Type"]).to eq("application/json")
     end
+
+    it "returns 404 if form has never existed" do
+      form = create :form
+      get live_form_path(form.id), as: :json
+
+      expect(response.status).to eq(404)
+      expect(response.headers["Content-Type"]).to eq("application/json")
+    end
   end
 
   describe "#show_draft" do


### PR DESCRIPTION
#### What problem does the pull request solve?
This is an over hang from the draft/live feature work we did. We needed to be able to support forms-runner before it had three different modes to display forms in (preview-live, preview-draft & Live). Before that work was done forms-runner could only display live forms and preview-form (ie no way to work out if its a draft/live it should be previewing).

Now what should happen is if a form is created and has never been made live then we should be returning 404 when the show_live endpoint is called rather than returning the draft form.

I've tested this locally and forms-api and forms-runner return 404 (and correct 404 page in the runner) when you try to view a form that has never been live.


Trello card: https://trello.com/c/yTVLXp4d/746-forms-api-should-return-404-when-asked-for-a-version-of-a-live-form-that-doesnt-exist

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
