### PR TITLE
Move push_to_dev and reset_to_main Rake tasks to pipeline:dev: namespace

### DIFF
--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -3,37 +3,41 @@ require "json"
 require "net/http"
 require "shellwords"
 
-desc "Push the commit at the tip of the current branch to the dev environment"
-task push_to_dev: :environment do
-  puts "Getting Git commit..."
-  git_hash = `git rev-parse HEAD`.chomp
-  $CHILD_STATUS.success? or raise
+namespace :pipeline do
+  namespace :dev do
+    desc "Push the commit at the tip of the current branch to the dev environment"
+    task push_to_dev: :environment do
+      puts "Getting Git commit..."
+      git_hash = `git rev-parse HEAD`.chomp
+      $CHILD_STATUS.success? or raise
 
-  puts "Will use Git commit: #{git_hash}"
-  puts "Checking commit has been pushed..."
+      puts "Will use Git commit: #{git_hash}"
+      puts "Checking commit has been pushed..."
 
-  resp = Net::HTTP.get_response URI("https://api.github.com/repos/alphagov/forms-api/commits/#{git_hash}")
-  if resp.code != "200"
-    puts "Commit has not been pushed. The pipelines will not be able to find it."
-    puts "Push the commit and run the command again."
-    raise
+      resp = Net::HTTP.get_response URI("https://api.github.com/repos/alphagov/forms-api/commits/#{git_hash}")
+      if resp.code != "200"
+        puts "Commit has not been pushed. The pipelines will not be able to find it."
+        puts "Push the commit and run the command again."
+        raise
+      end
+      puts "The commit is present in the remote"
+
+      push_commit_to_dev(git_hash)
+    end
+
+    desc "Push the commit at the tip of origin/main to the dev environment"
+    task reset_dev_to_main: :environment do
+      puts "Updating Git remotes"
+      sh "git", "fetch", verbose: false
+
+      git_hash = `git rev-parse origin/main`.chomp
+      $CHILD_STATUS.success? or raise
+
+      puts "Will use Git commit from tip of origin/main: #{git_hash}"
+
+      push_commit_to_dev(git_hash)
+    end
   end
-  puts "The commit is present in the remote"
-
-  push_commit_to_dev(git_hash)
-end
-
-desc "Push the commit at the tip of origin/main to the dev environment"
-task reset_dev_to_main: :environment do
-  puts "Updating Git remotes"
-  sh "git", "fetch", verbose: false
-
-  git_hash = `git rev-parse origin/main`.chomp
-  $CHILD_STATUS.success? or raise
-
-  puts "Will use Git commit from tip of origin/main: #{git_hash}"
-
-  push_commit_to_dev(git_hash)
 end
 
 def push_commit_to_dev(git_hash)


### PR DESCRIPTION
### What problem does this pull request solve?

We introduced a new namespace that these tasks fit in nicely.
