### PR TITLE
Add empty what happens next markdown field

### DIFF
--- a/db/migrate/20231116142411_add_what_happens_next_markdown_to_forms.rb
+++ b/db/migrate/20231116142411_add_what_happens_next_markdown_to_forms.rb
@@ -1,0 +1,20 @@
+class AddWhatHappensNextMarkdownToForms < ActiveRecord::Migration[7.0]
+  def change
+    add_column :forms, :what_happens_next_markdown, :text
+
+    reversible do |direction|
+      MadeLiveForm.find_each do |made_live_form|
+        form_blob = JSON.parse(made_live_form.json_form_blob, symbolize_names: true)
+
+        direction.up do
+          form_blob[:what_happens_next_markdown] = nil
+        end
+        direction.down do
+          form_blob.delete(:what_happens_next_markdown)
+        end
+
+        made_live_form.update!(json_form_blob: form_blob.to_json)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_24_153800) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_16_142411) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,6 +55,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_24_153800) do
     t.datetime "updated_at", null: false
     t.bigint "creator_id"
     t.bigint "organisation_id"
+    t.text "what_happens_next_markdown"
   end
 
   create_table "made_live_forms", force: :cascade do |t|

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -261,6 +261,7 @@ RSpec.describe Form, type: :model do
         "declaration_section_completed",
         "pages",
         "page_order",
+        "what_happens_next_markdown",
       )
     end
   end

--- a/spec/request/api/v1/forms_controller_spec.rb
+++ b/spec/request/api/v1/forms_controller_spec.rb
@@ -195,6 +195,7 @@ describe Api::V1::FormsController, type: :request do
         form_slug: "test-form-1",
         start_page: nil,
         what_happens_next_text: nil,
+        what_happens_next_markdown: nil,
         support_email: nil,
         support_phone: nil,
         support_url: nil,


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/AbPj2LRr/1191-allow-markdown-on-confirmation-page-what-happens-next-content

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Adds a null `what_happens_next_markdown` field to the form. Also adds this null field to the most recent `made_live_form`.

To do in other PRs:
- add logic in the runner (https://github.com/alphagov/forms-runner/pull/496) and admin to use the markdown field if it's present, and the HTML if not 
- convert the HTML content in the API into markdown and store it in this new field
- cleanup: delete the old field and all the logic related to it which we no longer need

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
