### PR TITLE
Fix draft check not including archived_with_draft

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -17,7 +17,7 @@ class Form < ApplicationRecord
   end
 
   def has_draft_version
-    draft? || live_with_draft?
+    draft? || live_with_draft? || archived_with_draft?
   end
 
   def draft_version

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -186,6 +186,12 @@ RSpec.describe Form, type: :model do
 
       expect(live_form.has_draft_version).to eq(true)
     end
+
+    it "returns true if form is archived with a draft" do
+      live_form.state = :archived_with_draft
+
+      expect(live_form.has_draft_version).to eq(true)
+    end
   end
 
   describe "#live_at" do


### PR DESCRIPTION
### What problem does this pull request solve?

This is an API fix for the work here https://trello.com/c/9QBLASbG/1331-add-archive-tag 

In order to correctly identify forms with draft versions, the `has_draft_version` method should also include the `archived_with_draft` state! 