### PR TITLE
Allow forms to not have an organisation set

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -4,7 +4,7 @@ class Form < ApplicationRecord
   has_many :pages, -> { order(position: :asc) }, dependent: :destroy
   has_many :made_live_forms, -> { order(created_at: :asc) }, dependent: :destroy
 
-  validates :org, :name, presence: true
+  validates :name, presence: true
   validate :marking_complete_with_errors
 
   scope :filter_by_org, ->(org) { where org: org }

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -26,18 +26,12 @@ RSpec.describe Form, type: :model do
   describe "validations" do
     it "validates" do
       form.name = "test"
-      form.org = "test-org"
       expect(form).to be_valid
     end
 
     it "requires name" do
       expect(form).to be_invalid
       expect(form.errors[:name]).to include("can't be blank")
-    end
-
-    it "requires org" do
-      expect(form).to be_invalid
-      expect(form.errors[:org]).to include("can't be blank")
     end
 
     context "when the form has validation errors" do


### PR DESCRIPTION
This is required so that trial users without organisations can create forms.

Trello card: https://trello.com/c/8kysclWz

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
