### PR TITLE
Remove timestamp constraint

### DIFF
--- a/db/migrate/20221216112945_create_forms.rb
+++ b/db/migrate/20221216112945_create_forms.rb
@@ -1,6 +1,6 @@
 class CreateForms < ActiveRecord::Migration[7.0]
   def change
-    create_table :forms, if_not_exists: true do |t|
+    create_table :forms do |t|
       t.text :name
       t.text :submission_email
       t.text :org

--- a/db/migrate/20221219153156_create_pages.rb
+++ b/db/migrate/20221219153156_create_pages.rb
@@ -1,6 +1,6 @@
 class CreatePages < ActiveRecord::Migration[7.0]
   def change
-    create_table :pages, if_not_exists: true do |t|
+    create_table :pages do |t|
       t.text :question_text
       t.text :question_short_name
       t.text :hint_text
@@ -12,7 +12,6 @@ class CreatePages < ActiveRecord::Migration[7.0]
       t.timestamps
     end
 
-    add_reference :pages, :form, foreign_key: true, if_not_exists: true
-    add_timestamps(:pages, default: Time.zone.now, if_not_exists: true)
+    add_reference :pages, :form, foreign_key: true
   end
 end


### PR DESCRIPTION
These were only made explicit to support a potential rollback to Grape as we migrated from there to Rails in the past. However this is now causing us issues as part of our Rails 7.1 upgrade [1]

[1]: https://github.com/alphagov/forms-api/actions/runs/6876807358/job/18703161928?pr=369

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
