### PR TITLE
Add additional_guidance_markdown column for deploy smoothing

### DIFF
--- a/db/migrate/20230824141905_add_additional_guidance_markdown_column.rb
+++ b/db/migrate/20230824141905_add_additional_guidance_markdown_column.rb
@@ -1,0 +1,5 @@
+class AddAdditionalGuidanceMarkdownColumn < ActiveRecord::Migration[7.0]
+  def change
+    add_column :pages, :additional_guidance_markdown, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_22_123702) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_24_141905) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -78,6 +78,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_22_123702) do
     t.integer "position"
     t.text "page_heading"
     t.text "guidance_markdown"
+    t.text "additional_guidance_markdown"
     t.index ["form_id"], name: "index_pages_on_form_id"
   end
 

--- a/spec/request/api/v1/pages_controller_spec.rb
+++ b/spec/request/api/v1/pages_controller_spec.rb
@@ -73,7 +73,8 @@ describe Api::V1::PagesController, type: :request do
                                                            created_at: "2023-01-01T12:00:00.000Z",
                                                            updated_at: "2023-01-01T12:00:00.000Z",
                                                            page_heading: nil,
-                                                           guidance_markdown: nil).as_json)
+                                                           guidance_markdown: nil,
+                                                           additional_guidance_markdown: nil).as_json)
     end
 
     context "with params missing required keys" do


### PR DESCRIPTION
In order to deploy the column name change more easily, this adds back the old column so that we can swap more gracefully