### PR TITLE
Add rake task to remove access token

### DIFF
--- a/lib/tasks/access_tokens.rake
+++ b/lib/tasks/access_tokens.rake
@@ -1,0 +1,13 @@
+namespace :access_tokens do
+  desc "Remove an access token for a user"
+  task :remove_access_token, %i[owner_email] => :environment do |_, args|
+    usage_message = "usage: rake access_tokens:remove_access_token[<owner_email>]".freeze
+    abort usage_message if args[:owner_email].blank?
+
+    token = AccessToken.find_by(owner: args[:owner_email])
+    abort "Access token with owner #{args[:owner_email]} not found" unless token
+
+    token.destroy!
+    puts "Access token removed for #{args[:owner_email]}"
+  end
+end

--- a/spec/lib/tasks/access_tokens.rake_spec.rb
+++ b/spec/lib/tasks/access_tokens.rake_spec.rb
@@ -1,0 +1,29 @@
+require "rake"
+
+require "rails_helper"
+
+RSpec.describe "access_tokens.rake" do
+  before do
+    Rake.application.rake_require "tasks/access_tokens"
+    Rake::Task.define_task(:environment)
+  end
+
+  describe "access_tokens:remove_access_token" do
+    subject(:task) do
+      Rake::Task["access_tokens:remove_access_token"]
+        .tap(&:reenable)
+    end
+
+    let(:token) { AccessToken.new(owner: "test-owner") }
+
+    before do
+      token.owner = "test-user@example.com"
+      token.generate_token
+      token.save!
+    end
+
+    it "removes an access token for a user" do
+      expect { task.invoke(token.owner) }.to output(/Access token removed for test-user@example.com/).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
### What problem does this pull request solve?

We need to remove a developer's access token. At the moment our workflow relies on another dev with a valid token to follow the steps with our access token API. As an API this makes sense for users, but there are situations where no one has an access token and it's just a bit painful.

We don't want to have to do things like run a SQL query or raiding a backup token.

The intention is to use our cli tool which is restricted.

https://trello.com/c/GDNpsobU

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
