### PR TITLE
Add organisation_id to form model

### DIFF
--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -57,6 +57,12 @@ class Api::V1::FormsController < ApplicationController
     render json: { success: true }.to_json, status: :ok
   end
 
+  def update_organisation_for_creator
+    params.require(%i[creator_id organisation_id])
+    Form.where(creator_id: params[:creator_id]).update_all(organisation_id: params[:organisation_id], updated_at: Time.zone.now)
+    render json: { success: true }.to_json, status: :ok
+  end
+
 private
 
   def form

--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -1,10 +1,12 @@
 class Api::V1::FormsController < ApplicationController
   def index
     org = params[:org]
+    organisation_id = params[:organisation_id]
     creator_id = params[:creator_id]
 
     forms = Form.all
     forms = forms.filter_by_org(org) if org.present?
+    forms = forms.filter_by_organisation_id(organisation_id) if organisation_id.present?
     forms = forms.filter_by_creator_id(creator_id) if creator_id.present?
 
     render json: forms.order(:name).to_json

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -8,6 +8,7 @@ class Form < ApplicationRecord
   validate :marking_complete_with_errors
 
   scope :filter_by_org, ->(org) { where org: org }
+  scope :filter_by_organisation_id, ->(organisation_id) { where organisation_id: }
   scope :filter_by_creator_id, ->(creator_id) { where creator_id: creator_id }
 
   def start_page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
 
       collection do
         patch "/update-org-for-creator", to: "api/v1/forms#update_org_for_creator"
+        patch "/update-organisation-for-creator", to: "api/v1/forms#update_organisation_for_creator"
       end
 
       resources :pages, controller: "api/v1/pages", param: :page_id do

--- a/db/migrate/20230615094934_add_organisation_id_to_forms.rb
+++ b/db/migrate/20230615094934_add_organisation_id_to_forms.rb
@@ -1,0 +1,5 @@
+class AddOrganisationIdToForms < ActiveRecord::Migration[7.0]
+  def change
+    add_column :forms, :organisation_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_02_145728) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_15_094934) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,6 +55,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_02_145728) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "creator_id"
+    t.bigint "organisation_id"
   end
 
   create_table "made_live_forms", force: :cascade do |t|

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     submission_email { Faker::Internet.email(domain: "example.gov.uk") }
     privacy_policy_url { Faker::Internet.url(host: "gov.uk") }
     org { "test-org" }
+    organisation_id { 1 }
     support_email { nil }
     support_phone { nil }
     support_url { nil }

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -229,6 +229,7 @@ RSpec.describe Form, type: :model do
         "name",
         "submission_email",
         "org",
+        "organisation_id",
         "creator_id",
         "created_at",
         "updated_at",

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -393,4 +393,57 @@ describe Api::V1::FormsController, type: :request do
       end
     end
   end
+
+  describe "#update_organisation_for_creator" do
+    let(:selected_creator_id) { 1234 }
+    let(:updated_organisation_id) { 111 }
+
+    before do
+      patch update_organisation_for_creator_forms_path, params: { creator_id: selected_creator_id, organisation_id: updated_organisation_id }
+    end
+
+    context "when some forms match creator ID" do
+      it "updates organisation only if creator ID matches" do
+        expect(response).to have_http_status(:ok)
+
+        all_forms.each do |form|
+          form.reload
+          if form.creator_id == selected_creator_id
+            expect(form.organisation_id).to eq(updated_organisation_id)
+          else
+            expect(form.organisation_id).not_to eq(updated_organisation_id)
+          end
+        end
+      end
+    end
+
+    context "when no forms match creator ID" do
+      let(:selected_creator_id) { 321 }
+
+      it "does not update organisation" do
+        expect(response).to have_http_status(:ok)
+
+        all_forms.each do |form|
+          form.reload
+          expect(form.organisation_id).not_to eq(updated_organisation_id)
+        end
+      end
+    end
+
+    context "without creator ID" do
+      let(:selected_creator_id) { nil }
+
+      it "returns bad request if creator ID is missing" do
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
+    context "without organisation ID" do
+      let(:updated_organisation_id) { nil }
+
+      it "returns bad request if organisation ID is missing" do
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What problem does the pull request solve?

We want to associate forms with organisations using a stable key, however organisations slugs can change, so we want to change the key to be the primary key of the organisation table, the ID.

This PR adds a new attribute to the form model to store the organisation ID. To fully migrate will require other changes in other PRs, once the data has been copied across successfully we can then remove the old `org` attribute that held the slug.

Trello card: https://trello.com/c/pt9lphfe