### PR TITLE
Log page ID with requests and improve logging of form ID

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,6 +30,7 @@ class ApplicationController < ActionController::API
                         elsif params[:form_id].present?
                           params[:form_id]
                         end
+    payload[:page_id] = params[:page_id] if params[:page_id].present?
   end
 
 private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,11 @@ class ApplicationController < ActionController::API
     payload[:host] = request.host
     payload[:request_id] = request.request_id
     payload[:requested_by] = "#{@access_token.owner}-#{@access_token.id}" if @access_token.present?
-    payload[:form_id] = params[:form_id] if params[:form_id].present?
+    payload[:form_id] = if params[:id].present?
+                          params[:id]
+                        elsif params[:form_id].present?
+                          params[:form_id]
+                        end
   end
 
 private

--- a/config/application.rb
+++ b/config/application.rb
@@ -61,6 +61,7 @@ module FormsApi
         h[:request_id] = event.payload[:request_id]
         h[:requested_by] = event.payload[:requested_by] if event.payload[:requested_by]
         h[:form_id] = event.payload[:form_id] if event.payload[:form_id]
+        h[:page_id] = event.payload[:page_id] if event.payload[:page_id]
         h[:params] = event.payload[:params].except(:controller, :action)
         h[:exception] = event.payload[:exception] if event.payload[:exception]
       end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

When searching Splunk for requests related to a particular page of a form it would be nice to be able to construct a query with `page_id=n`.

This PR adds the page ID to the log event JSON payload so that this will be possible in future.

See https://github.com/alphagov/forms-runner/pull/431 and https://github.com/alphagov/forms-admin/pull/668 for similar PRs for the runner and admin apps.

While adding this functionality I also noticed that we're not consistently logging `form_id` with every request, because the name of the param changes depending on the route. This PR also tries to fix that, so we get the `form_id` key in all relevant requests.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?