### PR TITLE
Fix issue with routes being deleted when answer type hasn't changed

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -22,7 +22,7 @@ class Page < ApplicationRecord
 
     save!
     form.update!(question_section_completed: false)
-    routing_conditions.destroy_all if answer_type_previously_was&.to_sym == :selection
+    routing_conditions.destroy_all if answer_type_changed_from_selection
 
     true
   end
@@ -36,5 +36,9 @@ class Page < ApplicationRecord
     options[:methods] ||= [:next_page]
     options[:include] ||= { routing_conditions: { methods: :validation_errors } }
     super(options)
+  end
+
+  def answer_type_changed_from_selection
+    answer_type_previously_was&.to_sym == :selection && answer_type&.to_sym != :selection
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -83,6 +83,14 @@ RSpec.describe Page, type: :model do
           expect(page.reload.routing_conditions).to be_empty
         end
       end
+
+      context "when the page is saved without changing the answer type" do
+        it "does not delete the conditions" do
+          page.question_text = "test"
+          page.save_and_update_form
+          expect(page.reload.routing_conditions).not_to be_empty
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### What problem does the pull request solve?

Fixes a bug with routes being deleted when they shouldn't. Essentially whenever a selection question was saved, the question's route would be deleted too - regardless of whether the answer type had actually changed. As far as I can tell this is because the check we were doing - `answer_type_previously_was` - only tells us that the page was a selection question before, not whether it's actually changed.

Trello card: None

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
