### PR TITLE
Remove Alpine edge repositories from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,6 @@ ENV RAILS_ENV="${RAILS_ENV:-production}" \
 
 WORKDIR /app
 
-# Edge repo is necessary for openssl 3
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
 RUN apk update
 RUN apk upgrade --available
 RUN apk add libc6-compat openssl-dev libpq


### PR DESCRIPTION

### What problem does this pull request solve?

In commit 6979388 we used both the stable and edge repos for Alpine because we wanted OpenSSL 3 in our app image. However, OpenSSL 3 is the default version of OpenSSL in Alpine 3.17.0 [[1]]. So we no longer have a need for edge.

With Alpine 3.17 at the time of this commit fetching the edge repo index fails, so building this Dockerfile fails with the error:

```
Step 24/35 : RUN apk update
 ---> Running in 247913f7587d
fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/community/aarch64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/edge/main/aarch64/APKINDEX.tar.gz
ERROR: http://dl-cdn.alpinelinux.org/alpine/edge/main: BAD signature
WARNING: Ignoring http://dl-cdn.alpinelinux.org/alpine/edge/main: No such file or directory
v3.17.5-107-g07fd110f6bf [https://dl-cdn.alpinelinux.org/alpine/v3.17/main]
v3.17.5-108-gfe9a155566d [https://dl-cdn.alpinelinux.org/alpine/v3.17/community]
1 errors; 17699 distinct packages available
The command ‘/bin/sh -c apk update’ returned a non-zero code: 1
```

The Alpine wiki says that

> Warning: Do not enable stable and edge repos at the same time. This can break your system. Either use edge or stable.

[[2]].

As we no longer need the edge repos, and it does not appear to work,
this commit removes the use of edge from the Dockerfile.

[1]: https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.17.0
[2]: https://wiki.alpinelinux.org/wiki/Repositories



### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?