### PR TITLE
Fix logging of form_id in FormsController

### DIFF
--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -1,4 +1,9 @@
 class Api::V1::FormsController < ApplicationController
+  def append_info_to_payload(payload)
+    super
+    payload[:form_id] = params[:id] if params[:id].present?
+  end
+
   def index
     organisation_id = params[:organisation_id]
     creator_id = params[:creator_id]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,11 +25,7 @@ class ApplicationController < ActionController::API
     payload[:host] = request.host
     payload[:request_id] = request.request_id
     payload[:requested_by] = "#{@access_token.owner}-#{@access_token.id}" if @access_token.present?
-    payload[:form_id] = if params[:id].present?
-                          params[:id]
-                        elsif params[:form_id].present?
-                          params[:form_id]
-                        end
+    payload[:form_id] = params[:form_id] if params[:form_id].present?
     payload[:page_id] = params[:page_id] if params[:page_id].present?
   end
 

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -24,6 +24,19 @@ describe Api::V1::FormsController, type: :request do
     all_forms
   end
 
+  describe "#append_info_to_payload" do
+    it "adds :id to payload as :form_id" do
+      payload = nil
+      ActiveSupport::Notifications.subscribe("process_action.action_controller") do |_name, _start, _finish, _id, payload_|
+        payload = payload_
+      end
+
+      get form_path(id: 987), as: :json
+
+      expect(payload).to include form_id: "987"
+    end
+  end
+
   describe "#index" do
     it "when no forms exist for an organisation, returns 200 and an empty json array" do
       get(forms_path, params: { organisation_id: 3 }, headers:)


### PR DESCRIPTION
### What problem does this pull request solve?
<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

For requests that are routed to the FormsController, the form ID is named `:id` rather than `:form_id`, so the logging setup needs to be slightly different. This commit adds a specialisation of the `append_info_to_payload` method to the `FormsController` class so we get the correct behaviour when necessary.

Thanks @thomasiles for pointing out the issue and suggesting that we can use OOP to fix this (see https://github.com/alphagov/forms-api/pull/339#discussion_r1358180399).


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?