### PR TITLE
Add rake task for setting external_id to id for all forms

### DIFF
--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -12,4 +12,13 @@ namespace :forms do
 
     puts "Updated organisation for Form: #{form.id} to be #{args[:organisation_id]}"
   end
+
+  desc "Sets the external_id for all forms to their id"
+  task set_external_ids: :environment do
+    puts "setting external_id for each form to their id"
+
+    Form.find_each { |form| form.update_column(:external_id, form.id) }
+
+    puts "external_id has been set for each form to their id"
+  end
 end

--- a/spec/lib/tasks/forms.rake_spec.rb
+++ b/spec/lib/tasks/forms.rake_spec.rb
@@ -31,4 +31,22 @@ RSpec.describe "forms.rake" do
               .to_stdout
     end
   end
+
+  describe "forms:set_external_ids" do
+    subject(:task) do
+      Rake::Task["forms:set_external_ids"]
+        .tap(&:reenable)
+    end
+
+    let(:form) { create :form, id: form_id }
+    let(:form_id) { 3 }
+
+    it "sets a form's external_id to its id" do
+      form.update!(external_id: nil)
+      expect { task.invoke }
+        .to change { form.reload.external_id }.to(form_id.to_s)
+        .and output(/external_id has been set for each form to their id/)
+              .to_stdout
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

https://trello.com/c/UUocDXYa/1680-5-migration-for-existing-form-external-ids-5

This rake task will attribute every form's external id as its id. This is meant to be a task that is run once, and after this https://github.com/alphagov/forms-api/pull/544 has been deployed. 

From that point forwards, all new forms and existing forms will have an `external_id`, which will lead on to the next steps for moving away from exposing our form ids