### PR TITLE
Change has_draft_version & has_live_version to use form state column

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -17,9 +17,7 @@ class Form < ApplicationRecord
   end
 
   def has_draft_version
-    return true if made_live_forms.blank?
-
-    updated_at > live_at
+    draft? || live_with_draft?
   end
 
   def draft_version

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -29,11 +29,11 @@ class Form < ApplicationRecord
   end
 
   def has_live_version
-    made_live_forms.present?
+    live? || live_with_draft?
   end
 
   def live_version
-    raise ActiveRecord::RecordNotFound if made_live_forms.blank?
+    raise ActiveRecord::RecordNotFound unless has_live_version
 
     made_live_forms.last.json_form_blob
   end

--- a/spec/lib/tasks/forms_admin_spec.rb
+++ b/spec/lib/tasks/forms_admin_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "forms_admin.rake" do
       Rake::Task["forms_admin:make_unlive"].invoke(form.id)
 
       form.reload
-      expect(form.has_live_version).to be false
+      expect(form.made_live_forms.present?).to be false
     end
 
     it "does not make a form unlive if it has no live version" do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -177,15 +177,18 @@ RSpec.describe Form, type: :model do
     let(:live_form) { create(:made_live_form).form }
     let(:new_form) { create(:form) }
 
-    it "returns true if form has not been made live before" do
+    it "returns true if form is draft" do
+      new_form.state = :draft
       expect(new_form.has_draft_version).to eq(true)
     end
 
-    it "returns false if form has been made live and not edited" do
+    it "returns false if form is live and no edits" do
+      live_form.state = :live
       expect(live_form.has_draft_version).to eq(false)
     end
 
-    it "returns true if form has been made live and been edited" do
+    it "returns true if form is live with a draft" do
+      live_form.state = :live_with_draft
       live_form.update!(name: "Form (edited)")
 
       expect(live_form.has_draft_version).to eq(true)

--- a/spec/requests/api/v1/forms_controller_spec.rb
+++ b/spec/requests/api/v1/forms_controller_spec.rb
@@ -315,14 +315,14 @@ describe Api::V1::FormsController, type: :request do
       expect(json_body.to_json).to eq made_live_form.json_form_blob
     end
 
-    it "returns 404 if live form doesn't exist" do
+    it "returns 404 if form has never existed" do
       get live_form_path(1), as: :json
 
       expect(response.status).to eq(404)
       expect(response.headers["Content-Type"]).to eq("application/json")
     end
 
-    it "returns 404 if form has never existed" do
+    it "returns 404 if form is not live " do
       form = create :form
       get live_form_path(form.id), as: :json
 


### PR DESCRIPTION
### BLOCKED BY
- https://github.com/alphagov/forms-api/pull/425 needs to be deployed first

### What problem does this pull request solve?

This is the last piece of the puzzle, with these changes forms-admin & forms-runner will be able to identify a form's status by the state column. Eventually, we will want to remove these methods but we might want to keep them around as it does allow forms-api to control which statuses should be considered draft or live. forms-admin uses these methods to show/hide the draft/live status tags to users.

Once this is merged we can look at adding Archive state 

Trello card: https://trello.com/c/YTzyf7wz/1339-implement-better-state-of-forms-tracking

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
