### PR TITLE
Add x86_64-darwin-23 to platforms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,6 +323,7 @@ PLATFORMS
   arm64-darwin-23
   x86_64-darwin-21
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
### What problem does this pull request solve?

Adds x86_64-darwin-23 to the bundle's platforms. This corresponds to macOS v14 Sonoma.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
