### PR TITLE
Delete existing routes if answer_type is not selection

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -18,7 +18,13 @@ class Page < ApplicationRecord
   end
 
   def save_and_update_form
-    save && form.update!(question_section_completed: false)
+    return true unless has_changes_to_save?
+
+    save!
+    form.update!(question_section_completed: false)
+    routing_conditions.destroy_all if answer_type_previously_was&.to_sym == :selection
+
+    true
   end
 
   def next_page


### PR DESCRIPTION
#### What problem does the pull request solve?
We warn users when they edit their pages and changing the answer type will delete any existing routes.

While reviewing this part of the page, it was noted that the current implementation would reset the
form "question section completed" attribute every time a user pressed "save" regardless of whether there was anything to be changed. This has been changed in this commit so that we only attempt to save the page and modify form attributes if there are actually changes.

Trello card: https://trello.com/c/hC31J4xI/737-add-invalid-answer-type-warning-to-forms-api-and-delete-route

#### Checklist

- [ ] I've used the pull request template
- [ ] I've linked this PR to the relevant issue (if mission work)
- [ ] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
