### PR TITLE
Allow user to create a draft for an archived form

### DIFF
--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -29,6 +29,7 @@ class Api::V1::FormsController < ApplicationController
       # TODO: https://trello.com/c/dg9CFPgp/1503-user-triggers-state-change-from-live-to-livewithdraft
       # Will not be needed when users can trigger this event themselves through the UI
       form.create_draft_from_live_form! if form.live?
+      form.create_draft_from_archived_form! if form.archived?
 
       render json: form.to_json, status: :ok
     else

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -33,6 +33,7 @@ class Page < ApplicationRecord
     # TODO: https://trello.com/c/dg9CFPgp/1503-user-triggers-state-change-from-live-to-livewithdraft
     # Will not be needed when users can trigger this event themselves through the UI
     form.create_draft_from_live_form! if form.live?
+    form.create_draft_from_archived_form! if form.archived?
 
     form.update!(question_section_completed: false)
     check_conditions.destroy_all if answer_type_changed_from_selection

--- a/app/service/task_status_service.rb
+++ b/app/service/task_status_service.rb
@@ -85,9 +85,11 @@ private
 
   def make_live_status
     if @form.has_draft_version
-      return mandatory_tasks_completed? ? :not_started : :cannot_start
+      mandatory_tasks_completed? ? :not_started : :cannot_start
+    elsif @form.has_been_archived
+      :not_started
+    elsif @form.has_live_version
+      :completed
     end
-
-    :completed if @form.has_live_version
   end
 end

--- a/app/service/task_status_service.rb
+++ b/app/service/task_status_service.rb
@@ -34,31 +34,23 @@ private
   end
 
   def pages_status
-    if @form.question_section_completed && @form.pages.any?
-      :completed
-    elsif @form.pages.any?
-      :in_progress
-    else
-      :not_started
-    end
+    return :completed if @form.question_section_completed && @form.pages.any?
+    return :in_progress if @form.pages.any?
+
+    :not_started
   end
 
   def declaration_status
-    if @form.declaration_section_completed
-      :completed
-    elsif @form.declaration_text.present?
-      :in_progress
-    else
-      :not_started
-    end
+    return :completed if @form.declaration_section_completed
+    return :in_progress if @form.declaration_text.present?
+
+    :not_started
   end
 
   def what_happens_next_status
-    if @form.what_happens_next_markdown.present?
-      :completed
-    else
-      :not_started
-    end
+    return :completed if @form.what_happens_next_markdown.present?
+
+    :not_started
   end
 
   def payment_link_status
@@ -68,28 +60,25 @@ private
   end
 
   def privacy_policy_status
-    if @form.privacy_policy_url.present?
-      :completed
-    else
-      :not_started
-    end
+    return :completed if @form.privacy_policy_url.present?
+
+    :not_started
   end
 
   def support_contact_details_status
-    if @form.support_email.present? || @form.support_phone.present? || (@form.support_url_text.present? && @form.support_url)
-      :completed
-    else
-      :not_started
-    end
+    return :completed if @form.support_email.present? || @form.support_phone.present? || (@form.support_url_text.present? && @form.support_url)
+
+    :not_started
   end
 
   def make_live_status
-    if @form.has_draft_version
-      mandatory_tasks_completed? ? :not_started : :cannot_start
-    elsif @form.has_been_archived
-      :not_started
-    elsif @form.has_live_version
-      :completed
-    end
+    return make_live_status_for_draft if @form.has_draft_version
+    return :not_started if @form.has_been_archived
+
+    :completed if @form.has_live_version
+  end
+
+  def make_live_status_for_draft
+    mandatory_tasks_completed? ? :not_started : :cannot_start
   end
 end

--- a/app/state_machines/form_state_machine.rb
+++ b/app/state_machines/form_state_machine.rb
@@ -41,6 +41,10 @@ module FormStateMachine
         transitions from: :live, to: :live_with_draft
       end
 
+      event :create_draft_from_archived_form do
+        transitions from: :archived, to: :archived_with_draft
+      end
+
       event :archive_live_form do
         transitions from: :live, to: :archived
         transitions from: :live_with_draft, to: :archived_with_draft

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -55,6 +55,11 @@ FactoryBot.define do
       after(:create, &:make_live!)
     end
 
+    trait :archived do
+      live
+      after(:create, &:archive_live_form!)
+    end
+
     trait :with_support do
       support_email { Faker::Internet.email(domain: "example.gov.uk") }
       support_phone { Faker::Lorem.paragraph(sentence_count: 2, supplemental: true, random_sentences_to_add: 4) }

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -203,6 +203,26 @@ RSpec.describe Page, type: :model do
       expect(form.question_section_completed).to be false
     end
 
+    context "when the form is live" do
+      let(:form) { create(:form, :live) }
+
+      it "updates the form state to live_with_draft" do
+        page.question_text = "Edited question"
+        page.save_and_update_form
+        expect(form.state).to eq("live_with_draft")
+      end
+    end
+
+    context "when the form is archived" do
+      let(:form) { create(:form, :archived) }
+
+      it "updates the form state to archived_with_draft" do
+        page.question_text = "Edited question"
+        page.save_and_update_form
+        expect(form.state).to eq("archived_with_draft")
+      end
+    end
+
     context "when page has routing conditions" do
       let(:routing_conditions) { [(create :condition)] }
       let(:check_conditions) { routing_conditions }

--- a/spec/service/task_status_service_spec.rb
+++ b/spec/service/task_status_service_spec.rb
@@ -165,11 +165,43 @@ describe TaskStatusService do
         end
       end
 
+      context "with a live form with a draft and all tasks complete" do
+        let(:form) { build(:form, :ready_for_live, state: :live_with_draft) }
+
+        it "returns the not started status" do
+          expect(task_status_service.task_statuses[:make_live_status]).to eq :not_started
+        end
+      end
+
+      context "with an archived form with a draft and incomplete tasks" do
+        let(:form) { build(:form, state: :archived_with_draft) }
+
+        it "returns the not started status" do
+          expect(task_status_service.task_statuses[:make_live_status]).to eq :cannot_start
+        end
+      end
+
+      context "with an archived form with a draft and all tasks complete" do
+        let(:form) { build(:form, :ready_for_live, state: :archived_with_draft) }
+
+        it "returns the not started status" do
+          expect(task_status_service.task_statuses[:make_live_status]).to eq :not_started
+        end
+      end
+
       context "with a live form" do
         let(:form) { create(:form, :live) }
 
         it "returns the completed status" do
           expect(task_status_service.task_statuses[:make_live_status]).to eq :completed
+        end
+      end
+
+      context "with an archived form" do
+        let(:form) { build(:form, state: :archived) }
+
+        it "returns the completed status" do
+          expect(task_status_service.task_statuses[:make_live_status]).to eq :not_started
         end
       end
     end

--- a/spec/state_machines/form_state_machine_spec.rb
+++ b/spec/state_machines/form_state_machine_spec.rb
@@ -92,6 +92,22 @@ RSpec.describe FormStateMachine do
     end
   end
 
+  describe ".create_draft_from_archived_form" do
+    let(:form) { FakeForm.new(state: :archived) }
+
+    it "transitions to archived_with_draft if form is archived" do
+      expect(form).to transition_from(:archived).to(:archived_with_draft).on_event(:create_draft_from_archived_form)
+    end
+
+    context "when form is draft" do
+      let(:form) { FakeForm.new(state: :draft) }
+
+      it "does not transition to live_with_draft" do
+        expect(form).not_to transition_from(:draft).to(:archived_with_draft).on_event(:create_draft_from_archived_form)
+      end
+    end
+  end
+
   describe ".archive_live_form" do
     context "when the form is draft" do
       let(:form) { FakeForm.new(state: :draft) }


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/UVCBeTs8/1433-allow-user-to-create-a-draft-for-an-archived-form

This PR:
- Adds a state transition from `archived` -> `archived_with_draft`
- Updates the state of an archived form to `archived_with_draft` when the form or a page of the form is updated
- Returns the appropriate `make_live_status` of the form for an archived form. This will be "Cannot start yet" if there is a draft with incomplete tasks, otherwise it will be "Not started"

### Things to consider when reviewing

You can test this by archiving a form and then clicking "Edit the draft of this form". The task list should show "Not started" for the "Make your changes live" task. If you mark a task as incomplete, this should change to "Cannot start yet".

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
