### PR TITLE
Add update_org_for_creator bulk update endpoint

### DIFF
--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -49,6 +49,11 @@ class Api::V1::FormsController < ApplicationController
     render json: form.draft_version, status: :ok
   end
 
+  def update_org_for_creator
+    params.require(%i[creator_id org])
+    Form.where(creator_id: params[:creator_id]).update_all(org: params[:org], updated_at: Time.zone.now)
+  end
+
 private
 
   def form

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
       end
 
       collection do
-        patch "/update_org_for_creator", to: "api/v1/forms#update_org_for_creator"
+        patch "/update-org-for-creator", to: "api/v1/forms#update_org_for_creator"
       end
 
       resources :pages, controller: "api/v1/pages", param: :page_id do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,10 @@ Rails.application.routes.draw do
         get "/draft", to: "api/v1/forms#show_draft"
       end
 
+      collection do
+        patch "/update_org_for_creator", to: "api/v1/forms#update_org_for_creator"
+      end
+
       resources :pages, controller: "api/v1/pages", param: :page_id do
         member do
           resources :conditions, controller: "api/v1/conditions", param: :condition_id


### PR DESCRIPTION
#### What problem does the pull request solve?
When a user gets their account changed from trial to editor we want to have their forms added to their new organisation. This PR adds a specific bulk update endpoint to update the `org` for all forms with a matching `creator_id`. forms-admin can then use this endpoint when a user's role changes from trial to editor.

Trello card: https://trello.com/c/esvZIXnn

#### Checklist

- [x] I've used the pull request template
- [x] I've linked this PR to the relevant issue (if mission work)
- [x] I've written unit tests for these changes (if code change)
- [ ] I've updated the documentation in (If any documentation requires updating)
  - [ ] README.md
  - [ ] Elsewhere (please link)
