### PR TITLE
Set make_live_status for archived form

### DIFF
--- a/app/service/task_status_service.rb
+++ b/app/service/task_status_service.rb
@@ -88,6 +88,6 @@ private
       return mandatory_tasks_completed? ? :not_started : :cannot_start
     end
 
-    :completed if @form.has_live_version
+    :completed
   end
 end

--- a/spec/service/task_status_service_spec.rb
+++ b/spec/service/task_status_service_spec.rb
@@ -165,8 +165,32 @@ describe TaskStatusService do
         end
       end
 
+      context "with a live form with a draft and all tasks complete" do
+        let(:form) { build(:form, :ready_for_live, state: :live_with_draft) }
+
+        it "returns the not started status" do
+          expect(task_status_service.task_statuses[:make_live_status]).to eq :not_started
+        end
+      end
+
+      context "with an archived form with a draft and all tasks complete" do
+        let(:form) { build(:form, :ready_for_live, state: :archived_with_draft) }
+
+        it "returns the not started status" do
+          expect(task_status_service.task_statuses[:make_live_status]).to eq :not_started
+        end
+      end
+
       context "with a live form" do
         let(:form) { create(:form, :live) }
+
+        it "returns the completed status" do
+          expect(task_status_service.task_statuses[:make_live_status]).to eq :completed
+        end
+      end
+
+      context "with an archived form" do
+        let(:form) { build(:form, state: :archived) }
 
         it "returns the completed status" do
           expect(task_status_service.task_statuses[:make_live_status]).to eq :completed


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/UyRNXHGh/1330-implement-archive-a-form-journey

If a form has state `archived`, `make_live_status` was returning a value of nil. This caused an exception to be thrown in forms-admin when loading the page to create a draft version of the form.

Default this method to return "completed" if the form doesn't have a draft version - as this implies that the form must be in either `live` or `archived` state.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
