### PR TITLE
Convert what happens next content to markdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,3 +81,5 @@ group :test do
   # Code coverage reporter
   gem "simplecov", require: false
 end
+
+gem "reverse_markdown", "~> 2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,6 +234,8 @@ GEM
       io-console (~> 0.5)
     request_store (1.5.1)
       rack (>= 1.4)
+    reverse_markdown (2.1.1)
+      nokogiri
     rexml (3.2.6)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
@@ -332,6 +334,7 @@ DEPENDENCIES
   pg (~> 1.5)
   puma (~> 6.4)
   rails (~> 7.0.8)
+  reverse_markdown (~> 2.1)
   rspec-rails
   rubocop-govuk
   sentry-rails

--- a/lib/tasks/what_happens_next_markdown.rake
+++ b/lib/tasks/what_happens_next_markdown.rake
@@ -1,0 +1,65 @@
+class TextHelpers
+  include ActionView::Helpers::TextHelper
+end
+
+namespace :what_happens_next_markdown do
+  desc "Populate what_happens_next_markdown field"
+  task populate: :environment do
+    Form.find_each do |form|
+      formatted_html = TextHelpers.new.simple_format(
+        form.what_happens_next_text,
+        {},
+        sanitize: true,
+        sanitize_options: {
+          tags: %w[a ol ul li p],
+          attributes: %w[href class rel target title],
+        },
+      )
+      markdown = ReverseMarkdown.convert(formatted_html).strip
+      form.what_happens_next_markdown = form.what_happens_next_text.blank? ? "" : markdown
+
+      form.made_live_forms.each do |made_live_form|
+        form_blob = JSON.parse(made_live_form.json_form_blob, symbolize_names: true)
+
+        formatted_html = TextHelpers.new.simple_format(
+          form_blob[:what_happens_next_text],
+          {},
+          sanitize: true,
+          sanitize_options: {
+            tags: %w[a ol ul li p],
+            attributes: %w[href class rel target title],
+          },
+        )
+        markdown = ReverseMarkdown.convert(formatted_html).strip
+        form_blob[:what_happens_next_markdown] = form_blob[:what_happens_next_text].blank? ? "" : markdown
+
+        made_live_form.update!(json_form_blob: form_blob.to_json)
+      end
+
+      form.save!
+    rescue StandardError => e
+      puts "Error processing form #{form.id} (#{form.name})"
+      puts e
+    end
+  end
+
+  desc "Depopulate what_happens_next_markdown field"
+  task depopulate: :environment do
+    Form.find_each do |form|
+      form.what_happens_next_markdown = nil
+
+      form.made_live_forms.each do |made_live_form|
+        form_blob = JSON.parse(made_live_form.json_form_blob, symbolize_names: true)
+
+        form_blob[:what_happens_next_markdown] = nil
+
+        made_live_form.update!(json_form_blob: form_blob.to_json)
+      end
+
+      form.save!
+    rescue StandardError => e
+      puts "Error processing form #{form.id} (#{form.name})"
+      puts e
+    end
+  end
+end

--- a/spec/lib/tasks/what_happens_next_markdown_spec.rb
+++ b/spec/lib/tasks/what_happens_next_markdown_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "what_happens_next_markdown.rake" do
+  describe "what_happens_next_markdown:populate", type: :task do
+    before do
+      Rake.application.rake_require "tasks/what_happens_next_markdown"
+      Rake::Task.define_task(:environment)
+    end
+
+    it "populates the what_happens_next_markdown field on the form and the live form JSON" do
+      form = create(:form, what_happens_next_text: "You will get a response soon.\n\nIn the meantime:<ul><li>A list item</li></ul>", what_happens_next_markdown: nil)
+      made_live_form = create(:made_live_form, form:)
+
+      Rake::Task["what_happens_next_markdown:populate"].invoke
+
+      form.reload
+      made_live_form.reload
+
+      made_live_form_blob = JSON.parse(made_live_form.json_form_blob, symbolize_names: true)
+      expect(form.what_happens_next_markdown).to eq "You will get a response soon.\n\nIn the meantime:\n\n- A list item"
+      expect(made_live_form_blob[:what_happens_next_markdown]).to eq "You will get a response soon.\n\nIn the meantime:\n\n- A list item"
+    end
+  end
+
+  describe "what_happens_next_markdown:depopulate", type: :task do
+    before do
+      Rake.application.rake_require "tasks/what_happens_next_markdown"
+      Rake::Task.define_task(:environment)
+    end
+
+    it "removes the what_happens_next_markdown content from the form and the live form JSON" do
+      form = create(:form, what_happens_next_text: "You will get a response soon.\n\nIn the meantime:<ul><li>A list item</li></ul>", what_happens_next_markdown: "You will get a response soon.\n\nIn the meantime:\n\n- A list item")
+      made_live_form = create(:made_live_form, form:)
+
+      Rake::Task["what_happens_next_markdown:depopulate"].invoke
+
+      form.reload
+      made_live_form.reload
+
+      made_live_form_blob = JSON.parse(made_live_form.json_form_blob, symbolize_names: true)
+      expect(form.what_happens_next_markdown).to eq nil
+      expect(made_live_form_blob[:what_happens_next_markdown]).to eq nil
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/AbPj2LRr/1191-allow-markdown-on-confirmation-page-what-happens-next-content

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Adds a rake task which takes the content of the what_happens_next_text field, converts it to markdown using the ReverseMarkdown gem, then saves this markdown in the to the what_happens_next_markdown field that we added in #371. It also adds this markdown to the made live form.

Doing this as a rake task means we're not stuck with a migration that's dependent on a specific gem, and we've previously said we'd consider reserving migrations for schema changes. The downside is we'll have to run the task manually in each environment.

To do in other PRs:
- cleanup: delete the old field and all the logic related to it which we no longer need

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
