### PR TITLE
Make is_optional column non-nullable

### DIFF
--- a/db/migrate/20240510092310_make_is_optional_non_nullable.rb
+++ b/db/migrate/20240510092310_make_is_optional_non_nullable.rb
@@ -1,0 +1,5 @@
+class MakeIsOptionalNonNullable < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :pages, :is_optional, false, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_08_134335) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_10_092310) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -71,7 +71,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_08_134335) do
     t.text "hint_text"
     t.text "answer_type"
     t.integer "next_page"
-    t.boolean "is_optional"
+    t.boolean "is_optional", null: false
     t.jsonb "answer_settings"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
 
     question_text { Faker::Lorem.question }
     answer_type { Page::ANSWER_TYPES.sample }
-    is_optional { nil }
+    is_optional { false }
     answer_settings { nil }
     sequence(:position)
     routing_conditions { [] }


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->https://trello.com/c/WjhNHghp/1482-make-this-question-optional-checkbox-isnt-marked-as-optional

This field should always be either `true` or `false` - we don't want to allow `nil` values. This commit makes it non-nullable, and converts the existing `nil` values to `false`.

Shouldn't be merged until https://github.com/alphagov/forms-admin/pull/1143 has gone in

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
