### PR TITLE
Add heading and detailed guidance columns to pages

### DIFF
--- a/db/migrate/20230801100920_add_detailed_guidance_to_pages.rb
+++ b/db/migrate/20230801100920_add_detailed_guidance_to_pages.rb
@@ -1,0 +1,8 @@
+class AddDetailedGuidanceToPages < ActiveRecord::Migration[7.0]
+  def change
+    change_table :pages, bulk: true do |t|
+      t.text :page_heading
+      t.text :detailed_guidance_markdown
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_15_094934) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_01_100920) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -77,6 +77,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_15_094934) do
     t.datetime "updated_at", null: false
     t.bigint "form_id"
     t.integer "position"
+    t.text "page_heading"
+    t.text "detailed_guidance_markdown"
     t.index ["form_id"], name: "index_pages_on_form_id"
   end
 

--- a/spec/request/api/v1/pages_controller_spec.rb
+++ b/spec/request/api/v1/pages_controller_spec.rb
@@ -71,7 +71,9 @@ describe Api::V1::PagesController, type: :request do
                                                            routing_conditions: [],
                                                            has_routing_errors: false,
                                                            created_at: "2023-01-01T12:00:00.000Z",
-                                                           updated_at: "2023-01-01T12:00:00.000Z").as_json)
+                                                           updated_at: "2023-01-01T12:00:00.000Z",
+                                                           page_heading: nil,
+                                                           detailed_guidance_markdown: nil).as_json)
     end
 
     context "with params missing required keys" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/hu2VpKTR/931-store-a-questions-page-heading-and-detailed-guidance

Adding two columns for the detailed guidance work - the `page_heading` and `detailed_guidance_markdown` happy to take name suggestions on them!

