### PR TITLE
Remove page_order column from forms table

### DIFF
--- a/db/migrate/20240201145400_remove_page_order_from_form.rb
+++ b/db/migrate/20240201145400_remove_page_order_from_form.rb
@@ -1,0 +1,5 @@
+class RemovePageOrderFromForm < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :forms, :page_order, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_26_213348) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_01_145400) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -49,7 +49,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_26_213348) do
     t.text "declaration_text"
     t.boolean "question_section_completed", default: false
     t.boolean "declaration_section_completed", default: false
-    t.integer "page_order", array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "creator_id"

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -13,7 +13,6 @@ FactoryBot.define do
     declaration_text { nil }
     question_section_completed { false }
     declaration_section_completed { false }
-    page_order { nil }
     state { :draft }
 
     trait :new_form do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -260,7 +260,6 @@ RSpec.describe Form, type: :model do
         "question_section_completed",
         "declaration_section_completed",
         "pages",
-        "page_order",
         "what_happens_next_markdown",
       )
     end

--- a/spec/requests/api/v1/forms_controller_spec.rb
+++ b/spec/requests/api/v1/forms_controller_spec.rb
@@ -202,7 +202,6 @@ describe Api::V1::FormsController, type: :request do
         declaration_text: nil,
         question_section_completed: false,
         declaration_section_completed: false,
-        page_order: nil,
         created_at: form1.created_at.as_json,
         updated_at: form1.updated_at.as_json,
         has_routing_errors: false,


### PR DESCRIPTION
### What problem does this pull request solve?
This column is obsolete and was created before Jan 2023 when forms-api was not using rails. It was initial created to start an array of page ids in a particular order but when we moved over to rails we switched over to using acts_as_a_list gem which handled positing and ordering of associated records. I checked in forms-admin adn forms- runner and none of the code uses it nor does any newish form include it.
Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
