### PR TITLE
Allow archived forms to be made live

### DIFF
--- a/app/state_machines/form_state_machine.rb
+++ b/app/state_machines/form_state_machine.rb
@@ -34,7 +34,7 @@ module FormStateMachine
           made_live_forms.create!(json_form_blob: form_blob.to_json, created_at: live_at)
         end
 
-        transitions from: %i[draft live_with_draft], to: :live, guard: proc { ready_for_live }
+        transitions from: %i[draft live_with_draft archived archived_with_draft], to: :live, guard: proc { ready_for_live }
       end
 
       event :create_draft_from_live_form do

--- a/spec/state_machines/form_state_machine_spec.rb
+++ b/spec/state_machines/form_state_machine_spec.rb
@@ -50,6 +50,30 @@ RSpec.describe FormStateMachine do
         it_behaves_like "transition to live state", FakeForm, :live_with_draft
       end
     end
+
+    context "when form is archived" do
+      let(:form) { FakeForm.new(state: :archived) }
+
+      it "does not transition to live state by default" do
+        expect(form).not_to transition_from(:archived).to(:live).on_event(:make_live)
+      end
+
+      context "when all sections are completed" do
+        it_behaves_like "transition to live state", FakeForm, :archived
+      end
+    end
+
+    context "when form is archived_with_draft" do
+      let(:form) { FakeForm.new(state: :archived_with_draft) }
+
+      it "does not transition to live state by default" do
+        expect(form).not_to transition_from(:archived_with_draft).to(:live).on_event(:make_live)
+      end
+
+      context "when all sections are completed" do
+        it_behaves_like "transition to live state", FakeForm, :archived_with_draft
+      end
+    end
   end
 
   describe ".create_draft_from_live_form" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/li50etsD/1432-implement-form-unarchiving

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
Updates the state machine to allow archived and archived_with_draft forms to be made live. This will enable us to implement unarchiving a form in forms-admin.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
