### PR TITLE
Rename additional_guidance* vars etc to guidance

### DIFF
--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -82,7 +82,7 @@ private
     end
   end
 
-  def additional_guidance_params
+  def guidance_params
     %i[page_heading guidance_markdown]
   end
 
@@ -94,7 +94,7 @@ private
       :answer_type,
       :next_page,
       :is_optional,
-      *additional_guidance_params,
+      *guidance_params,
       answer_setting_params,
     )
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -11,7 +11,7 @@ class Page < ApplicationRecord
 
   validates :question_text, presence: true
   validates :answer_type, presence: true, inclusion: { in: ANSWER_TYPES }
-  validate :additional_guidance_fields
+  validate :guidance_fields
 
   def destroy_and_update_form!
     form = self.form
@@ -57,7 +57,7 @@ class Page < ApplicationRecord
 
 private
 
-  def additional_guidance_fields
+  def guidance_fields
     if page_heading.present? && guidance_markdown.blank?
       errors.add(:guidance_markdown, "must be present when Page Heading is present")
     elsif guidance_markdown.present? && page_heading.blank?

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
     page_heading { nil }
     guidance_markdown { nil }
 
-    trait :with_additional_guidance do
+    trait :with_guidance do
       page_heading { Faker::Quote.yoda }
       guidance_markdown { "## List of items \n\n\n #{Faker::Markdown.ordered_list}" }
     end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Page, type: :model do
       expect(page.errors[:answer_type]).to include("is not included in the list")
     end
 
-    context "when additional_guidance_fields are provided" do
+    context "when guidance_fields are provided" do
       it "requires guidance_markdown if page_heading is present" do
         page.page_heading = "My new page heading"
         expect(page).to be_invalid


### PR DESCRIPTION
### What problem does this pull request solve?
We should no longer be referring to "additional guidance" in our codebase and instead should be referring to it as just guidance

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
