### PR TITLE
Add .DS_Store files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ config/settings/*.local.yml
 config/environments/*.local.yml
 
 coverage
+
+.DS_Store


### PR DESCRIPTION
.DS_Store files are macOS-specific metadata files that there is no need to share, so shouldn't be tracked by git