### PR TITLE
Rename authentication_key to auth_key

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,9 +32,9 @@ class ApplicationController < ActionController::API
 private
 
   def authenticate_using_old_env_vars
-    return false if request.headers["X-Api-Token"].blank? || Settings.forms_api.authentication_key.blank?
+    return false if request.headers["X-Api-Token"].blank? || Settings.forms_api.auth_key.blank?
 
-    request.headers["X-Api-Token"] == Settings.forms_api.authentication_key
+    request.headers["X-Api-Token"] == Settings.forms_api.auth_key
   end
 
   def authenticate_using_access_tokens

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,6 @@
 forms_api:
+  auth_key:
   enabled_auth: true
-  authentication_key:
-
 
 # Configuration for Sentry
 # Sentry will only initialise if dsn is set to some other value

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,3 +1,3 @@
 forms_api:
+  auth_key:
   enabled_auth: false
-  authentication_key:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,3 +1,3 @@
 forms_api:
+  auth_key:
   enabled_auth: false
-  authentication_key:

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -22,7 +22,7 @@ describe "Settings" do
     forms_api = settings[:forms_api]
 
     include_examples expected_value_test, :enabled_auth, forms_api, true
-    include_examples expected_value_test, :authentication_key, forms_api, nil
+    include_examples expected_value_test, :auth_key, forms_api, nil
   end
 
   describe "sentry" do

--- a/spec/request/application_controller_spec.rb
+++ b/spec/request/application_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe ApplicationController, type: :request do
   describe "#authentication" do
-    let(:token) { Settings.forms_api.authentication_key }
+    let(:token) { Settings.forms_api.auth_key }
     let(:json_body) { JSON.parse(response.body, symbolize_names: true) }
     let(:req_headers) do
       {
@@ -24,8 +24,8 @@ describe ApplicationController, type: :request do
 
     context "when valid header and token passed" do
       it "returns 200" do
+        Settings.forms_api.auth_key = 123_456
         Settings.forms_api.enabled_auth = true
-        Settings.forms_api.authentication_key = 123_456
         get forms_path, params: { organisation_id: 1 }, headers: req_headers
         expect(response.status).to eq(200)
       end
@@ -39,8 +39,8 @@ describe ApplicationController, type: :request do
       end
 
       it "returns 401" do
+        Settings.forms_api.auth_key = 123_456
         Settings.forms_api.enabled_auth = true
-        Settings.forms_api.authentication_key = 123_456
         get forms_path, params: { organisation_id: 1 }, headers: req_headers
         expect(response.status).to eq(401)
       end
@@ -50,7 +50,7 @@ describe ApplicationController, type: :request do
       let(:token) { "incorrect-auth-key" }
 
       it "returns 200" do
-        Settings.forms_api.authentication_key = 123_456
+        Settings.forms_api.auth_key = 123_456
         get forms_path, params: { organisation_id: 1 }, headers: req_headers
         expect(response.status).to eq(401)
       end
@@ -68,8 +68,8 @@ describe ApplicationController, type: :request do
       let(:time_now) { Time.zone.now }
 
       before do
+        Settings.forms_api.auth_key = 1234
         Settings.forms_api.enabled_auth = true
-        Settings.forms_api.authentication_key = 1234
         access_token
         token
         access_token.save!
@@ -119,8 +119,8 @@ describe ApplicationController, type: :request do
       let(:time_now) { Time.zone.now }
 
       before do
+        Settings.forms_api.auth_key = 1234
         Settings.forms_api.enabled_auth = true
-        Settings.forms_api.authentication_key = 1234
         access_token
         token
         access_token.save!


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

In other apps we call this setting `Settings.forms_api.auth_key`. It would be helpful if this setting had the same name in all apps, because we could set it everywhere with one environment variable.

This commit renames the setting key in forms-api to match what is currently in forms-admin and forms-runner.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?