### PR TITLE
Change API endpoints to respond with resource

### DIFF
--- a/app/controllers/api/v1/conditions_controller.rb
+++ b/app/controllers/api/v1/conditions_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::ConditionsController < ApplicationController
     new_condition = page.routing_conditions.new(condition_params)
 
     if new_condition.save_and_update_form
-      render json: { id: new_condition.id }, status: :created
+      render json: new_condition.to_json, status: :created
     else
       render json: new_condition.errors.to_json, status: :bad_request
     end
@@ -21,7 +21,7 @@ class Api::V1::ConditionsController < ApplicationController
     condition.assign_attributes(condition_params)
 
     if condition.save_and_update_form
-      render json: { success: true }.to_json, status: :ok
+      render json: condition.to_json, status: :ok
     else
       render json: page.errors.to_json, status: :bad_request
     end
@@ -29,7 +29,7 @@ class Api::V1::ConditionsController < ApplicationController
 
   def destroy
     condition.destroy_and_update_form!
-    render json: { success: true }.to_json, status: :ok
+    render status: :no_content
   end
 
 private

--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -39,7 +39,7 @@ class Api::V1::FormsController < ApplicationController
   def make_live
     if form.ready_for_live
       form.make_live!
-      render json: { success: true }.to_json, status: :ok
+      render json: form.live_version, status: :ok
     else
       render json: form.incomplete_tasks.to_json, status: :forbidden
     end

--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -56,7 +56,7 @@ class Api::V1::FormsController < ApplicationController
   def update_organisation_for_creator
     params.require(%i[creator_id organisation_id])
     Form.where(creator_id: params[:creator_id]).update_all(organisation_id: params[:organisation_id], updated_at: Time.zone.now)
-    render json: { success: true }.to_json, status: :ok
+    render status: :no_content
   end
 
 private

--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::FormsController < ApplicationController
   def create
     new_form = Form.new(form_params)
     if new_form.save
-      render json: { id: new_form.id }, status: :created # Fixup - just returning id here, could we return whole object?
+      render json: new_form.to_json, status: :created
     else
       render json: new_form.errors.to_json, status: :bad_request
     end
@@ -21,7 +21,7 @@ class Api::V1::FormsController < ApplicationController
 
   def update
     if form.update(form_params)
-      render json: { success: true }.to_json, status: :ok
+      render json: form.to_json, status: :ok
     else
       render json: form.errors.to_json, status: :bad_request
     end
@@ -33,7 +33,7 @@ class Api::V1::FormsController < ApplicationController
 
   def destroy
     form.destroy!
-    render json: { success: true }.to_json, status: :ok
+    render status: :no_content
   end
 
   def make_live

--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::PagesController < ApplicationController
       page.move_lower
       form.update!(question_section_completed: false)
     end
-    render json: { success: 1 }.to_json, status: :ok
+    render json: page.to_json, status: :ok
   end
 
   def move_up
@@ -41,7 +41,7 @@ class Api::V1::PagesController < ApplicationController
       page.move_higher
       form.update!(question_section_completed: false)
     end
-    render json: { success: 1 }.to_json, status: :ok
+    render json: page.to_json, status: :ok
   end
 
 private

--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::PagesController < ApplicationController
     new_page = form.pages.new(page_params)
 
     if new_page.save_and_update_form
-      render json: { id: new_page.id }, status: :created
+      render json: new_page.to_json, status: :created
     end
   end
 
@@ -19,13 +19,13 @@ class Api::V1::PagesController < ApplicationController
     page.assign_attributes(page_params)
 
     if page.save_and_update_form
-      render json: { success: true }.to_json, status: :ok
+      render json: page.to_json, status: :ok
     end
   end
 
   def destroy
     page.destroy_and_update_form!
-    render json: { success: true }.to_json, status: :ok
+    render status: :no_content
   end
 
   def move_down

--- a/spec/request/api/v1/conditions_controller_spec.rb
+++ b/spec/request/api/v1/conditions_controller_spec.rb
@@ -52,7 +52,7 @@ describe Api::V1::ConditionsController, type: :request do
     it "returns condition id, status code 201 when new condition created" do
       expect(response.status).to eq(201)
       expect(response.headers["Content-Type"]).to eq("application/json")
-      expect(json_body).to eq({ id: new_condition.id })
+      expect(json_body).to include(id: new_condition.id, **new_condition_params)
     end
 
     context "with a form with question_section_completed = true" do
@@ -116,7 +116,7 @@ describe Api::V1::ConditionsController, type: :request do
     it "returns correct response" do
       expect(response.status).to eq(200)
       expect(response.headers["Content-Type"]).to eq("application/json")
-      expect(json_body).to eq({ success: true })
+      expect(json_body).to include(**params)
       expect(condition.reload.answer_value).to eq(answer_value)
       expect(form.reload.question_section_completed).to be false
     end
@@ -128,9 +128,7 @@ describe Api::V1::ConditionsController, type: :request do
     end
 
     it "removes the condition and returns the correct response" do
-      expect(response.status).to eq(200)
-      expect(response.headers["Content-Type"]).to eq("application/json")
-      expect(json_body).to eq({ success: true })
+      expect(response.status).to eq(204)
       expect(routing_page.routing_conditions.count).to eq(0)
       expect(form.reload.question_section_completed).to be false
     end

--- a/spec/request/api/v1/conditions_controller_spec.rb
+++ b/spec/request/api/v1/conditions_controller_spec.rb
@@ -50,7 +50,7 @@ describe Api::V1::ConditionsController, type: :request do
     end
 
     it "returns condition id, status code 201 when new condition created" do
-      expect(response.status).to eq(201)
+      expect(response).to have_http_status(:created)
       expect(response.headers["Content-Type"]).to eq("application/json")
       expect(json_body).to include(id: new_condition.id, **new_condition_params)
     end
@@ -114,7 +114,7 @@ describe Api::V1::ConditionsController, type: :request do
     end
 
     it "returns correct response" do
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
       expect(response.headers["Content-Type"]).to eq("application/json")
       expect(json_body).to include(**params)
       expect(condition.reload.answer_value).to eq(answer_value)
@@ -128,7 +128,7 @@ describe Api::V1::ConditionsController, type: :request do
     end
 
     it "removes the condition and returns the correct response" do
-      expect(response.status).to eq(204)
+      expect(response).to have_http_status(:no_content)
       expect(routing_page.routing_conditions.count).to eq(0)
       expect(form.reload.question_section_completed).to be false
     end

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -99,7 +99,7 @@ describe Api::V1::FormsController, type: :request do
       it "returns a status code 201 when new form created" do
         expect(response.status).to eq(201)
         expect(response.headers["Content-Type"]).to eq("application/json")
-        expect(json_body).to eq(id: created_form[:id])
+        expect(json_body).to include(id: created_form[:id], **new_form_params)
       end
 
       it "created the form in the DB" do
@@ -125,7 +125,7 @@ describe Api::V1::FormsController, type: :request do
       it "returns a status code 201" do
         expect(response.status).to eq(201)
         expect(response.headers["Content-Type"]).to eq("application/json")
-        expect(json_body).to eq(id: created_form[:id])
+        expect(json_body).to include(id: created_form[:id], **new_form_params)
       end
 
       it "created the form in the DB" do
@@ -213,7 +213,7 @@ describe Api::V1::FormsController, type: :request do
       put form_path(form1), params: { submission_email: "test@example.gov.uk" }, as: :json
       expect(response.status).to eq(200)
       expect(response.headers["Content-Type"]).to eq("application/json")
-      expect(json_body).to eq(success: true)
+      expect(json_body).to include(submission_email: "test@example.gov.uk")
       expect(form1.reload.submission_email).to eq("test@example.gov.uk")
     end
 
@@ -239,17 +239,13 @@ describe Api::V1::FormsController, type: :request do
     it "when given an existing id, returns 200 and deletes the form from DB" do
       form_to_be_deleted = create :form
       delete form_path(form_to_be_deleted), as: :json
-      expect(response.status).to eq(200)
-      expect(response.headers["Content-Type"]).to eq("application/json")
-      expect(json_body).to eq({ success: true })
+      expect(response.status).to eq(204)
     end
 
     it "when given an existing id, returns 200 and deletes the form and any existing pages from DB" do
       form_to_be_deleted = create :form, :with_pages
       delete form_path(form_to_be_deleted), as: :json
-      expect(response.status).to eq(200)
-      expect(response.headers["Content-Type"]).to eq("application/json")
-      expect(json_body).to eq({ success: true })
+      expect(response.status).to eq(204)
     end
   end
 

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -97,7 +97,7 @@ describe Api::V1::FormsController, type: :request do
 
     context "with valid params" do
       it "returns a status code 201 when new form created" do
-        expect(response.status).to eq(201)
+        expect(response).to have_http_status(:created)
         expect(response.headers["Content-Type"]).to eq("application/json")
         expect(json_body).to include(id: created_form[:id], **new_form_params)
       end
@@ -123,7 +123,7 @@ describe Api::V1::FormsController, type: :request do
       let(:new_form_params) { { organisation_id: 1, name: "test form one", submission_email: "test@example.gov.uk", support_url: "http://example.org" } }
 
       it "returns a status code 201" do
-        expect(response.status).to eq(201)
+        expect(response).to have_http_status(:created)
         expect(response.headers["Content-Type"]).to eq("application/json")
         expect(json_body).to include(id: created_form[:id], **new_form_params)
       end
@@ -211,7 +211,7 @@ describe Api::V1::FormsController, type: :request do
     it "when given an valid id and params, updates DB and returns 200" do
       form1 = create :form
       put form_path(form1), params: { submission_email: "test@example.gov.uk" }, as: :json
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
       expect(response.headers["Content-Type"]).to eq("application/json")
       expect(json_body).to include(submission_email: "test@example.gov.uk")
       expect(form1.reload.submission_email).to eq("test@example.gov.uk")
@@ -239,13 +239,13 @@ describe Api::V1::FormsController, type: :request do
     it "when given an existing id, returns 200 and deletes the form from DB" do
       form_to_be_deleted = create :form
       delete form_path(form_to_be_deleted), as: :json
-      expect(response.status).to eq(204)
+      expect(response).to have_http_status(:no_content)
     end
 
     it "when given an existing id, returns 200 and deletes the form and any existing pages from DB" do
       form_to_be_deleted = create :form, :with_pages
       delete form_path(form_to_be_deleted), as: :json
-      expect(response.status).to eq(204)
+      expect(response).to have_http_status(:no_content)
     end
   end
 

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -250,6 +250,14 @@ describe Api::V1::FormsController, type: :request do
   end
 
   describe "#make_live" do
+    before do
+      freeze_time
+    end
+
+    after do
+      unfreeze_time
+    end
+
     context "when given a form with missing sections" do
       it "doesn't make the form live" do
         form_to_be_made_live = create(:form, :new_form)
@@ -265,7 +273,7 @@ describe Api::V1::FormsController, type: :request do
       post make_live_form_path(form_to_be_made_live), as: :json
       expect(response.status).to eq(200)
       expect(response.headers["Content-Type"]).to eq("application/json")
-      expect(json_body).to eq({ success: true })
+      expect(json_body).to include(live_at: Time.zone.now)
     end
   end
 

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -332,7 +332,7 @@ describe Api::V1::FormsController, type: :request do
 
     context "when some forms match creator ID" do
       it "updates organisation only if creator ID matches" do
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:no_content)
 
         all_forms.each do |form|
           form.reload
@@ -349,7 +349,7 @@ describe Api::V1::FormsController, type: :request do
       let(:selected_creator_id) { 321 }
 
       it "does not update organisation" do
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:no_content)
 
         all_forms.each do |form|
           form.reload

--- a/spec/request/api/v1/pages_controller_spec.rb
+++ b/spec/request/api/v1/pages_controller_spec.rb
@@ -276,7 +276,7 @@ describe Api::V1::PagesController, type: :request do
       it "returns correct response" do
         expect(response.status).to eq(200)
         expect(response.headers["Content-Type"]).to eq("application/json")
-        expect(json_body).to eq({ success: 1 })
+        expect(json_body).to include(position: page_to_move.position + 1)
       end
 
       it "changes order of pages returned" do
@@ -295,7 +295,7 @@ describe Api::V1::PagesController, type: :request do
       it "returns correct response" do
         expect(response.status).to eq(200)
         expect(response.headers["Content-Type"]).to eq("application/json")
-        expect(json_body).to eq({ success: 1 })
+        expect(json_body).to include(position: page_to_move.position)
       end
 
       it "does not change order of pages" do
@@ -327,7 +327,7 @@ describe Api::V1::PagesController, type: :request do
       it "returns correct response" do
         expect(response.status).to eq(200)
         expect(response.headers["Content-Type"]).to eq("application/json")
-        expect(json_body).to eq({ success: 1 })
+        expect(json_body).to include(position: page_to_move.position - 1)
       end
 
       it "changes order of pages returned" do
@@ -346,7 +346,7 @@ describe Api::V1::PagesController, type: :request do
       it "returns correct response" do
         expect(response.status).to eq(200)
         expect(response.headers["Content-Type"]).to eq("application/json")
-        expect(json_body).to eq({ success: 1 })
+        expect(json_body).to include(position: page_to_move.position)
       end
 
       it "does not change order of pages" do

--- a/spec/request/api/v1/pages_controller_spec.rb
+++ b/spec/request/api/v1/pages_controller_spec.rb
@@ -60,7 +60,7 @@ describe Api::V1::PagesController, type: :request do
     it "returns page id, status code 201 when new page created" do
       expect(response.status).to eq(201)
       expect(response.headers["Content-Type"]).to eq("application/json")
-      expect(json_body).to eq({ id: new_page.id })
+      expect(json_body).to include(id: new_page.id, **new_page_params.deep_symbolize_keys)
     end
 
     it "creates DB row with new_page_params, fresh id, form_id set and next_page: nil" do
@@ -159,7 +159,7 @@ describe Api::V1::PagesController, type: :request do
     it "returns correct response" do
       expect(response.status).to eq(200)
       expect(response.headers["Content-Type"]).to eq("application/json")
-      expect(json_body).to eq({ success: true })
+      expect(json_body).to include(**params)
       expect(page1.reload.question_text).to eq("updated page title")
       expect(form.reload.question_section_completed).to be false
     end
@@ -187,7 +187,7 @@ describe Api::V1::PagesController, type: :request do
         it "returns correct response" do
           expect(response.status).to eq(200)
           expect(response.headers["Content-Type"]).to eq("application/json")
-          expect(json_body).to eq({ success: true })
+          expect(json_body).to include(**params.deep_symbolize_keys)
           page1.reload
           expect(page1.answer_settings&.symbolize_keys).to eq(settings)
         end
@@ -208,9 +208,9 @@ describe Api::V1::PagesController, type: :request do
       it "returns correct response" do
         expect(response.status).to eq(200)
         expect(response.headers["Content-Type"]).to eq("application/json")
-        expect(json_body).to eq({ success: true })
+        expect(json_body).to include(**params.deep_symbolize_keys)
         page1.reload
-        expect(page1.answer_settings&.deep_symbolize_keys).to eq(answer_settings)
+        expect(page1.answer_settings.deep_symbolize_keys).to eq(answer_settings)
       end
     end
   end
@@ -229,9 +229,7 @@ describe Api::V1::PagesController, type: :request do
 
     context "with existing page" do
       it "removes page and returns correct response" do
-        expect(response.status).to eq(200)
-        expect(response.headers["Content-Type"]).to eq("application/json")
-        expect(json_body).to eq({ success: true })
+        expect(response.status).to eq(204)
         expect(form.pages.count).to eq(1)
         expect(form.reload.question_section_completed).to be false
       end

--- a/spec/request/api/v1/pages_controller_spec.rb
+++ b/spec/request/api/v1/pages_controller_spec.rb
@@ -58,7 +58,7 @@ describe Api::V1::PagesController, type: :request do
     end
 
     it "returns page id, status code 201 when new page created" do
-      expect(response.status).to eq(201)
+      expect(response).to have_http_status(:created)
       expect(response.headers["Content-Type"]).to eq("application/json")
       expect(json_body).to include(id: new_page.id, **new_page_params.deep_symbolize_keys)
     end
@@ -157,7 +157,7 @@ describe Api::V1::PagesController, type: :request do
     end
 
     it "returns correct response" do
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
       expect(response.headers["Content-Type"]).to eq("application/json")
       expect(json_body).to include(**params)
       expect(page1.reload.question_text).to eq("updated page title")
@@ -185,7 +185,7 @@ describe Api::V1::PagesController, type: :request do
         let(:answer_settings) { settings }
 
         it "returns correct response" do
-          expect(response.status).to eq(200)
+          expect(response).to have_http_status(:ok)
           expect(response.headers["Content-Type"]).to eq("application/json")
           expect(json_body).to include(**params.deep_symbolize_keys)
           page1.reload
@@ -206,7 +206,7 @@ describe Api::V1::PagesController, type: :request do
       end
 
       it "returns correct response" do
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(:ok)
         expect(response.headers["Content-Type"]).to eq("application/json")
         expect(json_body).to include(**params.deep_symbolize_keys)
         page1.reload
@@ -229,7 +229,7 @@ describe Api::V1::PagesController, type: :request do
 
     context "with existing page" do
       it "removes page and returns correct response" do
-        expect(response.status).to eq(204)
+        expect(response).to have_http_status(:no_content)
         expect(form.pages.count).to eq(1)
         expect(form.reload.question_section_completed).to be false
       end
@@ -274,7 +274,7 @@ describe Api::V1::PagesController, type: :request do
 
     context "with valid page" do
       it "returns correct response" do
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(:ok)
         expect(response.headers["Content-Type"]).to eq("application/json")
         expect(json_body).to include(position: page_to_move.position + 1)
       end
@@ -293,7 +293,7 @@ describe Api::V1::PagesController, type: :request do
       let(:page_to_move) { last_page }
 
       it "returns correct response" do
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(:ok)
         expect(response.headers["Content-Type"]).to eq("application/json")
         expect(json_body).to include(position: page_to_move.position)
       end
@@ -325,7 +325,7 @@ describe Api::V1::PagesController, type: :request do
 
     context "with valid page" do
       it "returns correct response" do
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(:ok)
         expect(response.headers["Content-Type"]).to eq("application/json")
         expect(json_body).to include(position: page_to_move.position - 1)
       end
@@ -344,7 +344,7 @@ describe Api::V1::PagesController, type: :request do
       let(:page_to_move) { first_page }
 
       it "returns correct response" do
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(:ok)
         expect(response.headers["Content-Type"]).to eq("application/json")
         expect(json_body).to include(position: page_to_move.position)
       end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/1Wr1DCBT <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

 We want the API to respond with a resource when requests are made, even if it's a request to update or delete an object. As well as being more in line with other APIs (see the JSON::API spec for example [[1]]), this will also let us reduce the number of requests we need to make in the admin app.

For the simple traditional CRUD (Create, Read, Update, and Delete) operations the conventional responses are prescribed in the JSON::API spec. For some of our endpoints, they don't really fit into the RESTful/CRUD model, so I've just gone with what I think is most predictable/useful.

Note that technically the changes in this PR are breaking changes and should result in a new API version, but currently our API is internal only and none of the consumers rely on the response body data, so no breakage has occured and I think we can get away without the version bump.

[1]: https://jsonapi.org/format/

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?

I've tested these changes locally and in dev using the end to end tests.