### PR TITLE
Add code that makes forms un-live

### DIFF
--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -50,6 +50,15 @@ class Api::V1::FormsController < ApplicationController
     end
   end
 
+  def make_unlive
+    if form.has_live_version
+      form.make_unlive!
+      render json: form, status: :ok
+    else
+      render json: { error: "Form has no live version" }, status: :bad_request
+    end
+  end
+
   def show_live
     render json: form.live_version, status: :ok
   end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -87,6 +87,10 @@ class Form < ApplicationRecord
 
   delegate :task_statuses, to: :task_status_service
 
+  def make_unlive!
+    made_live_forms.destroy_all
+  end
+
 private
 
   def task_status_service

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,9 +8,10 @@ Rails.application.routes.draw do
   scope "api/v1" do
     resources :forms, controller: "api/v1/forms" do
       member do
-        post "/make-live", to: "api/v1/forms#make_live"
-        get "/live", to: "api/v1/forms#show_live"
         get "/draft", to: "api/v1/forms#show_draft"
+        get "/live", to: "api/v1/forms#show_live"
+        post "/make-live", to: "api/v1/forms#make_live"
+        post "/make-unlive", to: "api/v1/forms#make_unlive"
       end
 
       collection do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -159,6 +159,20 @@ RSpec.describe Form, type: :model do
     end
   end
 
+  describe ".make_unlive!" do
+    let(:made_live_form) { create :made_live_form }
+    let(:form) { made_live_form.form }
+
+    it "deletes the made live version" do
+      expect { form.make_unlive! }.to change { MadeLiveForm.exists?(made_live_form.id) }.to(false)
+    end
+
+    it "sets the live_at to nil" do
+      form.make_unlive!
+      expect(form.live_at).to be_nil
+    end
+  end
+
   describe "#has_draft_version" do
     let(:live_form) { create(:made_live_form).form }
     let(:new_form) { create(:form) }

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -290,6 +290,17 @@ describe Api::V1::FormsController, type: :request do
     end
   end
 
+  describe "make unlive" do
+    it "makes a live form unlive" do
+      form = (create :made_live_form).form
+      post make_unlive_form_path(form), as: :json
+
+      expect(response.status).to eq(200)
+      expect(response.headers["Content-Type"]).to eq("application/json")
+      expect(json_body).to include(live_at: nil)
+    end
+  end
+
   describe "#show_live" do
     it "returns the actual made live version which includes pages" do
       made_live_form = create :made_live_form


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/E6iLOdFK/1180-add-a-un-alive-switch-for-a-form

If a form hits any sort of trouble, we need a reliable way to make it offline

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
