### PR TITLE
Bump rexml from 3.3.1 to 3.3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,7 +245,7 @@ GEM
       rack (>= 1.4)
     reverse_markdown (2.1.1)
       nokogiri
-    rexml (3.3.1)
+    rexml (3.3.2)
       strscan
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)


### PR DESCRIPTION
### What problem does this pull request solve?

Main build was failing due to a CVE
https://github.com/ruby/rexml/security/advisories/GHSA-4xqq-m2hx-25v8 which is fixed in rexml version 3.3.2

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
