### PR TITLE
Rename param for access tokens route

### DIFF
--- a/app/controllers/api/v1/access_tokens_controller.rb
+++ b/app/controllers/api/v1/access_tokens_controller.rb
@@ -6,9 +6,9 @@ class Api::V1::AccessTokensController < ApplicationController
 
   def create
     @access_token = AccessToken.new(token_params)
-    users_token = @access_token.generate_token
+    token = @access_token.generate_token
     if @access_token.save
-      render json: { token: users_token }.to_json, status: :created
+      render json: { **@access_token.as_json, token: }.to_json, status: :created
     else
       render json: @access_token.errors.to_json, status: :bad_request
     end
@@ -17,7 +17,8 @@ class Api::V1::AccessTokensController < ApplicationController
   def deactivate
     @access_token = AccessToken.find(token_deactivate_params)
     @access_token.update!(deactivated_at: Time.zone.now)
-    render json: { status: "`#{@access_token.owner}` has been deactivated" }.to_json, status: :ok
+    status = "`#{@access_token.owner}` has been deactivated"
+    render json: { **@access_token.as_json, status: }.to_json, status: :ok
   end
 
   def caller_identity

--- a/app/controllers/api/v1/access_tokens_controller.rb
+++ b/app/controllers/api/v1/access_tokens_controller.rb
@@ -35,6 +35,6 @@ private
   end
 
   def token_deactivate_params
-    params.require(:id)
+    params.require(:token_id)
   end
 end

--- a/app/controllers/api/v1/access_tokens_controller.rb
+++ b/app/controllers/api/v1/access_tokens_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::AccessTokensController < ApplicationController
   def index
     @access_tokens = AccessToken.all
-    render json: @access_tokens.as_json(except: [:token_digest]).to_json, status: :ok
+    render json: @access_tokens.to_json, status: :ok
   end
 
   def create
@@ -22,7 +22,7 @@ class Api::V1::AccessTokensController < ApplicationController
 
   def caller_identity
     if @access_token
-      render json: @access_token.to_json, status: :ok
+      render json: @access_token.to_json(except: []), status: :ok
     else
       render json: { error: "Not found - No token used." }.to_json, status: :not_found
     end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -8,4 +8,9 @@ class AccessToken < ApplicationRecord
     self.token_digest = Digest::SHA256.hexdigest(users_token)
     users_token
   end
+
+  def as_json(options = {})
+    options[:except] ||= [:token_digest]
+    super
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
       put "/pages/:page_id/up", to: "api/v1/pages#move_up", as: :move_page_up
     end
 
-    resources :access_tokens, path: "access-tokens", controller: "api/v1/access_tokens", only: %i[index create] do
+    resources :access_tokens, path: "access-tokens", controller: "api/v1/access_tokens", only: %i[index create], param: :token_id do
       member do
         put "/deactivate", to: "api/v1/access_tokens#deactivate"
       end

--- a/spec/request/api/v1/access_tokens_controller_spec.rb
+++ b/spec/request/api/v1/access_tokens_controller_spec.rb
@@ -27,12 +27,14 @@ describe Api::V1::AccessTokensController, type: :request do
 
   describe "#create" do
     before do
-      allow(AccessToken).to receive(:new).and_return(OpenStruct.new(save: true, generate_token: "test-token"))
+      token = build(:access_token, id: 1)
+      allow(token).to receive(:generate_token).and_return("test-token")
+      allow(AccessToken).to receive(:new).and_return(token)
       post access_tokens_path, params: { owner: "testing user" }, as: :json
     end
 
     it "returns a user token" do
-      expect(response.body).to eq({ token: "test-token" }.to_json)
+      expect(response.parsed_body).to include({ "id" => 1, "token" => "test-token" })
     end
 
     it "returns 201 if its saved" do
@@ -82,7 +84,7 @@ describe Api::V1::AccessTokensController, type: :request do
     end
 
     it "returns a status message" do
-      expect(json_body).to eq({ status: "`#{access_token.owner}` has been deactivated" })
+      expect(json_body).to include(status: "`#{access_token.owner}` has been deactivated")
     end
 
     context "when access token is not found" do


### PR DESCRIPTION
### What problem does this pull request solve?

Renames the name of the placeholder in the routes for access tokens from `:id` to `:token_id`, to make it harder to confuse the parameter with the form ID of other routes.

I also expanded the responses from the access token endpoints so that you actually get the ID when you create a token.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?