### PR TITLE
API Token tweaks

### DIFF
--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -5,7 +5,7 @@ class AccessToken < ApplicationRecord
   scope :active, -> { where(deactivated_at: nil) }
 
   def generate_token
-    users_token = SecureRandom.uuid
+    users_token = "forms_#{SecureRandom.uuid}"
     self.token_digest = Digest::SHA256.hexdigest(users_token)
     users_token
   end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -1,5 +1,6 @@
 class AccessToken < ApplicationRecord
   validates :token_digest, :owner, presence: true
+  validates :token_digest, uniqueness: { conditions: -> { active } }
 
   scope :active, -> { where(deactivated_at: nil) }
 

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -66,12 +66,12 @@ RSpec.describe AccessToken, type: :model do
     let(:result) { access_token.generate_token }
 
     it "generates a user token before validation" do
-      expect(result).to eq("testing-123")
+      expect(result).to eq("forms_testing-123")
     end
 
     it "generates a sha-256 token before validation" do
       result
-      expect(access_token.token_digest).to eq("8d9754db9759ab1785644440dbf19f88ab45ae326e421da6c1cb6e45140d534f")
+      expect(access_token.token_digest).to eq("f3aed9ecfc2db207800ca641f45e24d2f6de030487b7270871c04046808c1b22")
     end
   end
 end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -24,6 +24,22 @@ RSpec.describe AccessToken, type: :model do
       expect(access_token).to be_invalid
       expect(access_token.errors[:token_digest]).to include("can't be blank")
     end
+
+    it "is invalid to have two active tokens with the same digest" do
+      access_token_1 = described_class.create!(owner: "test1", token_digest: "baabaa")
+      expect(access_token_1).to be_valid
+
+      access_token_2 = described_class.new(owner: "test2", token_digest: "baabaa")
+      expect(access_token_2).not_to be_valid
+    end
+
+    it "is valid to reuse the same token digest" do
+      access_token_1 = described_class.create!(owner: "test1", token_digest: "baabaa")
+      access_token_1.update!(deactivated_at: Time.zone.now)
+
+      access_token_2 = described_class.new(owner: "test2", token_digest: "baabaa")
+      expect(access_token_2).to be_valid
+    end
   end
 
   describe "scopes" do


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

While working on #368 I realised that we don't have anything preventing the same API token being used more than once. This seems like a bug to me.

I've also thought it would make API keys easier to identify if they have a prefix, the same way GitHub or Trello does, so I added that as well.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?