### PR TITLE
Add payment_url to forms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,9 @@ gem "lograge"
 gem "sentry-rails"
 gem "sentry-ruby"
 
+# Use validate_url so we don't have to write custom URL validation
+gem "validate_url"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,6 +212,7 @@ GEM
     pg (1.5.5)
     psych (5.1.2)
       stringio
+    public_suffix (5.0.4)
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
@@ -337,6 +338,9 @@ GEM
     tzinfo-data (1.2024.1)
       tzinfo (>= 1.0.0)
     unicode-display_width (2.5.0)
+    validate_url (1.0.15)
+      activemodel (>= 3.0.0)
+      public_suffix
     webrick (1.8.1)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -377,6 +381,7 @@ DEPENDENCIES
   simplecov
   tzinfo
   tzinfo-data
+  validate_url
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -7,6 +7,7 @@ class Form < ApplicationRecord
   has_many :made_live_forms, -> { order(created_at: :asc) }, dependent: :destroy
 
   validates :name, presence: true
+  validates :payment_url, url: true, allow_blank: true
   validate :marking_complete_with_errors
 
   scope :filter_by_organisation_id, ->(organisation_id) { where organisation_id: }

--- a/app/service/task_status_service.rb
+++ b/app/service/task_status_service.rb
@@ -20,6 +20,7 @@ class TaskStatusService
       pages_status:,
       declaration_status:,
       what_happens_next_status:,
+      payment_link_status:,
       privacy_policy_status:,
       support_contact_details_status:,
       make_live_status:,
@@ -58,6 +59,12 @@ private
     else
       :not_started
     end
+  end
+
+  def payment_link_status
+    return :completed if @form.payment_url.present?
+
+    :optional
   end
 
   def privacy_policy_status

--- a/db/migrate/20240208124208_add_payment_url_to_forms.rb
+++ b/db/migrate/20240208124208_add_payment_url_to_forms.rb
@@ -1,0 +1,5 @@
+class AddPaymentUrlToForms < ActiveRecord::Migration[7.1]
+  def change
+    add_column :forms, :payment_url, :string
+  end
+end

--- a/db/migrate/20240208134335_add_payment_url_to_made_live_forms.rb
+++ b/db/migrate/20240208134335_add_payment_url_to_made_live_forms.rb
@@ -1,0 +1,18 @@
+class AddPaymentUrlToMadeLiveForms < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |direction|
+      MadeLiveForm.find_each do |made_live_form|
+        form_blob = JSON.parse(made_live_form.json_form_blob, symbolize_names: true)
+
+        direction.up do
+          form_blob[:payment_url] = nil
+        end
+        direction.down do
+          form_blob.delete(:payment_url)
+        end
+
+        made_live_form.update!(json_form_blob: form_blob.to_json)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_01_145400) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_08_124208) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,6 +55,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_01_145400) do
     t.bigint "organisation_id"
     t.text "what_happens_next_markdown"
     t.string "state"
+    t.string "payment_url"
   end
 
   create_table "made_live_forms", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_08_124208) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_08_134335) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -282,6 +282,7 @@ RSpec.describe Form, type: :model do
         "declaration_section_completed",
         "pages",
         "what_happens_next_markdown",
+        "payment_url",
       )
     end
   end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -398,6 +398,7 @@ RSpec.describe Form, type: :model do
         pages_status: :completed,
         declaration_status: :completed,
         what_happens_next_status: :completed,
+        payment_link_status: :optional,
         privacy_policy_status: :completed,
         support_contact_details_status: :completed,
         make_live_status: :completed,

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -61,6 +61,27 @@ RSpec.describe Form, type: :model do
           expect(form).to be_valid
         end
       end
+
+      context "when the payment url is not a url" do
+        it "returns invalid" do
+          form.payment_url = "not a url"
+          expect(form).to be_invalid
+        end
+      end
+
+      context "when the payment url is a url" do
+        it "returns valid" do
+          form.payment_url = "https://example.com/"
+          expect(form).to be_valid
+        end
+      end
+
+      context "when there is no payment url" do
+        it "returns valid" do
+          form.payment_url = nil
+          expect(form).to be_valid
+        end
+      end
     end
   end
 

--- a/spec/requests/api/v1/forms_controller_spec.rb
+++ b/spec/requests/api/v1/forms_controller_spec.rb
@@ -209,6 +209,7 @@ describe Api::V1::FormsController, type: :request do
         ready_for_live: false,
         task_statuses: { declaration_status: "not_started", make_live_status: "cannot_start", name_status: "completed", pages_status: "not_started", privacy_policy_status: "not_started", support_contact_details_status: "not_started", what_happens_next_status: "not_started" },
         state: "draft",
+        payment_url: nil,
       )
     end
   end

--- a/spec/requests/api/v1/forms_controller_spec.rb
+++ b/spec/requests/api/v1/forms_controller_spec.rb
@@ -207,7 +207,7 @@ describe Api::V1::FormsController, type: :request do
         has_routing_errors: false,
         incomplete_tasks: %w[missing_pages missing_what_happens_next missing_privacy_policy_url missing_contact_details],
         ready_for_live: false,
-        task_statuses: { declaration_status: "not_started", make_live_status: "cannot_start", name_status: "completed", pages_status: "not_started", privacy_policy_status: "not_started", support_contact_details_status: "not_started", what_happens_next_status: "not_started" },
+        task_statuses: { declaration_status: "not_started", make_live_status: "cannot_start", name_status: "completed", pages_status: "not_started", privacy_policy_status: "not_started", support_contact_details_status: "not_started", what_happens_next_status: "not_started", payment_link_status: "optional" },
         state: "draft",
         payment_url: nil,
       )

--- a/spec/service/task_status_service_spec.rb
+++ b/spec/service/task_status_service_spec.rb
@@ -94,6 +94,24 @@ describe TaskStatusService do
       end
     end
 
+    describe "payment link status" do
+      context "with a new form" do
+        let(:form) { build(:form, :new_form) }
+
+        it "returns the correct default value" do
+          expect(task_status_service.task_statuses[:payment_link_status]).to eq :optional
+        end
+      end
+
+      context "with a form with a payment link" do
+        let(:form) { build(:form, :new_form, payment_url: Faker::Internet.url(host: "gov.uk")) }
+
+        it "returns the completed status" do
+          expect(task_status_service.task_statuses[:payment_link_status]).to eq :completed
+        end
+      end
+    end
+
     describe "privacy policy status" do
       context "with a new form" do
         let(:form) { build(:form, :new_form) }
@@ -202,6 +220,7 @@ describe TaskStatusService do
         pages_status: :completed,
         declaration_status: :completed,
         what_happens_next_status: :completed,
+        payment_link_status: :optional,
         privacy_policy_status: :completed,
         support_contact_details_status: :completed,
         make_live_status: :completed,


### PR DESCRIPTION
### What problem does this pull request solve?

https://trello.com/c/VEe72eLB/1357-add-backend-code-to-support-saving-payment-links-for-a-form

### Things to consider when reviewing

Adds a column for `payment_url` to forms. This will be used to store a payment link if one is provided from admin - and to trigger and generate the payment page in the runner