### PR TITLE
Remove 'additional' from guidance_markdown column

### DIFF
--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -83,7 +83,7 @@ private
   end
 
   def additional_guidance_params
-    %i[page_heading additional_guidance_markdown]
+    %i[page_heading guidance_markdown]
   end
 
   def page_params

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -58,10 +58,10 @@ class Page < ApplicationRecord
 private
 
   def additional_guidance_fields
-    if page_heading.present? && additional_guidance_markdown.blank?
-      errors.add(:additional_guidance_markdown, "must be present when Page Heading is present")
-    elsif additional_guidance_markdown.present? && page_heading.blank?
-      errors.add(:page_heading, "must be present when Additional Guidance Markdown is present")
+    if page_heading.present? && guidance_markdown.blank?
+      errors.add(:guidance_markdown, "must be present when Page Heading is present")
+    elsif guidance_markdown.present? && page_heading.blank?
+      errors.add(:page_heading, "must be present when Guidance Markdown is present")
     end
   end
 end

--- a/db/migrate/20230822123702_change_additional_guidance_markdown_to_guidance_markdown.rb
+++ b/db/migrate/20230822123702_change_additional_guidance_markdown_to_guidance_markdown.rb
@@ -1,0 +1,5 @@
+class ChangeAdditionalGuidanceMarkdownToGuidanceMarkdown < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :pages, :additional_guidance_markdown, :guidance_markdown
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_04_113818) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_22_123702) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -77,7 +77,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_04_113818) do
     t.bigint "form_id"
     t.integer "position"
     t.text "page_heading"
-    t.text "additional_guidance_markdown"
+    t.text "guidance_markdown"
     t.index ["form_id"], name: "index_pages_on_form_id"
   end
 

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -21,11 +21,11 @@ FactoryBot.define do
     check_conditions { [] }
     goto_conditions { [] }
     page_heading { nil }
-    additional_guidance_markdown { nil }
+    guidance_markdown { nil }
 
     trait :with_additional_guidance do
       page_heading { Faker::Quote.yoda }
-      additional_guidance_markdown { "## List of items \n\n\n #{Faker::Markdown.ordered_list}" }
+      guidance_markdown { "## List of items \n\n\n #{Faker::Markdown.ordered_list}" }
     end
 
     trait :with_hints do

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -50,16 +50,16 @@ RSpec.describe Page, type: :model do
     end
 
     context "when additional_guidance_fields are provided" do
-      it "requires additional_guidance_markdown if page_heading is present" do
+      it "requires guidance_markdown if page_heading is present" do
         page.page_heading = "My new page heading"
         expect(page).to be_invalid
-        expect(page.errors[:additional_guidance_markdown]).to include("must be present when Page Heading is present")
+        expect(page.errors[:guidance_markdown]).to include("must be present when Page Heading is present")
       end
 
-      it "requires page_heading if additional_guidance_markdown is present" do
-        page.additional_guidance_markdown = "Some extra guidance for this question"
+      it "requires page_heading if guidance_markdown is present" do
+        page.guidance_markdown = "Some extra guidance for this question"
         expect(page).to be_invalid
-        expect(page.errors[:page_heading]).to include("must be present when Additional Guidance Markdown is present")
+        expect(page.errors[:page_heading]).to include("must be present when Guidance Markdown is present")
       end
     end
   end

--- a/spec/request/api/v1/pages_controller_spec.rb
+++ b/spec/request/api/v1/pages_controller_spec.rb
@@ -73,7 +73,7 @@ describe Api::V1::PagesController, type: :request do
                                                            created_at: "2023-01-01T12:00:00.000Z",
                                                            updated_at: "2023-01-01T12:00:00.000Z",
                                                            page_heading: nil,
-                                                           additional_guidance_markdown: nil).as_json)
+                                                           guidance_markdown: nil).as_json)
     end
 
     context "with params missing required keys" do


### PR DESCRIPTION
Renaming the `additional_guidance_markdown` column to `guidance_markdown`. There's a corresponding change to admin here https://github.com/alphagov/forms-admin/pull/602