### PR TITLE
Use what_happens_next markdown in task completion check

### DIFF
--- a/app/service/task_status_service.rb
+++ b/app/service/task_status_service.rb
@@ -53,7 +53,7 @@ private
   end
 
   def what_happens_next_status
-    if @form.what_happens_next_text.present?
+    if @form.what_happens_next_text.present? || @form.what_happens_next_markdown.present?
       :completed
     else
       :not_started

--- a/spec/service/task_status_service_spec.rb
+++ b/spec/service/task_status_service_spec.rb
@@ -85,10 +85,18 @@ describe TaskStatusService do
         end
       end
 
-      context "with a form which has a what happens next section" do
+      context "with a form which has a what_happens_next_text" do
         let(:form) { build(:form, :new_form, what_happens_next_text: "We usually respond to applications within 10 working days.") }
 
-        it "returns the in progress status" do
+        it "returns the completed status" do
+          expect(task_status_service.task_statuses[:what_happens_next_status]).to eq :completed
+        end
+      end
+
+      context "with a form which has a what_happens_next_markdown" do
+        let(:form) { build(:form, :new_form, what_happens_next_markdown: "We usually respond to applications within 10 working days.") }
+
+        it "returns the completed status" do
           expect(task_status_service.task_statuses[:what_happens_next_status]).to eq :completed
         end
       end


### PR DESCRIPTION
### What problem does this pull request solve?

As part of the ready_for_live check we test whether the form user has provided what happens next information. This previously only checked whether the what_happens_next_text field was populated, but we also want it to return true if what_happens_next markdown is populated as well.

Trello card: <!-- link -->Part of https://trello.com/c/AbPj2LRr/1191-allow-markdown-on-confirmation-page-what-happens-next-content

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
