### PR TITLE
Use dependabot to update all dependencies, including dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,6 @@ updates:
   # Maintain dependencies for Ruby/Rails bundler
   - package-ecosystem: "bundler"
     directory: "/"
-    allow:
-      - dependency-type: "production"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10


### PR DESCRIPTION
We recently agreed in Tech Weekly that we would use Dependabot to update dev dependencies [[1](https://docs.google.com/document/d/1iHfUoCzgg-2Mk9wbi5o46fFVRak_R6nNQ2m8OqSz_hs/edit#heading=h.7s0kdy18xg3s)].

This PR removes the configuration lines that restricted Dependabot to updating only production dependencies. If we find this causes too much noise, we may refine the configuration again in future, but for now lets just see how it goes.