### PR TITLE
Rename detailed_guidance_markdown column  to match forms-admin

### DIFF
--- a/db/migrate/20230804113818_rename_pages_detailed_guidance_markdown_to_additional_guidance_markdown.rb
+++ b/db/migrate/20230804113818_rename_pages_detailed_guidance_markdown_to_additional_guidance_markdown.rb
@@ -1,0 +1,5 @@
+class RenamePagesDetailedGuidanceMarkdownToAdditionalGuidanceMarkdown < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :pages, :detailed_guidance_markdown, :additional_guidance_markdown
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_01_100920) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_04_113818) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -77,7 +77,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_01_100920) do
     t.bigint "form_id"
     t.integer "position"
     t.text "page_heading"
-    t.text "detailed_guidance_markdown"
+    t.text "additional_guidance_markdown"
     t.index ["form_id"], name: "index_pages_on_form_id"
   end
 

--- a/spec/request/api/v1/pages_controller_spec.rb
+++ b/spec/request/api/v1/pages_controller_spec.rb
@@ -73,7 +73,7 @@ describe Api::V1::PagesController, type: :request do
                                                            created_at: "2023-01-01T12:00:00.000Z",
                                                            updated_at: "2023-01-01T12:00:00.000Z",
                                                            page_heading: nil,
-                                                           detailed_guidance_markdown: nil).as_json)
+                                                           additional_guidance_markdown: nil).as_json)
     end
 
     context "with params missing required keys" do


### PR DESCRIPTION
### What problem does this pull request solve?

Rename pages detailed_guidance_markdown to match name used in forms-admin

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
