### PR TITLE
SPIKE - using a state machine for draft/live form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,3 +83,7 @@ group :test do
 end
 
 gem "reverse_markdown", "~> 2.1"
+
+# Add state machine for forms
+gem "aasm", "~> 5.5"
+gem "after_commit_everywhere", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,8 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (5.5.0)
+      concurrent-ruby (~> 1.0)
     actioncable (7.1.3)
       actionpack (= 7.1.3)
       activesupport (= 7.1.3)
@@ -85,6 +87,9 @@ GEM
       tzinfo (~> 2.0)
     acts_as_list (1.1.0)
       activerecord (>= 4.2)
+    after_commit_everywhere (1.3.1)
+      activerecord (>= 4.2)
+      activesupport
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.6)
@@ -345,7 +350,9 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aasm (~> 5.5)
   acts_as_list
+  after_commit_everywhere (~> 1.0)
   bootsnap
   brakeman
   bundler-audit

--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -45,7 +45,7 @@ class Api::V1::FormsController < ApplicationController
   end
 
   def make_live
-    if form.make_form_live!
+    if form.make_live!
       render json: form.live_version, status: :ok
     else
       render json: form.incomplete_tasks.to_json, status: :forbidden

--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -42,8 +42,7 @@ class Api::V1::FormsController < ApplicationController
   end
 
   def make_live
-    if form.ready_for_live
-      form.make_live!
+    if form.make_form_live!
       render json: form.live_version, status: :ok
     else
       render json: form.incomplete_tasks.to_json, status: :forbidden

--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -26,6 +26,9 @@ class Api::V1::FormsController < ApplicationController
 
   def update
     if form.update(form_params)
+      form.draft_new_live_form! if form.live?
+      form.create_draft_from_archived_form! if form.archived?
+
       render json: form.to_json, status: :ok
     else
       render json: form.errors.to_json, status: :bad_request

--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -50,8 +50,7 @@ class Api::V1::FormsController < ApplicationController
   end
 
   def make_unlive
-    if form.has_live_version
-      form.make_unlive!
+    if form.archive_live_form!
       render json: form, status: :ok
     else
       render json: { error: "Form has no live version" }, status: :bad_request

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -8,7 +8,7 @@ class Condition < ApplicationRecord
   has_one :form, through: :routing_page
 
   def save_and_update_form
-    save
+    save!
     form.update!(question_section_completed: false)
     form.draft_new_live_form! if form.live?
     form.create_draft_from_archived_form! if form.archived?

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -8,7 +8,10 @@ class Condition < ApplicationRecord
   has_one :form, through: :routing_page
 
   def save_and_update_form
-    save && form.update!(question_section_completed: false)
+    save
+    form.update!(question_section_completed: false)
+    form.draft_new_live_form! if form.live?
+    form.create_draft_from_archived_form! if form.archived?
   end
 
   def destroy_and_update_form!

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -17,14 +17,6 @@ class Form < ApplicationRecord
     pages&.first&.id
   end
 
-  def make_live!(live_at = nil)
-    live_at ||= Time.zone.now
-    touch(time: live_at)
-
-    form_blob = snapshot(live_at:)
-    made_live_forms.create!(json_form_blob: form_blob.to_json, created_at: live_at)
-  end
-
   def has_draft_version
     return true if made_live_forms.blank?
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -44,7 +44,7 @@ class Form < ApplicationRecord
   end
 
   def live_version
-    raise ActiveRecord::RecordNotFound if made_live_forms.blank?
+    raise ActiveRecord::RecordNotFound if made_live_forms.blank? || archived?
 
     made_live_forms.last.json_form_blob
   end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -1,4 +1,7 @@
+require_relative "../state_machines/form_state_machine"
 class Form < ApplicationRecord
+  include FormStateMachine
+
   has_paper_trail
 
   has_many :pages, -> { order(position: :asc) }, dependent: :destroy

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -18,9 +18,7 @@ class Form < ApplicationRecord
   end
 
   def has_draft_version
-    return true if made_live_forms.blank?
-
-    updated_at > live_at
+    draft? | draft_live? || draft_archived?
   end
 
   def draft_version
@@ -32,7 +30,7 @@ class Form < ApplicationRecord
   end
 
   def has_live_version
-    made_live_forms.present?
+    !draft?
   end
 
   def live_version

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -30,6 +30,9 @@ class Page < ApplicationRecord
     return true unless has_changes_to_save?
 
     save!
+    form.draft_new_live_form! if form.live?
+    form.create_draft_from_archived_form! if form.archived?
+
     form.update!(question_section_completed: false)
     check_conditions.destroy_all if answer_type_changed_from_selection
     check_conditions.destroy_all if answer_settings_changed_from_only_one_option

--- a/app/state_machines/form_state_machine.rb
+++ b/app/state_machines/form_state_machine.rb
@@ -32,16 +32,20 @@ module FormStateMachine
       end
 
       event :make_draft_changes_live do
-        transitions from :draft_live, to: :live
+        transitions from [:draft_live, :draft_archived], to: :live
       end
 
       event :archive_live_form do
         # TODO: Is this only if a form is live and no draft or could a live form be archived even if there is an existing draft?
-        transitions from :live, to: :archived
+        transitions from [:live, :draft_live], to: :archived, guard: Proc.new { has_live_version }
       end
 
       event :create_draft_from_archived_form do
         transitions from: :archived, to: :draft_archived
+      end
+
+      event :make_archived_form_live do
+        transitions from: :archived, to: :live
       end
 
     end

--- a/app/state_machines/form_state_machine.rb
+++ b/app/state_machines/form_state_machine.rb
@@ -9,7 +9,7 @@ module FormStateMachine
       live: "live",
       draft_live: "draft_live",
       archived: "archived",
-      draft_archived: "draft_archived"
+      draft_archived: "draft_archived",
     }
 
     aasm column: :state, enum: true do
@@ -23,36 +23,32 @@ module FormStateMachine
 
       event :make_form_live do
         after do
-          self.make_live!
+          make_live!
         end
 
-        transitions from: [:draft, :draft_live, :draft_archived], to: :live, guard: Proc.new { task_status_service.mandatory_tasks_completed? }
+        transitions from: %i[draft draft_live draft_archived], to: :live, guard: proc { task_status_service.mandatory_tasks_completed? }
       end
 
       event :draft_new_live_form do
-        transitions from: :live, to: :draft_live, guard: Proc.new { has_live_version }
+        transitions from: :live, to: :draft_live, guard: proc { has_live_version }
       end
 
       event :make_draft_changes_live do
-        transitions from: [:draft_live, :draft_archived], to: :live
+        transitions from: %i[draft_live draft_archived], to: :live
       end
 
       event :archive_live_form do
-        # TODO: Is this only if a form is live and no draft or could a live form be archived even if there is an existing draft?
-        transitions from: [:live, :draft_live], to: :archived, guard: Proc.new { has_live_version }
+        transitions from: %i[live draft_live], to: :archived, guard: proc { has_live_version }
       end
 
       event :create_draft_from_archived_form do
         transitions from: :archived, to: :draft_archived
       end
-
-      event :make_archived_form_live do
-        transitions from: :archived, to: :live
-      end
-
     end
 
-    private def task_status_service
+  private
+
+    def task_status_service
       @task_status_service ||= TaskStatusService.new(form: self)
     end
   end

--- a/app/state_machines/form_state_machine.rb
+++ b/app/state_machines/form_state_machine.rb
@@ -20,7 +20,11 @@ module FormStateMachine
       state :draft_archived
 
       event :make_form_live do
-        transitions from: :draft, to: :live, guard: Proc.new { task_status_service.mandatory_tasks_completed? }
+        after do
+          self.make_live!
+        end
+
+        transitions from: [:draft, :draft_live, :draft_archived], to: :live, guard: Proc.new { task_status_service.mandatory_tasks_completed? }
       end
 
       event :draft_new_live_form do

--- a/app/state_machines/form_state_machine.rb
+++ b/app/state_machines/form_state_machine.rb
@@ -1,0 +1,29 @@
+module FormStateMachine
+  extend ActiveSupport::Concern
+
+  included do
+    include AASM
+
+    enum :state, {
+      draft: "draft",
+      live: "live",
+    }
+
+    aasm column: :state, enum: true do
+      state :draft, initial: true
+      state :live
+
+      event :make_form_live do
+        transitions from: :draft, to: :live, guard: Proc.new { task_status_service.mandatory_tasks_completed? }
+      end
+
+      event :make_changes_live do
+        transitions from: :live, to: :draft, guard: Proc.new { has_live_version }
+      end
+    end
+
+    private def task_status_service
+      @task_status_service ||= TaskStatusService.new(form: self)
+    end
+  end
+end

--- a/app/state_machines/form_state_machine.rb
+++ b/app/state_machines/form_state_machine.rb
@@ -36,7 +36,7 @@ module FormStateMachine
         transitions from :live, to: :archived
       end
 
-      event :create_draft_from_arhived_form do
+      event :create_draft_from_archived_form do
         transitions from: :archived, to: :draft_archived
       end
 

--- a/app/state_machines/form_state_machine.rb
+++ b/app/state_machines/form_state_machine.rb
@@ -37,6 +37,7 @@ module FormStateMachine
         transitions from: :live, to: :draft_live, guard: proc { has_live_version }
       end
 
+      # TODO: do we want this even?
       event :make_draft_changes_live do
         transitions from: %i[draft_live draft_archived], to: :live
       end

--- a/app/state_machines/form_state_machine.rb
+++ b/app/state_machines/form_state_machine.rb
@@ -14,10 +14,12 @@ module FormStateMachine
 
     aasm column: :state, enum: true do
       state :draft, initial: true
-      state :live
-      state :draft_live
-      state :archived
-      state :draft_archived
+      state :live, :draft_live, :archived, :draft_archived
+      # or written like
+      # state :live
+      # state :draft_live
+      # state :archived
+      # state :draft_archived
 
       event :make_form_live do
         after do
@@ -32,12 +34,12 @@ module FormStateMachine
       end
 
       event :make_draft_changes_live do
-        transitions from [:draft_live, :draft_archived], to: :live
+        transitions from: [:draft_live, :draft_archived], to: :live
       end
 
       event :archive_live_form do
         # TODO: Is this only if a form is live and no draft or could a live form be archived even if there is an existing draft?
-        transitions from [:live, :draft_live], to: :archived, guard: Proc.new { has_live_version }
+        transitions from: [:live, :draft_live], to: :archived, guard: Proc.new { has_live_version }
       end
 
       event :create_draft_from_archived_form do

--- a/app/state_machines/form_state_machine.rb
+++ b/app/state_machines/form_state_machine.rb
@@ -21,9 +21,13 @@ module FormStateMachine
       # state :archived
       # state :draft_archived
 
-      event :make_form_live do
+      event :make_live do
         after do
-          make_live!
+          live_at ||= Time.zone.now
+          touch(time: live_at)
+
+          form_blob = self.snapshot(live_at:)
+          made_live_forms.create!(json_form_blob: form_blob.to_json, created_at: live_at)
         end
 
         transitions from: %i[draft draft_live draft_archived], to: :live, guard: proc { task_status_service.mandatory_tasks_completed? }

--- a/app/state_machines/form_state_machine.rb
+++ b/app/state_machines/form_state_machine.rb
@@ -7,19 +7,39 @@ module FormStateMachine
     enum :state, {
       draft: "draft",
       live: "live",
+      draft_live: "draft_live",
+      archived: "archived",
+      draft_archived: "draft_archived"
     }
 
     aasm column: :state, enum: true do
       state :draft, initial: true
       state :live
+      state :draft_live
+      state :archived
+      state :draft_archived
 
       event :make_form_live do
         transitions from: :draft, to: :live, guard: Proc.new { task_status_service.mandatory_tasks_completed? }
       end
 
-      event :make_changes_live do
-        transitions from: :live, to: :draft, guard: Proc.new { has_live_version }
+      event :draft_new_live_form do
+        transitions from: :live, to: :draft_live, guard: Proc.new { has_live_version }
       end
+
+      event :make_draft_changes_live do
+        transitions from :draft_live, to: :live
+      end
+
+      event :archive_live_form do
+        # TODO: Is this only if a form is live and no draft or could a live form be archived even if there is an existing draft?
+        transitions from :live, to: :archived
+      end
+
+      event :create_draft_from_arhived_form do
+        transitions from: :archived, to: :draft_archived
+      end
+
     end
 
     private def task_status_service

--- a/db/migrate/20240115195355_add_state_to_form.rb
+++ b/db/migrate/20240115195355_add_state_to_form.rb
@@ -1,5 +1,5 @@
 class AddStateToForm < ActiveRecord::Migration[7.1]
   def change
-    add_column :forms, :state, :string, default: "draft"
+    add_column :forms, :state, :string
   end
 end

--- a/db/migrate/20240115195355_add_state_to_form.rb
+++ b/db/migrate/20240115195355_add_state_to_form.rb
@@ -1,0 +1,5 @@
+class AddStateToForm < ActiveRecord::Migration[7.1]
+  def change
+    add_column :forms, :state, :string, default: "draft"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_06_162240) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_15_195355) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,6 +55,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_06_162240) do
     t.bigint "creator_id"
     t.bigint "organisation_id"
     t.text "what_happens_next_markdown"
+    t.string "state", default: "draft"
   end
 
   create_table "made_live_forms", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,7 +55,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_15_195355) do
     t.bigint "creator_id"
     t.bigint "organisation_id"
     t.text "what_happens_next_markdown"
-    t.string "state", default: "draft"
+    t.string "state"
   end
 
   create_table "made_live_forms", force: :cascade do |t|


### PR DESCRIPTION
### What problem does this pull request solve?

### States

```mermaid
stateDiagram
    Draft --> Live
    draft_live: Draft live
    Live --> draft_live
    draft_live --> Live
    draft_archived: Draft archived
    draft_live --> draft_archived
    Live --> Archived
    Archived --> Live
    Archived --> draft_archived
    draft_archived --> Live
 ```

#### Draft
Initial forms can be deleted as they are not official forms yet. Draft forms can be created/edited by trial/editor users. Previews of draft forms are viewable in `forms-runner`. This is the only state that a form created by a trial user can get to until the  trial users account has been upgraded to an Editor role.

#### Live
Form record is transitioned to this state when a user has completed all the required tasks for a form and decides to make a form live. Live forms cannot be HARD deleted as they are now official forms which could have been used by the public to submit their data to a government department. Previews of live forms are viewable in `forms-runner`.  When a form is made live we take a snapshot of the form, all its pages & all the page routing conditions and store it in `made_live_forms` table as JSON blob format. A form can have multiple "live versions" in `made_live_forms` table but we only ever return the latest version to our users. We keep multiple versions so we could serve up previous versions if need be or if users start a form and a new version is published, we should still be able to allow them to complete the version of form they started.

#### Draft live
Form record is transitioned to this state when a user clicks 
![image](https://github.com/alphagov/forms-api/assets/3441519/21e2494f-d7e8-4062-8abd-9da15484da72)
from the live form show page. This would be a change from the current method which is that we look at the forms `updated_at` and check if it is after the forms `live_at`.
A new draft of a live form but doesn't create a new record in the database. This state identifies when a form creator has made changes to a live form without affecting that live form. Once the form creator has approval for the changes to go live, the form can transition back to `Live` state.  Previews of draft forms are viewable in `forms-runner`. 

In this state, if a form is `archived`, the transition will go to `archived` and then on to `draft_archived` 

#### Archived
A form creator can only archive a form that is in either Live or Draft Live state. In this state a form filler would receive 404 "Page not Found" Error in forms-runner.  

#### Draft Archived
This is similar to how `Draft live` works except when  in this state a form filler would still receive 404 "Page not Found" Error in forms-runner unless they are previewing a draft version of the form. Once a form creator is ready to make a form live they should be able to transition this back to `Live` state.

[Trello](https://trello.com/c/G0bbEVGK/1447-spike-how-should-we-accurately-model-and-track-the-state-of-a-form)

- Adds a new column to forms table
- Adds aasm gem and after_commit_everywhere gem for activerecord support
- Mock out  a state machine for forms
	- reuse existing guards 		

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
