### PR TITLE
Warn users if their route ends up creating an endless loop

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -20,6 +20,7 @@ class Condition < ApplicationRecord
       warning_goto_page_doesnt_exist,
       warning_answer_doesnt_exist,
       warning_routing_to_next_page,
+      warning_goto_page_before_check_page,
     ].compact
   end
 
@@ -40,10 +41,21 @@ class Condition < ApplicationRecord
   def warning_routing_to_next_page
     return nil if check_page.nil? || goto_page.nil?
 
-    routing_page_position = check_page.position
+    check_page_position = check_page.position
     goto_page_position = goto_page.position
 
-    return { name: "cannot_route_to_next_page" } if goto_page_position == (routing_page_position + 1)
+    return { name: "cannot_route_to_next_page" } if goto_page_position == (check_page_position + 1)
+
+    nil
+  end
+
+  def warning_goto_page_before_check_page
+    return nil if check_page.nil? || goto_page.nil?
+
+    check_page_position = check_page.position
+    goto_page_position = goto_page.position
+
+    return { name: "cannot_have_goto_page_before_routing_page" } if goto_page_position < (check_page_position + 1)
 
     nil
   end


### PR DESCRIPTION
#### What problem does the pull request solve?

The API needs to calculate the whether the routing for a given condition makes sense from a sequencing perspective. That is, the question that’s being checked takes place before the question that’s being directed to. This should only happen when a user reorders questions.

Trello card: https://trello.com/c/iFDqUmDc/739-add-question-routing-is-out-of-sequence-error-to-conditions-in-api

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
