### PR TITLE
Add max length validation to page question_text, hint_text and page_heading

### DIFF
--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -8,8 +8,6 @@ class Api::V1::PagesController < ApplicationController
 
     if new_page.save_and_update_form
       render json: { id: new_page.id }, status: :created
-    else
-      render json: new_page.errors.to_json, status: :bad_request
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::API
   include ActionController::HttpAuthentication::Token::ControllerMethods
 
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
+  rescue_from ActiveRecord::RecordInvalid, with: :invalid_record
   rescue_from ActionController::ParameterMissing, with: :missing_parameter
 
   before_action :set_content_type
@@ -59,5 +60,9 @@ private
 
   def missing_parameter(exception)
     render json: { error: exception.message }, status: :bad_request
+  end
+
+  def invalid_record(resource)
+    render json: resource.record.errors, status: :unprocessable_entity
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -18,6 +18,7 @@ class Page < ApplicationRecord
 
   validates :answer_type, presence: true, inclusion: { in: ANSWER_TYPES }
   validate :guidance_fields_presence
+  validates :page_heading, length: { maximum: 250 }
   validate :guidance_markdown_length_and_tags
 
   def destroy_and_update_form!

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -12,6 +12,8 @@ class Page < ApplicationRecord
   ANSWER_TYPES = %w[number address date email national_insurance_number phone_number selection organisation_name text name].freeze
 
   validates :question_text, presence: true
+  validates :question_text, length: { maximum: 250 }
+
   validates :answer_type, presence: true, inclusion: { in: ANSWER_TYPES }
   validate :guidance_fields_presence
   validate :guidance_markdown_length_and_tags

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -14,6 +14,8 @@ class Page < ApplicationRecord
   validates :question_text, presence: true
   validates :question_text, length: { maximum: 250 }
 
+  validates :hint_text, length: { maximum: 500 }
+
   validates :answer_type, presence: true, inclusion: { in: ANSWER_TYPES }
   validate :guidance_fields_presence
   validate :guidance_markdown_length_and_tags

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,9 @@ en:
           attributes:
             hint_text:
               too_long: "Hint text must be %{count} characters or less"
+            page_heading:
+              blank: Enter a page heading
+              too_long: "Page heading must be %{count} characters or less"
             question_text:
               blank: Question text cannot be blank
               too_long: "Question text must be %{count} characters or less"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,8 @@ en:
       models:
         page:
           attributes:
+            hint_text:
+              too_long: "Hint text must be %{count} characters or less"
             question_text:
               blank: Question text cannot be blank
               too_long: "Question text must be %{count} characters or less"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,9 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t "hello"
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t("hello") %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   "true": "foo"
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  activerecord:
+    errors:
+      models:
+        page:
+          attributes:
+            question_text:
+              blank: Question text cannot be blank
+              too_long: "Question text must be %{count} characters or less"

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -25,10 +25,40 @@ RSpec.describe Page, type: :model do
       expect(page).to be_valid
     end
 
-    it "requires question_text" do
-      page.question_text = nil
-      expect(page).to be_invalid
-      expect(page.errors[:question_text]).to include("can't be blank")
+    describe "#question_text" do
+      let(:page) { build :page, question_text: }
+      let(:question_text) { "What is your address?" }
+
+      it "is required" do
+        page.question_text = nil
+        expect(page).to be_invalid
+        expect(page.errors[:question_text]).to include(I18n.t("activerecord.errors.models.page.attributes.question_text.blank"))
+      end
+
+      it "is valid if question text below 250 characters" do
+        expect(page).to be_valid
+      end
+
+      context "when question text 250 characters" do
+        let(:question_text) { "A" * 250 }
+
+        it "is valid" do
+          expect(page).to be_valid
+        end
+      end
+
+      context "when question text more 250 characters" do
+        let(:question_text) { "A" * 251 }
+
+        it "is invalid" do
+          expect(page).not_to be_valid
+        end
+
+        it "has an error message" do
+          page.valid?
+          expect(page.errors[:question_text]).to include(I18n.t("activerecord.errors.models.page.attributes.question_text.too_long", count: 250))
+        end
+      end
     end
 
     it "requires form" do

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -127,6 +127,36 @@ RSpec.describe Page, type: :model do
         expect(page.errors[:page_heading]).to include("must be present when Guidance Markdown is present")
       end
 
+      describe "page_heading length validations" do
+        let(:page) { build :page, :with_guidance, page_heading: }
+        let(:page_heading) { "What is your address?" }
+
+        it "is valid if page heading below 500 characters" do
+          expect(page).to be_valid
+        end
+
+        context "when page heading 250 characters" do
+          let(:page_heading) { "A" * 250 }
+
+          it "is valid" do
+            expect(page).to be_valid
+          end
+        end
+
+        context "when page_heading more than 250 characters" do
+          let(:page_heading) { "A" * 251 }
+
+          it "is invalid" do
+            expect(page).not_to be_valid
+          end
+
+          it "has an error message" do
+            page.valid?
+            expect(page.errors[:page_heading]).to include(I18n.t("activerecord.errors.models.page.attributes.page_heading.too_long", count: 250))
+          end
+        end
+      end
+
       context "when markdown is too long" do
         it "adds an error to guidance_markdown" do
           page.guidance_markdown = "ABC" * 5000

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -61,6 +61,41 @@ RSpec.describe Page, type: :model do
       end
     end
 
+    describe "#hint_text" do
+      let(:page) { build :page, hint_text: }
+      let(:hint_text) { "Enter your full name as it appears in your passport" }
+
+      it "is valid if hint text is empty" do
+        page.hint_text = nil
+        expect(page).to be_valid
+      end
+
+      it "is valid if hint text below 500 characters" do
+        expect(page).to be_valid
+      end
+
+      context "when hint text 500 characters" do
+        let(:hint_text) { "A" * 500 }
+
+        it "is valid" do
+          expect(page).to be_valid
+        end
+      end
+
+      context "when hint text more than 500 characters" do
+        let(:hint_text) { "A" * 501 }
+
+        it "is invalid" do
+          expect(page).not_to be_valid
+        end
+
+        it "has an error message" do
+          page.valid?
+          expect(page.errors[:hint_text]).to include(I18n.t("activerecord.errors.models.page.attributes.hint_text.too_long", count: 500))
+        end
+      end
+    end
+
     it "requires form" do
       page.form_id = nil
       expect(page).to be_invalid


### PR DESCRIPTION
### What problem does this pull request solve?

Adding sensible hard limits to question_text, hint_text and page_heading

Trello card: https://trello.com/c/MAokcg4Y/1001-add-size-limit-to-question-text-pageheading-hint-text


### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
