### PR TITLE
Add validation for guidance_markdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ WORKDIR /app
 RUN apk update
 RUN apk upgrade --available
 RUN apk add libc6-compat openssl-dev build-base libpq-dev
+# Adding git so that we can bundle install gems from github
+RUN apk add git
 RUN adduser -D ruby
 
 USER ruby

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ gem "bootsnap", require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem "rack-cors"
 
+# Our own custom markdown renderer
+gem "govuk-forms-markdown", github: "alphagov/govuk-forms-markdown", tag: "0.3.0"
+
 # For structured logging
 gem "lograge"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/alphagov/govuk-forms-markdown.git
+  revision: 673d4f1aea5328af7ed855dac75c156ebce92182
+  tag: 0.3.0
+  specs:
+    govuk-forms-markdown (0.3.0)
+      redcarpet (~> 3.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -213,6 +221,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    redcarpet (3.6.0)
     regexp_parser (2.6.1)
     reline (0.3.2)
       io-console (~> 0.5)
@@ -302,6 +311,7 @@ DEPENDENCIES
   debug
   factory_bot_rails
   faker
+  govuk-forms-markdown!
   lograge
   paper_trail
   pg (~> 1.5)

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -61,6 +61,31 @@ RSpec.describe Page, type: :model do
         expect(page).to be_invalid
         expect(page.errors[:page_heading]).to include("must be present when Guidance Markdown is present")
       end
+
+      context "when markdown is too long" do
+        it "adds an error to guidance_markdown" do
+          page.guidance_markdown = "ABC" * 5000
+          expect(page).to be_invalid
+          expect(page.errors[:guidance_markdown]).to include("is too long (maximum is 4999 characters)")
+        end
+      end
+
+      context "when markdown is using unsupported syntax" do
+        it "adds error to guidance_markdown" do
+          page.guidance_markdown = "# Heading level 1"
+          expect(page).to be_invalid
+          expect(page.errors[:guidance_markdown]).to include("can only contain formatting for links, subheadings(##), bulleted listed (*), or numbered lists(1.)")
+        end
+      end
+
+      context "when markdown is using unsupported syntax which is too long" do
+        it "adds error to guidance_markdown" do
+          page.guidance_markdown = "# Heading level 1\n\n" * 5000
+          expect(page).to be_invalid
+          expect(page.errors[:guidance_markdown]).to include("can only contain formatting for links, subheadings(##), bulleted listed (*), or numbered lists(1.)")
+          expect(page.errors[:guidance_markdown]).to include("is too long (maximum is 4999 characters)")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

We are pulling in `govuk-forms-markdown` gem for validations. Forms-admin will use the same validations that are in the gem but this is really a backstop to ensure that no invalid guidance_markdown is stored in the db and if it is invalid it should flag it up as an error.

Trello card: https://trello.com/c/CCmWlsUJ/958-implementing-markdown-in-forms-api

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
