### PR TITLE
Prevent marking questions section complete when there are routing errors

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -70,7 +70,11 @@ class Condition < ApplicationRecord
   def as_json(options = {})
     super(options.reverse_merge(
       except: [:next_page],
-      methods: [:validation_errors],
+      methods: %i[validation_errors has_routing_errors],
     ))
+  end
+
+  def has_routing_errors
+    validation_errors.any?
   end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -47,7 +47,7 @@ class Form < ApplicationRecord
   end
 
   def as_json(options = {})
-    options[:methods] ||= %i[live_at start_page has_draft_version has_live_version]
+    options[:methods] ||= %i[live_at start_page has_draft_version has_live_version has_routing_errors]
     super(options)
   end
 
@@ -65,4 +65,9 @@ class Form < ApplicationRecord
   # form_slug is always set based on name. This is here to allow Form
   # attributes to be updated easily based on json, without changning the value in the DB
   def form_slug=(slug); end
+
+  def has_routing_errors
+    pages.filter(&:has_routing_errors).any?
+  end
+
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -5,6 +5,8 @@ class Form < ApplicationRecord
   has_many :made_live_forms, -> { order(created_at: :asc) }, dependent: :destroy
 
   validates :org, :name, presence: true
+  validate :marking_complete_with_errors
+
   def start_page
     pages&.first&.id
   end
@@ -70,4 +72,7 @@ class Form < ApplicationRecord
     pages.filter(&:has_routing_errors).any?
   end
 
+  def marking_complete_with_errors
+    errors.add(:base, :has_validation_errors, message: "Form has routing validation errors") if question_section_completed && has_routing_errors
+  end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -33,12 +33,16 @@ class Page < ApplicationRecord
 
   def as_json(options = {})
     options[:except] ||= [:next_page]
-    options[:methods] ||= [:next_page]
-    options[:include] ||= { routing_conditions: { methods: :validation_errors } }
+    options[:methods] ||= %i[next_page has_routing_errors]
+    options[:include] ||= { routing_conditions: { methods: %i[validation_errors has_routing_errors] } }
     super(options)
   end
 
   def answer_type_changed_from_selection
     answer_type_previously_was&.to_sym == :selection && answer_type&.to_sym != :selection
+  end
+
+  def has_routing_errors
+    routing_conditions.filter(&:has_routing_errors).any?
   end
 end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -275,4 +275,26 @@ RSpec.describe Condition, type: :model do
       end
     end
   end
+
+  describe "#has_routing_errors" do
+    let(:form) { create :form }
+    let(:goto_page) { create :page, form: }
+    let(:goto_page_id) { goto_page.id }
+    let(:routing_page) { create :page, form: }
+    let(:condition) { create :condition, routing_page_id: routing_page.id, goto_page_id: }
+
+    context "when there are no validation errors" do
+      it "returns false" do
+        expect(condition.has_routing_errors).to be false
+      end
+    end
+
+    context "when there are validation errors" do
+      let(:goto_page_id) { nil }
+
+      it "returns true" do
+        expect(condition.has_routing_errors).to be true
+      end
+    end
+  end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -39,6 +39,33 @@ RSpec.describe Form, type: :model do
       expect(form).to be_invalid
       expect(form.errors[:org]).to include("can't be blank")
     end
+
+    context "when the form has validation errors" do
+      let(:form) { create :form, pages: [routing_page, goto_page] }
+      let(:routing_page) do
+        new_routing_page = create :page
+        new_routing_page.routing_conditions = [(create :condition, routing_page_id: new_routing_page.id, goto_page_id: nil)]
+        new_routing_page
+      end
+      let(:goto_page) { create :page }
+      let(:goto_page_id) { goto_page.id }
+
+      context "when the form is marked complete" do
+        it "returns invalid" do
+          form.question_section_completed = true
+
+          expect(form).to be_invalid
+          expect(form.errors[:base]).to include("Form has routing validation errors")
+        end
+      end
+
+      context "when the form is not marked complete" do
+        it "returns valid" do
+          form.question_section_completed = false
+          expect(form).to be_valid
+        end
+      end
+    end
   end
 
   describe "form_slug" do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -206,4 +206,29 @@ RSpec.describe Form, type: :model do
       )
     end
   end
+
+  describe "#has_routing_errors" do
+    let(:form) { create :form, pages: [routing_page, goto_page] }
+    let(:routing_page) do
+      new_routing_page = create :page
+      new_routing_page.routing_conditions = [(create :condition, routing_page_id: new_routing_page.id, goto_page_id:)]
+      new_routing_page
+    end
+    let(:goto_page) { create :page }
+    let(:goto_page_id) { goto_page.id }
+
+    context "when there are no validation errors" do
+      it "returns false" do
+        expect(form.has_routing_errors).to be false
+      end
+    end
+
+    context "when there are validation errors" do
+      let(:goto_page_id) { nil }
+
+      it "returns true" do
+        expect(form.has_routing_errors).to be true
+      end
+    end
+  end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -93,4 +93,26 @@ RSpec.describe Page, type: :model do
       end
     end
   end
+
+  describe "#has_routing_errors" do
+    let(:routing_page) { create :page, form: }
+    let(:goto_page) { create :page, form: }
+    let(:goto_page_id) { goto_page.id }
+    let(:routing_conditions) { [condition] }
+    let(:condition) { create :condition, routing_page_id: routing_page.id, goto_page_id: }
+
+    context "when there are no validation errors" do
+      it "returns false" do
+        expect(page.has_routing_errors).to be false
+      end
+    end
+
+    context "when there are validation errors" do
+      let(:goto_page_id) { nil }
+
+      it "returns true" do
+        expect(page.has_routing_errors).to be true
+      end
+    end
+  end
 end

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -65,6 +65,7 @@ describe Api::V1::FormsController, type: :request do
           :question_section_completed,
           :declaration_section_completed,
           :page_order,
+          :has_routing_errors,
         )
       end
     end
@@ -188,6 +189,7 @@ describe Api::V1::FormsController, type: :request do
         page_order: nil,
         created_at: form1.created_at.as_json,
         updated_at: form1.updated_at.as_json,
+        has_routing_errors: false,
       )
     end
   end

--- a/spec/request/api/v1/pages_controller_spec.rb
+++ b/spec/request/api/v1/pages_controller_spec.rb
@@ -69,6 +69,7 @@ describe Api::V1::PagesController, type: :request do
                                                            next_page: nil,
                                                            position: 1,
                                                            routing_conditions: [],
+                                                           has_routing_errors: false,
                                                            created_at: "2023-01-01T12:00:00.000Z",
                                                            updated_at: "2023-01-01T12:00:00.000Z").as_json)
     end


### PR DESCRIPTION
#### What problem does the pull request solve?

- Adds a validation to the API so that a form can't be marked as `question_section_completed: true` if it has routing validation errors
- Adds a `has_routing_errors` method to conditions, pages and forms, and makes these available in the API response to make checking this easier in forms-admin

In theory this validation should never actually fail, since forms-admin should only send the save request if the form is in a valid state, but this gives us some extra confidence.

Trello card: https://trello.com/c/W5mLjhd3/804-prevent-users-marking-the-pages-section-as-complete-while-there-are-routing-errors

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [n/a] I've updated the documentation in (If any documentation requires updating)
  - [n/a] README.md
  - [n/a] Elsewhere (please link)
