### PR TITLE
Make update_org_for_creator endpoint return status

### DIFF
--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -52,6 +52,7 @@ class Api::V1::FormsController < ApplicationController
   def update_org_for_creator
     params.require(%i[creator_id org])
     Form.where(creator_id: params[:creator_id]).update_all(org: params[:org], updated_at: Time.zone.now)
+    render json: { success: true }.to_json, status: :ok
   end
 
 private

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -319,7 +319,7 @@ describe Api::V1::FormsController, type: :request do
 
     context "when some forms match creator ID" do
       it "updates org only if creator ID matches" do
-        expect(response).to have_http_status(:no_content)
+        expect(response).to have_http_status(:ok)
 
         all_forms.each do |form|
           form.reload
@@ -336,7 +336,7 @@ describe Api::V1::FormsController, type: :request do
       let(:selected_creator_id) { 321 }
 
       it "does not update org" do
-        expect(response).to have_http_status(:no_content)
+        expect(response).to have_http_status(:ok)
 
         all_forms.each do |form|
           form.reload


### PR DESCRIPTION
#### What problem does the pull request solve?
By default `update_org_for_creator` returns 204 No Content, but to be consistent with other endpoints we should return 200 until we have a review of what status codes we should be returning for endpoints that conventionally would return no body in the response.

Trello card: https://trello.com/c/4Lxkorfb
