### PR TITLE
Add make live validation

### DIFF
--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -37,8 +37,12 @@ class Api::V1::FormsController < ApplicationController
   end
 
   def make_live
-    form.make_live!
-    render json: { success: true }.to_json, status: :ok
+    if form.ready_for_live
+      form.make_live!
+      render json: { success: true }.to_json, status: :ok
+    else
+      render json: form.missing_sections.to_json, status: :forbidden
+    end
   end
 
   def show_live

--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -41,7 +41,7 @@ class Api::V1::FormsController < ApplicationController
       form.make_live!
       render json: { success: true }.to_json, status: :ok
     else
-      render json: form.missing_sections.to_json, status: :forbidden
+      render json: form.incomplete_tasks.to_json, status: :forbidden
     end
   end
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -52,7 +52,7 @@ class Form < ApplicationRecord
   end
 
   def as_json(options = {})
-    options[:methods] ||= %i[live_at start_page has_draft_version has_live_version has_routing_errors]
+    options[:methods] ||= %i[live_at start_page has_draft_version has_live_version has_routing_errors ready_for_live missing_sections task_statuses]
     super(options)
   end
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -52,7 +52,7 @@ class Form < ApplicationRecord
   end
 
   def as_json(options = {})
-    options[:methods] ||= %i[live_at start_page has_draft_version has_live_version has_routing_errors ready_for_live missing_sections task_statuses]
+    options[:methods] ||= %i[live_at start_page has_draft_version has_live_version has_routing_errors ready_for_live incomplete_tasks task_statuses]
     super(options)
   end
 
@@ -83,7 +83,7 @@ class Form < ApplicationRecord
     task_status_service.mandatory_tasks_completed?
   end
 
-  delegate :missing_sections, to: :task_status_service
+  delegate :incomplete_tasks, to: :task_status_service
 
   delegate :task_statuses, to: :task_status_service
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -78,4 +78,18 @@ class Form < ApplicationRecord
   def marking_complete_with_errors
     errors.add(:base, :has_validation_errors, message: "Form has routing validation errors") if question_section_completed && has_routing_errors
   end
+
+  def ready_for_live
+    task_status_service.mandatory_tasks_completed?
+  end
+
+  delegate :missing_sections, to: :task_status_service
+
+  delegate :task_statuses, to: :task_status_service
+
+private
+
+  def task_status_service
+    @task_status_service ||= TaskStatusService.new(form: self)
+  end
 end

--- a/app/service/task_status_service.rb
+++ b/app/service/task_status_service.rb
@@ -1,0 +1,87 @@
+class TaskStatusService
+  def initialize(form:)
+    @form = form
+  end
+
+  def name_status
+    :completed
+  end
+
+  def pages_status
+    if @form.question_section_completed && @form.pages.any?
+      :completed
+    elsif @form.pages.any?
+      :in_progress
+    else
+      :not_started
+    end
+  end
+
+  def declaration_status
+    if @form.declaration_section_completed
+      :completed
+    elsif @form.declaration_text.present?
+      :in_progress
+    else
+      :not_started
+    end
+  end
+
+  def what_happens_next_status
+    if @form.what_happens_next_text.present?
+      :completed
+    else
+      :not_started
+    end
+  end
+
+  def privacy_policy_status
+    if @form.privacy_policy_url.present?
+      :completed
+    else
+      :not_started
+    end
+  end
+
+  def support_contact_details_status
+    if @form.support_email.present? || @form.support_phone.present? || (@form.support_url_text.present? && @form.support_url)
+      :completed
+    else
+      :not_started
+    end
+  end
+
+  def make_live_status
+    if @form.has_draft_version
+      if mandatory_tasks_completed?
+        return :not_started
+      else
+        return :cannot_start
+      end
+    end
+    return :completed if @form.has_live_version
+  end
+
+  def mandatory_tasks_completed?
+    missing_sections.empty?
+  end
+
+  def missing_sections
+    { missing_pages: pages_status,
+      missing_what_happens_next: what_happens_next_status,
+      missing_privacy_policy_url: privacy_policy_status,
+      missing_contact_details: support_contact_details_status }.reject { |_k, v| v == :completed }.map { |k, _v| k }
+  end
+
+  def task_statuses
+    {
+      name_status:,
+      pages_status:,
+      declaration_status:,
+      what_happens_next_status:,
+      privacy_policy_status:,
+      support_contact_details_status:,
+      make_live_status:,
+    }
+  end
+end

--- a/app/service/task_status_service.rb
+++ b/app/service/task_status_service.rb
@@ -3,6 +3,31 @@ class TaskStatusService
     @form = form
   end
 
+  def mandatory_tasks_completed?
+    incomplete_tasks.empty?
+  end
+
+  def incomplete_tasks
+    { missing_pages: pages_status,
+      missing_what_happens_next: what_happens_next_status,
+      missing_privacy_policy_url: privacy_policy_status,
+      missing_contact_details: support_contact_details_status }.reject { |_k, v| v == :completed }.map { |k, _v| k }
+  end
+
+  def task_statuses
+    {
+      name_status:,
+      pages_status:,
+      declaration_status:,
+      what_happens_next_status:,
+      privacy_policy_status:,
+      support_contact_details_status:,
+      make_live_status:,
+    }
+  end
+
+private
+
   def name_status
     :completed
   end
@@ -53,35 +78,8 @@ class TaskStatusService
 
   def make_live_status
     if @form.has_draft_version
-      if mandatory_tasks_completed?
-        return :not_started
-      else
-        return :cannot_start
-      end
+      return mandatory_tasks_completed? ? :not_started : :cannot_start
     end
     return :completed if @form.has_live_version
-  end
-
-  def mandatory_tasks_completed?
-    missing_sections.empty?
-  end
-
-  def missing_sections
-    { missing_pages: pages_status,
-      missing_what_happens_next: what_happens_next_status,
-      missing_privacy_policy_url: privacy_policy_status,
-      missing_contact_details: support_contact_details_status }.reject { |_k, v| v == :completed }.map { |k, _v| k }
-  end
-
-  def task_statuses
-    {
-      name_status:,
-      pages_status:,
-      declaration_status:,
-      what_happens_next_status:,
-      privacy_policy_status:,
-      support_contact_details_status:,
-      make_live_status:,
-    }
   end
 end

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -50,6 +50,7 @@ FactoryBot.define do
 
     trait :live do
       ready_for_live
+      after(:create, &:make_live!)
     end
 
     trait :with_support do

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -42,6 +42,7 @@ FactoryBot.define do
     end
 
     trait :ready_for_live do
+      with_pages
       support_email { Faker::Internet.email(domain: "example.gov.uk") }
       what_happens_next_text { "We usually respond to applications within 10 working days." }
       question_section_completed { true }

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -273,4 +273,77 @@ RSpec.describe Form, type: :model do
       end
     end
   end
+
+  describe "#ready_for_live" do
+    context "when a form is complete and ready to be made live" do
+      let(:completed_form) { create(:form, :live) }
+
+      it "returns true" do
+        expect(completed_form.ready_for_live).to eq true
+      end
+    end
+
+    context "when a form is incomplete and should still be in draft state" do
+      let(:new_form) { build :form, :new_form }
+
+      [
+        {
+          attribute: :pages,
+          attribute_value: [],
+        },
+        {
+          attribute: :what_happens_next_text,
+          attribute_value: nil,
+        },
+        {
+          attribute: :privacy_policy_url,
+          attribute_value: nil,
+        },
+        {
+          attribute: :support_email,
+          attribute_value: nil,
+        },
+      ].each do |scenario|
+        it "returns false if #{scenario[:attribute]} is missing" do
+          new_form.send("#{scenario[:attribute]}=", scenario[:attribute_value])
+          expect(new_form.ready_for_live).to eq false
+        end
+      end
+    end
+  end
+
+  describe "#missing_sections" do
+    context "when a form is complete and ready to be made live" do
+      let(:completed_form) { build :form, :live }
+
+      it "returns no missing sections" do
+        expect(completed_form.missing_sections).to be_empty
+      end
+    end
+
+    context "when a form is incomplete and should still be in draft state" do
+      let(:new_form) { build :form, :new_form }
+
+      it "returns a set of keys related to missing fields" do
+        expect(new_form.missing_sections).to match_array(%i[missing_pages missing_privacy_policy_url missing_contact_details missing_what_happens_next])
+      end
+    end
+  end
+
+  describe "#task_statuses" do
+    let(:completed_form) { create(:form, :live) }
+
+    it "returns a hash with each of the task statuses" do
+      expected_hash = {
+        name_status: :completed,
+        pages_status: :completed,
+        declaration_status: :completed,
+        what_happens_next_status: :completed,
+        privacy_policy_status: :completed,
+        support_contact_details_status: :completed,
+        make_live_status: :completed,
+      }
+      expect(completed_form.task_statuses).to eq expected_hash
+    end
+  end
 end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -312,12 +312,12 @@ RSpec.describe Form, type: :model do
     end
   end
 
-  describe "#missing_sections" do
+  describe "#incomplete_tasks" do
     context "when a form is complete and ready to be made live" do
       let(:completed_form) { build :form, :live }
 
       it "returns no missing sections" do
-        expect(completed_form.missing_sections).to be_empty
+        expect(completed_form.incomplete_tasks).to be_empty
       end
     end
 
@@ -325,7 +325,7 @@ RSpec.describe Form, type: :model do
       let(:new_form) { build :form, :new_form }
 
       it "returns a set of keys related to missing fields" do
-        expect(new_form.missing_sections).to match_array(%i[missing_pages missing_privacy_policy_url missing_contact_details missing_what_happens_next])
+        expect(new_form.incomplete_tasks).to match_array(%i[missing_pages missing_privacy_policy_url missing_contact_details missing_what_happens_next])
       end
     end
   end

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -193,7 +193,7 @@ describe Api::V1::FormsController, type: :request do
         created_at: form1.created_at.as_json,
         updated_at: form1.updated_at.as_json,
         has_routing_errors: false,
-        missing_sections: %w[missing_pages missing_what_happens_next missing_privacy_policy_url missing_contact_details],
+        incomplete_tasks: %w[missing_pages missing_what_happens_next missing_privacy_policy_url missing_contact_details],
         ready_for_live: false,
         task_statuses: { declaration_status: "not_started", make_live_status: "cannot_start", name_status: "completed", pages_status: "not_started", privacy_policy_status: "not_started", support_contact_details_status: "not_started", what_happens_next_status: "not_started" },
       )

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -193,6 +193,9 @@ describe Api::V1::FormsController, type: :request do
         created_at: form1.created_at.as_json,
         updated_at: form1.updated_at.as_json,
         has_routing_errors: false,
+        missing_sections: %w[missing_pages missing_what_happens_next missing_privacy_policy_url missing_contact_details],
+        ready_for_live: false,
+        task_statuses: { declaration_status: "not_started", make_live_status: "cannot_start", name_status: "completed", pages_status: "not_started", privacy_policy_status: "not_started", support_contact_details_status: "not_started", what_happens_next_status: "not_started" },
       )
     end
   end
@@ -251,8 +254,18 @@ describe Api::V1::FormsController, type: :request do
   end
 
   describe "#make_live" do
+    context "when given a form with missing sections" do
+      it "doesn't make the form live" do
+        form_to_be_made_live = create(:form, :new_form)
+        post make_live_form_path(form_to_be_made_live), as: :json
+        expect(response.status).to eq(403)
+        expect(response.headers["Content-Type"]).to eq("application/json")
+        expect(json_body).to eq(%w[missing_pages missing_what_happens_next missing_privacy_policy_url missing_contact_details])
+      end
+    end
+
     it "when given a form, sets live_at to current time" do
-      form_to_be_made_live = create :form
+      form_to_be_made_live = create(:form, :ready_for_live)
       post make_live_form_path(form_to_be_made_live), as: :json
       expect(response.status).to eq(200)
       expect(response.headers["Content-Type"]).to eq("application/json")

--- a/spec/service/task_status_service_spec.rb
+++ b/spec/service/task_status_service_spec.rb
@@ -12,7 +12,7 @@ describe TaskStatusService do
       let(:form) { build(:form, :new_form) }
 
       it "returns the correct default value" do
-        expect(task_status_service.name_status).to eq :completed
+        expect(task_status_service.task_statuses[:name_status]).to eq :completed
       end
     end
 
@@ -21,7 +21,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form) }
 
         it "returns the correct default value" do
-          expect(task_status_service.pages_status).to eq :not_started
+          expect(task_status_service.task_statuses[:pages_status]).to eq :not_started
         end
       end
 
@@ -29,14 +29,14 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form, :with_pages, question_section_completed: false) }
 
         it "returns the in progress status" do
-          expect(task_status_service.pages_status).to eq :in_progress
+          expect(task_status_service.task_statuses[:pages_status]).to eq :in_progress
         end
 
         context "and questions marked completed" do
           let(:form) { build(:form, :new_form, :with_pages, question_section_completed: true) }
 
           it "returns the completed status" do
-            expect(task_status_service.pages_status).to eq :completed
+            expect(task_status_service.task_statuses[:pages_status]).to eq :completed
           end
         end
       end
@@ -47,7 +47,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form) }
 
         it "returns the correct default value" do
-          expect(task_status_service.declaration_status).to eq :not_started
+          expect(task_status_service.task_statuses[:declaration_status]).to eq :not_started
         end
       end
 
@@ -55,7 +55,7 @@ describe TaskStatusService do
         let(:form) { build(:form, declaration_section_completed: false) }
 
         it "returns the not started status" do
-          expect(task_status_service.declaration_status).to eq :not_started
+          expect(task_status_service.task_statuses[:declaration_status]).to eq :not_started
         end
       end
 
@@ -63,7 +63,7 @@ describe TaskStatusService do
         let(:form) { build(:form, declaration_text: "I understand the implications", declaration_section_completed: false) }
 
         it "returns the in progress status" do
-          expect(task_status_service.declaration_status).to eq :in_progress
+          expect(task_status_service.task_statuses[:declaration_status]).to eq :in_progress
         end
       end
 
@@ -71,7 +71,7 @@ describe TaskStatusService do
         let(:form) { build(:form, declaration_section_completed: true) }
 
         it "returns the completed status" do
-          expect(task_status_service.declaration_status).to eq :completed
+          expect(task_status_service.task_statuses[:declaration_status]).to eq :completed
         end
       end
     end
@@ -81,7 +81,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form) }
 
         it "returns the correct default value" do
-          expect(task_status_service.what_happens_next_status).to eq :not_started
+          expect(task_status_service.task_statuses[:what_happens_next_status]).to eq :not_started
         end
       end
 
@@ -89,7 +89,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form, what_happens_next_text: "We usually respond to applications within 10 working days.") }
 
         it "returns the in progress status" do
-          expect(task_status_service.what_happens_next_status).to eq :completed
+          expect(task_status_service.task_statuses[:what_happens_next_status]).to eq :completed
         end
       end
     end
@@ -99,7 +99,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form) }
 
         it "returns the correct default value" do
-          expect(task_status_service.privacy_policy_status).to eq :not_started
+          expect(task_status_service.task_statuses[:privacy_policy_status]).to eq :not_started
         end
       end
 
@@ -107,7 +107,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form, privacy_policy_url: Faker::Internet.url(host: "gov.uk")) }
 
         it "returns the in progress status" do
-          expect(task_status_service.privacy_policy_status).to eq :completed
+          expect(task_status_service.task_statuses[:privacy_policy_status]).to eq :completed
         end
       end
     end
@@ -117,7 +117,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form) }
 
         it "returns the correct default value" do
-          expect(task_status_service.support_contact_details_status).to eq :not_started
+          expect(task_status_service.task_statuses[:support_contact_details_status]).to eq :not_started
         end
       end
 
@@ -125,7 +125,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form, :with_support) }
 
         it "returns the in progress status" do
-          expect(task_status_service.support_contact_details_status).to eq :completed
+          expect(task_status_service.task_statuses[:support_contact_details_status]).to eq :completed
         end
       end
     end
@@ -135,7 +135,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :new_form) }
 
         it "returns the correct default value" do
-          expect(task_status_service.make_live_status).to eq :cannot_start
+          expect(task_status_service.task_statuses[:make_live_status]).to eq :cannot_start
         end
       end
 
@@ -143,7 +143,7 @@ describe TaskStatusService do
         let(:form) { build(:form, :ready_for_live) }
 
         it "returns the not started status" do
-          expect(task_status_service.make_live_status).to eq :not_started
+          expect(task_status_service.task_statuses[:make_live_status]).to eq :not_started
         end
       end
 
@@ -151,7 +151,7 @@ describe TaskStatusService do
         let(:form) { create(:form, :live) }
 
         it "returns the completed status" do
-          expect(task_status_service.make_live_status).to eq :completed
+          expect(task_status_service.task_statuses[:make_live_status]).to eq :completed
         end
       end
     end
@@ -175,12 +175,12 @@ describe TaskStatusService do
     end
   end
 
-  describe "#missing_sections" do
+  describe "#incomplete_tasks" do
     context "when mandatory tasks are complete" do
       let(:form) { build :form, :live }
 
       it "returns no missing sections" do
-        expect(task_status_service.missing_sections).to be_empty
+        expect(task_status_service.incomplete_tasks).to be_empty
       end
     end
 
@@ -188,7 +188,7 @@ describe TaskStatusService do
       let(:form) { build :form, :new_form }
 
       it "returns a set of keys related to missing fields" do
-        expect(task_status_service.missing_sections).to match_array(%i[missing_pages missing_privacy_policy_url missing_contact_details missing_what_happens_next])
+        expect(task_status_service.incomplete_tasks).to match_array(%i[missing_pages missing_privacy_policy_url missing_contact_details missing_what_happens_next])
       end
     end
   end

--- a/spec/service/task_status_service_spec.rb
+++ b/spec/service/task_status_service_spec.rb
@@ -1,0 +1,212 @@
+require "rails_helper"
+
+describe TaskStatusService do
+  let(:task_status_service) do
+    described_class.new(form:)
+  end
+
+  let(:current_user) { build(:user, role: :editor) }
+
+  describe "statuses" do
+    describe "name status" do
+      let(:form) { build(:form, :new_form) }
+
+      it "returns the correct default value" do
+        expect(task_status_service.name_status).to eq :completed
+      end
+    end
+
+    describe "pages status" do
+      context "with a new form" do
+        let(:form) { build(:form, :new_form) }
+
+        it "returns the correct default value" do
+          expect(task_status_service.pages_status).to eq :not_started
+        end
+      end
+
+      context "with a form which has pages" do
+        let(:form) { build(:form, :new_form, :with_pages, question_section_completed: false) }
+
+        it "returns the in progress status" do
+          expect(task_status_service.pages_status).to eq :in_progress
+        end
+
+        context "and questions marked completed" do
+          let(:form) { build(:form, :new_form, :with_pages, question_section_completed: true) }
+
+          it "returns the completed status" do
+            expect(task_status_service.pages_status).to eq :completed
+          end
+        end
+      end
+    end
+
+    describe "declaration status" do
+      context "with a new form" do
+        let(:form) { build(:form, :new_form) }
+
+        it "returns the correct default value" do
+          expect(task_status_service.declaration_status).to eq :not_started
+        end
+      end
+
+      context "with a form which has no declaration content and is marked incomplete" do
+        let(:form) { build(:form, declaration_section_completed: false) }
+
+        it "returns the not started status" do
+          expect(task_status_service.declaration_status).to eq :not_started
+        end
+      end
+
+      context "with a form which has declaration content and is marked incomplete" do
+        let(:form) { build(:form, declaration_text: "I understand the implications", declaration_section_completed: false) }
+
+        it "returns the in progress status" do
+          expect(task_status_service.declaration_status).to eq :in_progress
+        end
+      end
+
+      context "with a form which has a declaration marked complete" do
+        let(:form) { build(:form, declaration_section_completed: true) }
+
+        it "returns the completed status" do
+          expect(task_status_service.declaration_status).to eq :completed
+        end
+      end
+    end
+
+    describe "what happens next status" do
+      context "with a new form" do
+        let(:form) { build(:form, :new_form) }
+
+        it "returns the correct default value" do
+          expect(task_status_service.what_happens_next_status).to eq :not_started
+        end
+      end
+
+      context "with a form which has a what happens next section" do
+        let(:form) { build(:form, :new_form, what_happens_next_text: "We usually respond to applications within 10 working days.") }
+
+        it "returns the in progress status" do
+          expect(task_status_service.what_happens_next_status).to eq :completed
+        end
+      end
+    end
+
+    describe "privacy policy status" do
+      context "with a new form" do
+        let(:form) { build(:form, :new_form) }
+
+        it "returns the correct default value" do
+          expect(task_status_service.privacy_policy_status).to eq :not_started
+        end
+      end
+
+      context "with a form which has a privacy policy section" do
+        let(:form) { build(:form, :new_form, privacy_policy_url: Faker::Internet.url(host: "gov.uk")) }
+
+        it "returns the in progress status" do
+          expect(task_status_service.privacy_policy_status).to eq :completed
+        end
+      end
+    end
+
+    describe "support contact details status status" do
+      context "with a new form" do
+        let(:form) { build(:form, :new_form) }
+
+        it "returns the correct default value" do
+          expect(task_status_service.support_contact_details_status).to eq :not_started
+        end
+      end
+
+      context "with a form which has contact details set" do
+        let(:form) { build(:form, :new_form, :with_support) }
+
+        it "returns the in progress status" do
+          expect(task_status_service.support_contact_details_status).to eq :completed
+        end
+      end
+    end
+
+    describe "make live status" do
+      context "with a new form" do
+        let(:form) { build(:form, :new_form) }
+
+        it "returns the correct default value" do
+          expect(task_status_service.make_live_status).to eq :cannot_start
+        end
+      end
+
+      context "with a form which is ready to go live" do
+        let(:form) { build(:form, :ready_for_live) }
+
+        it "returns the not started status" do
+          expect(task_status_service.make_live_status).to eq :not_started
+        end
+      end
+
+      context "with a live form" do
+        let(:form) { create(:form, :live) }
+
+        it "returns the completed status" do
+          expect(task_status_service.make_live_status).to eq :completed
+        end
+      end
+    end
+  end
+
+  describe "#mandatory_tasks_completed" do
+    context "when mandatory tasks have not been completed" do
+      let(:form) { build(:form, :new_form) }
+
+      it "returns false" do
+        expect(task_status_service.mandatory_tasks_completed?).to eq false
+      end
+    end
+
+    context "when mandatory tasks have been completed" do
+      let(:form) { build(:form, :ready_for_live) }
+
+      it "returns true" do
+        expect(task_status_service.mandatory_tasks_completed?).to eq true
+      end
+    end
+  end
+
+  describe "#missing_sections" do
+    context "when mandatory tasks are complete" do
+      let(:form) { build :form, :live }
+
+      it "returns no missing sections" do
+        expect(task_status_service.missing_sections).to be_empty
+      end
+    end
+
+    context "when a form is incomplete and should still be in draft state" do
+      let(:form) { build :form, :new_form }
+
+      it "returns a set of keys related to missing fields" do
+        expect(task_status_service.missing_sections).to match_array(%i[missing_pages missing_privacy_policy_url missing_contact_details missing_what_happens_next])
+      end
+    end
+  end
+
+  describe "#task_statuses" do
+    let(:form) { create(:form, :live) }
+
+    it "returns a hash with each of the task statuses" do
+      expected_hash = {
+        name_status: :completed,
+        pages_status: :completed,
+        declaration_status: :completed,
+        what_happens_next_status: :completed,
+        privacy_policy_status: :completed,
+        support_contact_details_status: :completed,
+        make_live_status: :completed,
+      }
+      expect(task_status_service.task_statuses).to eq expected_hash
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?
Currently we have validation in forms-admin that prevents making a form live until certain conditions are met. However the api will happily make a form live if those conditions aren’t met.

This PR adds an updated task status service from forms-admin, and uses it validate the status of mandatory tasks prior to making a form live. It also adds task status data to the form data itself.

Unfortunately the submission email status depends on data in the forms-admin db, so this isn't included in the validation. Instead the submission email check is still done in forms-admin, and is combined with the `incomplete_tasks` and `task_statuses` from forms-api.

It would be great to hear other people's opinions on whether this refactor (in effect splitting the validation across forms-api and forms-admin) is preferable to duplicating the validation and removing the need to pass data back via the form object.

Trello card: https://trello.com/c/xEyusUhB

### Things to consider when reviewing

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
