### PR TITLE
Configure RSpec to allow the --only-failures CLI option

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,10 +64,10 @@ RSpec.configure do |config|
   #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
   #   config.filter_run_when_matching :focus
   #
-  #   # Allows RSpec to persist some state between runs in order to support
-  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
-  #   # you configure your source control system to ignore this file.
-  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  # Allows RSpec to persist some state between runs in order to support
+  # the `--only-failures` and `--next-failure` CLI options. We recommend
+  # you configure your source control system to ignore this file.
+  config.example_status_persistence_file_path = "tmp/cache/spec/examples.txt"
   #
   #   # Limits the available syntax to the non-monkey patched syntax that is
   #   # recommended. For more details, see:


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

The `--only-failures` and `--next-failure` options in RSpec make it much quicker to re-run tests that have failed, however they need the `example_status_persistence_file_path` configuration to be set [[1]].

This commit tells RSpec to save a file `examples.txt` into the a new folder in the Rails app's `tmp` folder; this seems like as good a place as any, as it's already ignored by git and docker, and is clearly named.

[1]: https://rspec.info/features/3-12/rspec-core/command-line/only-failures/

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?