### PR TITLE
Add database seed with all question types form

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,70 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+
+submission_email = ENV["EMAIL"] || `git config --get user.email`.strip
+organisation_id = 1 # Assumes you're using the default database seed for forms-admin
+
+all_question_types_form = Form.create!(
+  name: "All question types form",
+  pages: [
+    Page.create(
+      question_text: "Single line of text",
+      answer_type: "text",
+      answer_settings: {
+        input_type: "single_line",
+      },
+    ),
+    Page.create(
+      question_text: "Number",
+      answer_type: "number",
+    ),
+    Page.create(
+      question_text: "Address",
+      answer_type: "address",
+      answer_settings: {
+        input_type: {
+          international_address: false,
+          uk_address: true,
+        },
+      },
+    ),
+    Page.create(
+      question_text: "Email address",
+      answer_type: "email",
+    ),
+    Page.create(
+      question_text: "Todays Date",
+      answer_type: "date",
+      answer_settings: {
+        input_type: "other_date",
+      },
+    ),
+    Page.create(
+      question_text: "National Insurance number",
+      answer_type: "national_insurance_number",
+    ),
+    Page.create(
+      question_text: "Phone number",
+      answer_type: "phone_number",
+    ),
+    Page.create(
+      question_text: "Multiple lines of text",
+      answer_type: "text",
+      answer_settings: {
+        input_type: "long_text",
+      },
+      is_optional: true,
+    ),
+  ],
+  question_section_completed: true,
+  declaration_text: "",
+  declaration_section_completed: true,
+  organisation_id:,
+  privacy_policy_url: "https://www.gov.uk/help/privacy-notice",
+  submission_email:,
+  support_email: "your.email+fakedata84701@gmail.com.gov.uk",
+  support_phone: "08000800",
+  what_happens_next_text: "Test",
+)
+all_question_types_form.make_live!

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -53,6 +53,19 @@ all_question_types_form = Form.create!(
       answer_type: "phone_number",
     ),
     Page.create(
+      question_text: "Selection from a list of options",
+      answer_type: "selection",
+      answer_settings: {
+        "only_one_option": "0", # TODO: investigate why we set this to "0"
+        "selection_options": [
+          { "name": "Option 1" },
+          { "name": "Option 2" },
+          { "name": "Option 3" },
+        ],
+      },
+      is_optional: true, # Include an option for 'None of the above'
+    ),
+    Page.create(
       question_text: "Multiple lines of text",
       answer_type: "text",
       answer_settings: {


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Make it quicker to get a useful test form created when doing local development.

This PR adds a copy of @DavidBiddle's 'All question types' form that already exists in dev at `/forms/71/live`. If you want to add this to your database you can simply run `rails db:seed`


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?