### PR TITLE
Add client-side data scrubbing to Sentry configuration

### DIFF
--- a/app/lib/email_parameter_filter_proc.rb
+++ b/app/lib/email_parameter_filter_proc.rb
@@ -1,0 +1,12 @@
+class EmailParameterFilterProc
+  # email regexp from regular-expressions.info/email.html
+  EMAIL_REGEXP = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i
+
+  def self.new(mask: ActiveSupport::ParameterFilter::FILTERED)
+    @mask = mask
+
+    proc do |_key, value|
+      value.is_a?(String) ? value.gsub!(EMAIL_REGEXP, @mask) : value
+    end
+  end
+end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,3 +1,7 @@
+require "active_support/parameter_filter"
+
+require "./app/lib/email_parameter_filter_proc"
+
 if Settings.sentry.dsn.present?
   Sentry.init do |config|
     config.dsn = Settings.sentry.dsn
@@ -5,5 +9,16 @@ if Settings.sentry.dsn.present?
     config.debug = true
     config.enable_tracing = false
     config.environment = Settings.sentry.environment
+
+    # use synchronous/blocking code for integration tests
+    config.background_worker_threads = 0 if Rails.env.test?
+
+    filter = ActiveSupport::ParameterFilter.new(
+      [EmailParameterFilterProc.new(mask: Settings.sentry.filter_mask)],
+      mask: Settings.sentry.filter_mask,
+    )
+    config.before_send = lambda do |event, _hint|
+      filter.filter(event.to_hash)
+    end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,5 +8,6 @@ forms_api:
 sentry:
   dsn:
   environment: local
+  filter_mask: "[Filtered (client-side)]"
 
 features: {}

--- a/spec/integration/sentry_spec.rb
+++ b/spec/integration/sentry_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe "config/initializers/sentry" do
+  attr_accessor :captured_event, :filtered_event
+
+  test_dsn = "https://fake@test-dsn/1".freeze
+
+  before :context do # rubocop:disable RSpec/BeforeAfterAll
+    if Settings.sentry.dsn.nil?
+      Settings.sentry.dsn = test_dsn
+
+      load "config/initializers/sentry.rb"
+    end
+  end
+
+  after :context do # rubocop:disable RSpec/BeforeAfterAll
+    if Settings.sentry.dsn == test_dsn
+      Sentry.close
+
+      Settings.sentry.dsn = nil
+    end
+  end
+
+  before do
+    allow(Sentry.configuration).to receive(:before_send).and_wrap_original do |original_method|
+      original_method = original_method.call
+      lambda do |event, hint|
+        @captured_event = event
+        @filtered_event = original_method.nil? ? event : original_method.call(event, hint)
+      end
+    end
+  end
+
+  context "when an exception is raised containing personally identifying information" do
+    let(:form) { build :form, id: 1, submission_email: "submission-email@test.example" }
+
+    before do
+      form.not_a_method
+    rescue NameError => e
+      Sentry.capture_exception(e)
+    end
+
+    it "scrubs email addresses from everywhere in the event" do
+      expect(filtered_event.to_hash.to_s).not_to include "submission-email@test.example"
+    end
+
+    it "replaces the email address in the exception with a comment" do
+      expect(filtered_event.to_hash[:exception][:values].first[:value]).to include "[Filtered (client-side)]"
+    end
+
+    it "keeps the rest of the exception message" do
+      expect(filtered_event.to_hash[:exception][:values].first[:value]).to include "undefined method"
+    end
+  end
+
+  context "when an breadcrumb is sent containing personally identifying information" do
+    before do
+      Sentry.add_breadcrumb(
+        Sentry::Breadcrumb.new(
+          category: "spec.integration.sentry_spec",
+          data: {
+            action: "test_breadcrumb",
+            params: {
+              forms_submission_form: {
+                temporary_submission: "new-submission-email@test.example",
+                notify_response_id: "some-random-number-0000",
+              },
+            },
+          },
+        ),
+      )
+
+      Sentry.capture_message("breadcrumbs test")
+    end
+
+    it "scrubs email addresses from everywhere in the event" do
+      expect(filtered_event.to_hash.to_s).not_to include "new-submission-email@test.example"
+    end
+
+    it "replaces the email address in the breadcrumbs with a comment" do
+      expect(filtered_event.to_hash[:breadcrumbs][:values].last[:data]["params"]["forms_submission_form"]["temporary_submission"]).to eq "[Filtered (client-side)]"
+    end
+  end
+end

--- a/spec/lib/email_parameter_filter_proc_spec.rb
+++ b/spec/lib/email_parameter_filter_proc_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+require_relative "../../app/lib/email_parameter_filter_proc"
+
+RSpec.describe EmailParameterFilterProc do
+  let(:email_parameter_filter) do
+    ActiveSupport::ParameterFilter.new(
+      [described_class.new],
+    )
+  end
+
+  it "filters email address from strings in hashes" do
+    expect(email_parameter_filter.filter({ email: "test@example.com" }))
+      .to eq({ email: "[FILTERED]" })
+  end
+
+  it "leaves value unchanged if it is not a string" do
+    expect(email_parameter_filter.filter({ symbol: :test }))
+      .to eq({ symbol: :test })
+  end
+
+  it "filters all email addresses from strings" do
+    expect(email_parameter_filter.filter_param("", "lorem ipsum example@filter.test dolor sit"))
+      .to eq("lorem ipsum [FILTERED] dolor sit")
+  end
+
+  context "when a custom mask is provided" do
+    let(:mask) { "********" }
+
+    let(:email_parameter_filter) do
+      ActiveSupport::ParameterFilter.new(
+        [described_class.new(mask:)], mask:
+      )
+    end
+
+    it "replaces email addresses with the custom mask" do
+      expect(email_parameter_filter.filter_param("", "hello test@gov.uk.example"))
+        .to eq("hello ********")
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/EW20O2Zx <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

This PR adds code to the Sentry initializer that filters out anything that looks like an email address before it is sent to the Sentry.io servers.

I've tested this locally by using the DSN from the our `forms-debugging-localhost-instances` project. If you have access to our Sentry installation you can see examples of events with scrubbed data at https://govuk-forms.sentry.io/issues/4706430125/ and https://govuk-forms.sentry.io/issues/4706430136/. Note that you may need to look at the latest event for those issues to see the client-side filtering in action.

Although I have made sure that the replacement text used to mask out sensitive data client-side is different to the one used for server-side scrubbing, the server-side scrubbing is also very diligent, and will filter out values if the key contains the term "email" even when the value doesn't look like an email address. This does mean that in production usage we might have occasions where we're not sure if the client-side filtering got to the email address first or not; we might want to have a think about that further.

This PR also includes automated tests for the filter; as well as testing the logic of the filter itself we test it's integration with Sentry. Writing these tests was pretty hard-going, note that we had to add a bit of test specific logic to the Sentry configuration to make these tests work, as well as be very careful about how we reach into the Sentry code to test the behaviour we're interested in.

The filter is pretty thorough, it uses a regex to find anything that looks like a valid email address anywhere in the Sentry event object. The regex comes from https://www.regular-expressions.info/email.html, and covers 99% of valid email addresses. There is probably a bit of unnecessary cycles being spent here, however as this code should only be invoked when there is an exception, I think that's acceptable. Also, in production Sentry runs in a background thread so the CPU time being used shouldn't affect threads serving users unless the server is already close to capacity.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?