### PR TITLE
add state column to form model and bare bones state machine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,11 @@ gem "config"
 # Auditing model changes and logging versions
 gem "paper_trail"
 
+# Add state machine for forms
+gem "aasm", "~> 5.5"
+# Used by AASM to autocommit state changes when even method is used with bang eg. make_live!
+gem "after_commit_everywhere", "~> 1.0"
+
 # Use postgresql as the database for Active Record
 gem "pg", "~> 1.5"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,8 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (5.5.0)
+      concurrent-ruby (~> 1.0)
     actioncable (7.1.3)
       actionpack (= 7.1.3)
       activesupport (= 7.1.3)
@@ -85,6 +87,9 @@ GEM
       tzinfo (~> 2.0)
     acts_as_list (1.1.0)
       activerecord (>= 4.2)
+    after_commit_everywhere (1.3.1)
+      activerecord (>= 4.2)
+      activesupport
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.6)
@@ -345,7 +350,9 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aasm (~> 5.5)
   acts_as_list
+  after_commit_everywhere (~> 1.0)
   bootsnap
   brakeman
   bundler-audit

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -58,13 +58,14 @@ class Form < ApplicationRecord
 
   def snapshot(**kwargs)
     # override methods so it doesn't include things we don't want
-    as_json(include: {
-      pages: {
-        include: {
-          routing_conditions: { methods: :validation_errors },
-        },
-      },
-    }, methods: [:start_page]).merge(kwargs)
+    as_json(except: :state,
+            include: {
+              pages: {
+                include: {
+                  routing_conditions: { methods: :validation_errors },
+                },
+              },
+            }, methods: [:start_page]).merge(kwargs)
   end
 
   # form_slug is always set based on name. This is here to allow Form

--- a/app/state_machines/form_state_machine.rb
+++ b/app/state_machines/form_state_machine.rb
@@ -1,0 +1,49 @@
+module FormStateMachine
+  extend ActiveSupport::Concern
+
+  included do
+    include AASM
+
+    enum :state, {
+      draft: "draft",
+      deleted: "deleted",
+      live: "live",
+      live_with_draft: "live_with_draft",
+    }
+
+    aasm column: :state, enum: true do
+      state :draft, initial: true
+      state :deleted, :live, :live_with_draft
+
+      event :delete_form do
+        after do
+          destroy!
+        end
+
+        transitions from: :draft, to: :deleted
+      end
+
+      event :make_live do
+        after do
+          live_at ||= Time.zone.now
+          touch(time: live_at)
+
+          form_blob = snapshot(live_at:)
+          made_live_forms.create!(json_form_blob: form_blob.to_json, created_at: live_at)
+        end
+
+        transitions from: %i[draft live_with_draft], to: :live, guard: proc { task_status_service.mandatory_tasks_completed? }
+      end
+
+      event :create_draft_from_live_form do
+        transitions from: :live, to: :live_with_draft
+      end
+    end
+
+  private
+
+    def task_status_service
+      @task_status_service ||= TaskStatusService.new(form: self)
+    end
+  end
+end

--- a/db/migrate/20240124160123_add_state_column_to_form.rb
+++ b/db/migrate/20240124160123_add_state_column_to_form.rb
@@ -1,0 +1,5 @@
+class AddStateColumnToForm < ActiveRecord::Migration[7.1]
+  def change
+    add_column :forms, :state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_06_162240) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_24_160123) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,6 +55,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_06_162240) do
     t.bigint "creator_id"
     t.bigint "organisation_id"
     t.text "what_happens_next_markdown"
+    t.string "state"
   end
 
   create_table "made_live_forms", force: :cascade do |t|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,8 +23,8 @@ require "sentry/test_helper"
 # of increasing the boot-up time by auto-requiring all files in the support
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
-#
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+
+Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/requests/api/v1/forms_controller_spec.rb
+++ b/spec/requests/api/v1/forms_controller_spec.rb
@@ -209,6 +209,7 @@ describe Api::V1::FormsController, type: :request do
         incomplete_tasks: %w[missing_pages missing_what_happens_next missing_privacy_policy_url missing_contact_details],
         ready_for_live: false,
         task_statuses: { declaration_status: "not_started", make_live_status: "cannot_start", name_status: "completed", pages_status: "not_started", privacy_policy_status: "not_started", support_contact_details_status: "not_started", what_happens_next_status: "not_started" },
+        state: nil,
       )
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require "active_support"
 require "active_support/testing/time_helpers"
+require "aasm/rspec"
 require "simplecov"
-require_relative "support/features"
 
 SimpleCov.start "rails" do
   coverage_dir("coverage/backend")

--- a/spec/state_machines/form_state_machine_spec.rb
+++ b/spec/state_machines/form_state_machine_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+class FakeForm < Form
+  include FormStateMachine
+end
+
+RSpec.describe FormStateMachine do
+  let(:form) { FakeForm.new }
+
+  it "has a default state of 'draft'" do
+    expect(form).to have_state(:draft)
+  end
+
+  describe ".delete_form event" do
+    it "does not transition if form is not a draft" do
+      expect(form).not_to transition_from(:live).to(:deleted).on_event(:delete_form)
+    end
+
+    context "when form is draft" do
+      let(:form) { FakeForm.new(state: :draft) }
+
+      it "transitions to deleted stated and is destroyed" do
+        expect(form).to receive(:destroy!)
+        expect(form).to transition_from(:draft).to(:deleted).on_event(:delete_form)
+      end
+    end
+  end
+
+  describe ".make_live" do
+    context "when form is draft" do
+      let(:form) { FakeForm.new(state: :draft) }
+
+      it "does not transition to live state by default" do
+        expect(form).not_to transition_from(:draft).to(:live).on_event(:make_live)
+      end
+
+      context "when all sections are completed" do
+        it_behaves_like "transition to live state", FakeForm, :draft, true
+      end
+    end
+
+    context "when form is live_with_draft" do
+      let(:form) { FakeForm.new(state: :live_with_draft) }
+
+      it "does not transition to live state by default" do
+        expect(form).not_to transition_from(:live_with_draft).to(:live).on_event(:make_live)
+      end
+
+      context "when all sections are completed" do
+        it_behaves_like "transition to live state", FakeForm, :live_with_draft, true
+      end
+    end
+  end
+
+  describe ".create_draft_from_live_form" do
+    let(:form) { FakeForm.new(state: :live) }
+
+    it "transitions to live_with_draft if form is live" do
+      expect(form).to transition_from(:live).to(:live_with_draft).on_event(:create_draft_from_live_form)
+    end
+
+    context "when form is draft" do
+      let(:form) { FakeForm.new(state: :draft) }
+
+      it "does not transition to live_with_draft" do
+        expect(form).not_to transition_from(:draft).to(:live_with_draft).on_event(:create_draft_from_live_form)
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/state_machine.rb
+++ b/spec/support/shared_examples/state_machine.rb
@@ -1,0 +1,21 @@
+RSpec.shared_examples "transition to live state" do |form_object, form_state, mandatory_tasks_completed|
+  let(:form) { form_object.new(state: form_state) }
+
+  before do
+    allow(TaskStatusService).to receive(:new).and_return(OpenStruct.new(mandatory_tasks_completed?: mandatory_tasks_completed))
+  end
+
+  it "transitions to live state" do
+    freeze_time do
+      time_now = Time.zone.now
+      form_snapshot = build(:form)
+      allow(form).to receive(:touch)
+      allow(form).to receive(:snapshot)
+                        .with(live_at: time_now)
+                        .and_return(form_snapshot)
+      allow(form.made_live_forms).to receive(:create!).with(json_form_blob: form_snapshot.to_json, created_at: time_now)
+
+      expect(form).to transition_from(form_state).to(:live).on_event(:make_live)
+    end
+  end
+end


### PR DESCRIPTION
### Related 
- https://github.com/alphagov/forms-api/pull/414

### What problem does this pull request solve?
This PR adds a state column (but doesn't populate it) and introduces a basic state machine which is not integrated into the forms model just yet.

See individual commit messages when reviewing

```mermaid
---
 title: Form states and events called to transition to state
---
stateDiagram-v2
    Draft --> Live : make_live!
    Draft --> Deleted : delete_form!
    live_with_draft: Live with draft
    Live --> live_with_draft : create_draft_from_live_form!
    live_with_draft --> Live : make_live!
   
```

Trello card:  https://trello.com/c/YTzyf7wz/1339-implement-better-state-of-forms-tracking

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
