### PR TITLE
Add attribute for "add another answer" for a single question

### DIFF
--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -90,6 +90,7 @@ private
       :answer_type,
       :next_page,
       :is_optional,
+      :is_repeatable,
       *guidance_params,
       answer_setting_params,
     )

--- a/app/service/features_report_service.rb
+++ b/app/service/features_report_service.rb
@@ -6,6 +6,7 @@ class FeaturesReportService
       live_pages_with_answer_type:,
       live_forms_with_payment:,
       live_forms_with_routing:,
+      live_forms_with_add_another_answer:,
     }
   end
 
@@ -29,5 +30,9 @@ private
 
   def live_pages_with_answer_type
     Page.joins(:form).where(forms: { state: %w[live live_with_draft] }).group(:answer_type).count.symbolize_keys
+  end
+
+  def live_forms_with_add_another_answer
+    Page.joins(:form).where(forms: { state: %w[live live_with_draft] }).select("forms.id,pages.is_repeatable").where(pages: { is_repeatable: true }).count("forms.id")
   end
 end

--- a/db/migrate/20240801093156_add_is_repeatable_to_pages.rb
+++ b/db/migrate/20240801093156_add_is_repeatable_to_pages.rb
@@ -1,0 +1,5 @@
+class AddIsRepeatableToPages < ActiveRecord::Migration[7.1]
+  def change
+    add_column :pages, :is_repeatable, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_10_092310) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_01_093156) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -79,6 +79,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_10_092310) do
     t.integer "position"
     t.text "page_heading"
     t.text "guidance_markdown"
+    t.boolean "is_repeatable", default: false, null: false
     t.index ["form_id"], name: "index_pages_on_form_id"
   end
 

--- a/spec/requests/api/v1/pages_controller_spec.rb
+++ b/spec/requests/api/v1/pages_controller_spec.rb
@@ -73,7 +73,8 @@ describe Api::V1::PagesController, type: :request do
                                                            created_at: "2023-01-01T12:00:00.000Z",
                                                            updated_at: "2023-01-01T12:00:00.000Z",
                                                            page_heading: nil,
-                                                           guidance_markdown: nil).as_json)
+                                                           guidance_markdown: nil,
+                                                           is_repeatable: false).as_json)
     end
 
     context "with params missing required keys" do

--- a/spec/requests/api/v1/reports_controller_spec.rb
+++ b/spec/requests/api/v1/reports_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::V1::ReportsController, type: :request do
         (build :page, answer_type: "name"),
         (build :page, answer_type: "organisation_name"),
         (build :page, answer_type: "phone_number"),
-        (build :page, answer_type: "email"),
+        (build :page, answer_type: "email", is_repeatable: true),
         (build :page, answer_type: "address"),
         (build :page, answer_type: "national_insurance_number"),
         (build :page, answer_type: "date"),
@@ -55,6 +55,7 @@ RSpec.describe Api::V1::ReportsController, type: :request do
         },
         live_forms_with_payment: 1,
         live_forms_with_routing: 1,
+        live_forms_with_add_another_answer: 1,
       })
     end
 

--- a/spec/service/features_report_service_spec.rb
+++ b/spec/service/features_report_service_spec.rb
@@ -49,11 +49,18 @@ describe FeaturesReportService do
     ]
   end
 
+  let!(:pages_with_add_another_answer) do
+    [
+      (build :page, answer_type: "name", is_repeatable: true),
+    ]
+  end
+
   let(:form_1_pages) { pages_with_all_answer_types }
   let(:form_2_pages) { pages_with_all_answer_types }
   let(:form_3_pages) { pages_with_repeated_answer_type }
   let(:form_4_pages) { pages_with_all_answer_types }
   let(:form_5_pages) { pages_with_repeated_answer_type }
+  let(:form_6_pages) { pages_with_with_add_another_answer }
 
   let(:payment_url) { nil }
 
@@ -123,6 +130,16 @@ describe FeaturesReportService do
           response = features_report_service.report
 
           expect(response[:live_forms_with_routing]).to eq 1
+        end
+      end
+
+      context "when a live form uses the add another answer feature" do
+        let(:form_5_pages) { pages_with_add_another_answer }
+
+        it "counts the form in the add another answer part of the report" do
+          response = features_report_service.report
+
+          expect(response[:live_forms_with_add_another_answer]).to eq 1
         end
       end
     end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://github.com/alphagov/forms-admin/pull/1364 <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to be able to support an "add another answer" feature for questions in forms.

This PR allows a single question to be marked as allowing more than one answer, in the simplest possible way.

Currently there is no support for this attribute in forms-admin or forms-runner, so the best way to test this is with an API client such as httpie or postman.

Also note that https://github.com/alphagov/forms-admin/pull/1364 needs to be merged before this PR, otherwise the end to end tests will break as forms-admin will refuse the new attribute.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?