### PR TITLE
1681 3 add unique form url code column to api 3

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -55,13 +55,14 @@ class Form < ApplicationRecord
   end
 
   def as_json(options = {})
+    options[:except] ||= [:external_id]
     options[:methods] ||= %i[live_at start_page has_draft_version has_live_version has_routing_errors ready_for_live incomplete_tasks task_statuses]
     super(options)
   end
 
   def snapshot(**kwargs)
     # override methods so it doesn't include things we don't want
-    as_json(except: :state,
+    as_json(except: %i[state external_id],
             include: {
               pages: {
                 include: {

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -13,6 +13,8 @@ class Form < ApplicationRecord
   scope :filter_by_organisation_id, ->(organisation_id) { where organisation_id: }
   scope :filter_by_creator_id, ->(creator_id) { where creator_id: }
 
+  after_create :set_external_id
+
   def start_page
     pages&.first&.id
   end
@@ -93,6 +95,10 @@ class Form < ApplicationRecord
   delegate :task_statuses, to: :task_status_service
 
 private
+
+  def set_external_id
+    update(external_id: id)
+  end
 
   def task_status_service
     @task_status_service ||= TaskStatusService.new(form: self)

--- a/db/migrate/20240801123903_add_external_id_to_forms.rb
+++ b/db/migrate/20240801123903_add_external_id_to_forms.rb
@@ -1,0 +1,6 @@
+class AddExternalIdToForms < ActiveRecord::Migration[7.1]
+  def change
+    add_column :forms, :external_id, :string
+    add_index :forms, :external_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_01_093156) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_01_123903) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -56,6 +56,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_01_093156) do
     t.text "what_happens_next_markdown"
     t.string "state"
     t.string "payment_url"
+    t.string "external_id"
+    t.index ["external_id"], name: "index_forms_on_external_id", unique: true
   end
 
   create_table "made_live_forms", force: :cascade do |t|
@@ -83,6 +85,31 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_01_093156) do
     t.index ["form_id"], name: "index_pages_on_form_id"
   end
 
+  create_table "question_sets", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "questions", force: :cascade do |t|
+    t.string "question_text"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "steps", force: :cascade do |t|
+    t.string "positionable_type", null: false
+    t.bigint "positionable_id", null: false
+    t.bigint "next_step_id"
+    t.integer "position"
+    t.bigint "parent_question_set_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["next_step_id"], name: "index_steps_on_next_step_id"
+    t.index ["parent_question_set_id"], name: "index_steps_on_parent_question_set_id"
+    t.index ["positionable_type", "positionable_id"], name: "index_steps_on_positionable"
+  end
+
   create_table "versions", force: :cascade do |t|
     t.string "item_type", null: false
     t.bigint "item_id", null: false
@@ -96,4 +123,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_01_093156) do
 
   add_foreign_key "made_live_forms", "forms"
   add_foreign_key "pages", "forms"
+  add_foreign_key "steps", "question_sets", column: "parent_question_set_id"
+  add_foreign_key "steps", "steps", column: "next_step_id"
 end

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
     declaration_section_completed { false }
     state { :draft }
     payment_url { nil }
+    external_id { nil }
 
     trait :new_form do
       submission_email { "" }

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -99,6 +99,13 @@ RSpec.describe Form, type: :model do
     end
   end
 
+  describe "external_id" do
+    it "intialises a new form with an external id matching its id" do
+      form = create :form
+      expect(form.external_id).to eq(form.id.to_s)
+    end
+  end
+
   describe "start_page" do
     it "returns nil when form has no pages" do
       expect(form.start_page).to be_nil


### PR DESCRIPTION
### What problem does this pull request solve?

https://trello.com/c/NNdV9jj3/1681-3-add-unique-form-url-code-column-to-api-3

The first part of adding external IDs for forms - this adds the external ID column, and starts assigning them for newly created forms with the their normal ID. 

The next step is to migrate all existing forms into the same format, so that all forms from that point onwards have an external id, which is equivalent to their current ID.

### Things to consider when reviewing

There aren't any UI aspects to this yet, so a little hard to test - but you can, once pulled down, check that all your existing forms are migrated with no external ID - but new forms are given one. 

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
