### PR TITLE
Remove tables from schema that don't have migrations

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,31 +85,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_01_123903) do
     t.index ["form_id"], name: "index_pages_on_form_id"
   end
 
-  create_table "question_sets", force: :cascade do |t|
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "questions", force: :cascade do |t|
-    t.string "question_text"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "steps", force: :cascade do |t|
-    t.string "positionable_type", null: false
-    t.bigint "positionable_id", null: false
-    t.bigint "next_step_id"
-    t.integer "position"
-    t.bigint "parent_question_set_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["next_step_id"], name: "index_steps_on_next_step_id"
-    t.index ["parent_question_set_id"], name: "index_steps_on_parent_question_set_id"
-    t.index ["positionable_type", "positionable_id"], name: "index_steps_on_positionable"
-  end
-
   create_table "versions", force: :cascade do |t|
     t.string "item_type", null: false
     t.bigint "item_id", null: false
@@ -123,6 +98,4 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_01_123903) do
 
   add_foreign_key "made_live_forms", "forms"
   add_foreign_key "pages", "forms"
-  add_foreign_key "steps", "question_sets", column: "parent_question_set_id"
-  add_foreign_key "steps", "steps", column: "next_step_id"
 end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

In commit 9293a99 the db/schema.rb file was updated with some new `create_table` statements from migrations weren't committed; I think this happened because some local changes were present in the database for changes unrelated to that commit.

We don't actually want these tables in the API database, at least not yet, so we haven't added any migrations for these tables; so these tables shouldn't be in the schema file. This commit removes them.

For developers running forms-api locally they will need to rebuild their development database to incorporate this change. For production systems this commit shouldn't have any effect, as the deployment process uses migrations rather than the schema file.


### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?