### PR TITLE
add `archive_live_form` state machine event to transition live form to draft

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -81,6 +81,7 @@ class Form < ApplicationRecord
   delegate :task_statuses, to: :task_status_service
 
   def make_unlive!
+    archive_live_form!
     made_live_forms.destroy_all
   end
 

--- a/app/state_machines/form_state_machine.rb
+++ b/app/state_machines/form_state_machine.rb
@@ -38,6 +38,16 @@ module FormStateMachine
       event :create_draft_from_live_form do
         transitions from: :live, to: :live_with_draft
       end
+
+      event :archive_live_form do
+        # TODO: Temporary transition until we do archive state properly so that live forms cant
+        # be accessed but still exist in the database
+        # https://trello.com/c/QXtBIrKc/1342-add-archived-states-to-forms-state-machine
+        transitions from: %i[live live_with_draft], to: :draft
+
+        # transitions from: :live, to: :archived
+        # transitions from: :live_with_draft, to: :archived_with_draft
+      end
     end
   end
 end

--- a/spec/lib/tasks/forms_admin_spec.rb
+++ b/spec/lib/tasks/forms_admin_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe "forms_admin.rake" do
 
       form.reload
       expect(form.made_live_forms.present?).to be false
+      expect(form.has_live_version).to be false
+      expect(form).to transition_from(:live).to(:draft).on_event(:archive_live_form)
     end
 
     it "does not make a form unlive if it has no live version" do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -171,6 +171,13 @@ RSpec.describe Form, type: :model do
       form.make_unlive!
       expect(form.live_at).to be_nil
     end
+
+    it "changes the state from live to draft" do
+      expect(form).to have_state(:live)
+      form.make_unlive!
+      form.reload
+      expect(form).to have_state(:draft)
+    end
   end
 
   describe "#has_draft_version" do

--- a/spec/requests/api/v1/forms_controller_spec.rb
+++ b/spec/requests/api/v1/forms_controller_spec.rb
@@ -293,12 +293,13 @@ describe Api::V1::FormsController, type: :request do
 
   describe "make unlive" do
     it "makes a live form unlive" do
-      form = (create :made_live_form).form
+      form = create(:made_live_form).form
       post make_unlive_form_path(form), as: :json
 
       expect(response.status).to eq(200)
       expect(response.headers["Content-Type"]).to eq("application/json")
       expect(json_body).to include(live_at: nil)
+      expect(json_body).to include(state: "draft")
     end
   end
 

--- a/spec/state_machines/form_state_machine_spec.rb
+++ b/spec/state_machines/form_state_machine_spec.rb
@@ -67,4 +67,20 @@ RSpec.describe FormStateMachine do
       end
     end
   end
+
+  describe ".archive_live_form" do
+    let(:form) { FakeForm.new(state: :live) }
+
+    it "transitions to draft if form is live" do
+      expect(form).to transition_from(:live).to(:draft).on_event(:archive_live_form)
+    end
+
+    context "when form is live_with_draft" do
+      let(:form) { FakeForm.new(state: :live_with_draft) }
+
+      it "transitions to draft if form is live_with_draft" do
+        expect(form).to transition_from(:live_with_draft).to(:draft).on_event(:archive_live_form)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

This adds a new event to state machine called `archive_live_form!` which for the time being will transition a live/live_with_draft form back to initial `draft` state. This is because the current `make_unlive` form method deletes all `made_live_forms` records and leaves the form in an invalid state of `live`. I think the event can stay as part of archive but when we come to do the archive state we can change the transitions in this event to point to archive/archive_with_draft state

### Before
```mermaid
---
 title: Form states and events called to transition to state
---
stateDiagram-v2
    Draft --> Live : make_live!
    Draft --> Deleted : delete_form!
    live_with_draft: Live with draft
    Live --> live_with_draft : create_draft_from_live_form!
    live_with_draft --> Live : make_live!
   
```


### After
```mermaid
---
 title: Form states and events called to transition to state
---
stateDiagram-v2
    Draft --> Live : make_live!
    Draft --> Deleted : delete_form!
    live_with_draft: Live with draft
    Live --> live_with_draft : create_draft_from_live_form!
    live_with_draft --> Live : make_live!
    live_with_draft --> Draft: archive_live_form!
    Live --> Draft: archive_live_form!
   
```

Trello card: https://trello.com/c/YTzyf7wz/1339-implement-better-state-of-forms-tracking
<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
