### PR TITLE
Add rake task to make a form not live

### DIFF
--- a/lib/tasks/forms_admin.rake
+++ b/lib/tasks/forms_admin.rake
@@ -1,0 +1,16 @@
+namespace :forms_admin do
+  desc "Unlive a form"
+  task :make_unlive, [:form_id] => :environment do |_, args|
+    form = Form.find(args[:form_id])
+
+    if form.made_live_forms.empty?
+      puts "Form #{form.name} is not live" unless Rails.env.test?
+      exit
+    end
+
+    form.make_unlive!
+    form.reload
+
+    puts "Unlived form #{form.name}" unless Rails.env.test?
+  end
+end

--- a/spec/lib/tasks/forms_admin_spec.rb
+++ b/spec/lib/tasks/forms_admin_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "forms_admin.rake" do
+  describe "forms_admin:make_unlive", type: :task do
+    before do
+      Rake.application.rake_require "tasks/forms_admin"
+      Rake::Task.define_task(:environment)
+    end
+
+    it "makes a given form unlive" do
+      form = create(:made_live_form).form
+      expect(form.has_live_version).to be true
+
+      Rake::Task["forms_admin:make_unlive"].invoke(form.id)
+
+      form.reload
+      expect(form.has_live_version).to be false
+    end
+
+    it "does not make a form unlive if it has no live version" do
+      form = create(:form)
+      expect(form.has_live_version).to be false
+
+      Rake::Task["forms_admin:make_unlive"].invoke(form.id)
+
+      form.reload
+      expect(form.has_live_version).to be false
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

This is a follow on from https://github.com/alphagov/forms-api/pull/363 and adds a rake task to call that code to make a form no longer live.

Trello card: https://trello.com/c/E6iLOdFK/1180-add-a-un-alive-switch-for-a-form

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
