### PR TITLE
Add URL query params to logging messages

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,6 +89,7 @@ Rails.application.configure do
       h[:request_id] = event.payload[:request_id]
       h[:requested_by] = event.payload[:requested_by] if event.payload[:requested_by]
       h[:form_id] = event.payload[:form_id] if event.payload[:form_id]
+      h[:params] = event.payload[:params].except(:controller, :action)
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

When a HTTP request includes query parameters it is useful to be able to see these in our logs. By default Lograge filters this out as it can contain sensitive information [[1]], but we don't have anything like that in our system.

This is especially useful at the moment when we are changing from using `org` slug to `organisation_id` (see PR #295, ticket https://trello.com/c/pt9lphfe), as without this logging we can't see what the admin app is sending to the api app for requests to `/forms`.

[1]: https://github.com/roidrage/lograge/blob/09bd96e1cb56f94841a64473e4195d413ce908fc/lib/lograge/log_subscribers/action_controller.rb#L21-L39
