### PR TITLE
Update Development Config

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -29,15 +29,15 @@ development:
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user running Rails.
-  #username: forms_api
+  username: postgres
 
   # The password associated with the postgres role (username).
-  #password:
+  password: postgres
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
   # domain sockets, so uncomment these lines.
-  #host: localhost
+  host: localhost
 
   # The TCP port the server listens on. Defaults to 5432.
   # If your server runs on a different port number, change accordingly.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,5 +70,5 @@ Rails.application.configure do
 
   # Add docker hostname for connecting from docker containers to host
   # so we can run other components in docker and the API locally
-  config.hosts << ".host.docker.internal"
+  config.hosts.push(".host.docker.internal", "forms-api:9292")
 end


### PR DESCRIPTION
This makes it simpler to run locally in development mode using default username, password and host for postgres running locally. The additional config.hosts for forms_api:9292 is necessary when running all applications with docker-compose.

### What problem does this pull request solve?
Running our apps locally.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
