### PR TITLE
add default rails healthcheck endpoint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,11 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
+  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
+  # Can be used by load balancers and uptime monitors to verify that the app is live.
+  get "/up" => "rails/health#show", as: :rails_health_check
+
+  # TODO: Remove once infrastructure has been updated to use /up
   get :ping, controller: :heartbeat
 
   # Defines the root path route ("/")

--- a/spec/request/application_controller_spec.rb
+++ b/spec/request/application_controller_spec.rb
@@ -158,4 +158,11 @@ describe ApplicationController, type: :request do
       end
     end
   end
+
+  describe "#up" do
+    it "returns http code 200" do
+      get rails_health_check_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

rails 7.1 introduced a health check endpoint by default. This default endpoint is called `/up`. Instead of returning 200 with the body response of `PONG`, it will return 200 if the app is healthy and it will output a html page with the background color set to green. If there is an issue it will return 500 error and the html page will have a red background.

We will need to update our infrastructure to use /up instead `/ping` and then we can remove our custom heartbeat controller.

A simple test was added as part of this commit, not to test Rails implementation but as a means to check the functionality is present in the application and should fail if someone deletes the route in error.

see https://github.com/rails/rails/blob/f481353150c100dbd944d5aa84f2480264cd723c/railties/lib/rails/health_controller.rb

Trello card: https://trello.com/c/J0l5SpeE/1417-use-rails-default-healthcheck-endpoint

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
