### PR TITLE
Add shell command trace to container run command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,4 @@ COPY --chown=ruby:ruby --from=build /app /app
 
 EXPOSE 9292
 
-CMD ["/bin/sh", "-c", "rake db:migrate && rails s -b 0.0.0.0 -p 9292"]
+CMD ["/bin/sh", "-o", "xtrace", "-c", "rake db:migrate && rails s -b 0.0.0.0 -p 9292"]


### PR DESCRIPTION
It is useful when looking at startup logs to be able to know what command was run, to understand the context of the log outputs.

See https://github.com/alphagov/forms-admin/pull/498 for more details.