### PR TITLE
Add AWS application load balancer trace ID to logs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,6 +27,7 @@ class ApplicationController < ActionController::API
     payload[:requested_by] = "#{@access_token.owner}-#{@access_token.id}" if @access_token.present?
     payload[:form_id] = params[:form_id] if params[:form_id].present?
     payload[:page_id] = params[:page_id] if params[:page_id].present?
+    payload[:trace_id] = request.env["HTTP_X_AMZN_TRACE_ID"].presence
   end
 
 private

--- a/config/application.rb
+++ b/config/application.rb
@@ -64,6 +64,7 @@ module FormsApi
         h[:page_id] = event.payload[:page_id] if event.payload[:page_id]
         h[:params] = event.payload[:params].except(:controller, :action)
         h[:exception] = event.payload[:exception] if event.payload[:exception]
+        h[:trace_id] = event.payload[:trace_id] if event.payload[:trace_id]
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to be able to correlate our Elastic Load Balancer logs with app logs. This is particularly useful when there is a `460` error because the client has closed the connection for taking too long.

This PR adds the `X-Amzn-Trace-Id` header [[1]] to our request logging.

[1]: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?