### PR TITLE
Move linting gems to development, test groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,12 +3,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.2.2"
 
-# Security audit our Gemfile.lock file for any vulnerable dependencies
-gem "bundler-audit"
-
-# A static analysis security vulnerability scanner for Ruby on Rails applications
-gem "brakeman"
-
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.6"
 
@@ -67,6 +61,12 @@ group :development, :test do
   gem "rubocop-govuk", require: false
 
   gem "rspec-rails"
+
+  # Security audit our Gemfile.lock file for any vulnerable dependencies
+  gem "bundler-audit"
+
+  # A static analysis security vulnerability scanner for Ruby on Rails applications
+  gem "brakeman"
 end
 
 group :development do


### PR DESCRIPTION
We don't need these gems installed when running apps in production.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?