### PR TITLE
Add task for updating the org that owns a form

### DIFF
--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -1,0 +1,15 @@
+namespace :forms do
+  desc "Update the organisation that owns a form"
+  task :update_organisation, %i[form_id organisation_id] => :environment do |_, args|
+    usage_message = "usage: rake forms:update_organisation[<form_id>, <organisation_id>]".freeze
+    abort usage_message if args[:form_id].blank? || args[:organisation_id].blank?
+
+    form = Form.find_by(id: args[:form_id])
+    abort "Form with ID: #{args[:form_id]} not found" unless form
+
+    form.organisation_id = args[:organisation_id]
+    form.save!
+
+    puts "Updated organisation for Form: #{form.id} to be #{args[:organisation_id]}"
+  end
+end

--- a/spec/lib/tasks/forms.rake_spec.rb
+++ b/spec/lib/tasks/forms.rake_spec.rb
@@ -1,0 +1,34 @@
+require "rake"
+
+require "rails_helper"
+
+RSpec.describe "forms.rake" do
+  before do
+    Rake.application.rake_require "tasks/forms"
+    Rake::Task.define_task(:environment)
+  end
+
+  describe "forms:update_organisation" do
+    subject(:task) do
+      Rake::Task["forms:update_organisation"]
+        .tap(&:reenable) # make sure task is invoked every time
+    end
+
+    let(:form) { create :form, id: 1, organisation_id: 1 }
+    let(:target_organisation_id) { 2 }
+
+    it "aborts when the form is not found" do
+      expect { task.invoke(2, target_organisation_id) }
+        .to output(/Form with ID: 2 not found/)
+              .to_stderr
+              .and raise_error(SystemExit) { |e| expect(e).not_to be_success }
+    end
+
+    it "updates the organisation for a form" do
+      expect { task.invoke(form.id, target_organisation_id) }
+        .to change { form.reload.organisation_id }.to(target_organisation_id)
+        .and output(/Updated organisation for Form: 1 to be 2/)
+              .to_stdout
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->sort of related to https://trello.com/c/xARqWpGD/1558-model-ibca-as-new-organisation

This is a common support task. Previously we had to do this with a manual request to the forms-api. This PR adds a new rake task so that we can perform this support task using `run-task` as we do for other tasks.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
