### PR TITLE
Prepare for dropping form.organisation_id column

### DIFF
--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -5,11 +5,9 @@ class Api::V1::FormsController < ApplicationController
   end
 
   def index
-    organisation_id = params[:organisation_id]
     creator_id = params[:creator_id]
 
     forms = Form.all
-    forms = forms.filter_by_organisation_id(organisation_id) if organisation_id.present?
     forms = forms.filter_by_creator_id(creator_id) if creator_id.present?
 
     render json: forms.order(:name).to_json

--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -72,12 +72,6 @@ class Api::V1::FormsController < ApplicationController
     render json: form.archived_live_version, status: :ok
   end
 
-  def update_organisation_for_creator
-    params.require(%i[creator_id organisation_id])
-    Form.where(creator_id: params[:creator_id]).update_all(organisation_id: params[:organisation_id], updated_at: Time.zone.now)
-    render status: :no_content
-  end
-
 private
 
   def form

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -10,7 +10,6 @@ class Form < ApplicationRecord
   validates :payment_url, url: true, allow_blank: true
   validate :marking_complete_with_errors
 
-  scope :filter_by_organisation_id, ->(organisation_id) { where organisation_id: }
   scope :filter_by_creator_id, ->(creator_id) { where creator_id: }
 
   after_create :set_external_id

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -14,6 +14,8 @@ class Form < ApplicationRecord
 
   after_create :set_external_id
 
+  self.ignored_columns = %w[organisation_id]
+
   def start_page
     pages&.first&.id
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,10 +20,6 @@ Rails.application.routes.draw do
         post "/archive", to: "api/v1/forms#archive"
       end
 
-      collection do
-        patch "/update-organisation-for-creator", to: "api/v1/forms#update_organisation_for_creator"
-      end
-
       resources :pages, controller: "api/v1/pages", param: :page_id do
         member do
           resources :conditions, controller: "api/v1/conditions", param: :condition_id

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,7 +7,6 @@
 #   Character.create(name: "Luke", movie: movies.first)
 
 submission_email = ENV["EMAIL"] || `git config --get user.email`.strip
-organisation_id = 1 # Assumes you're using the default database seed for forms-admin
 
 all_question_types_form = Form.create!(
   name: "All question types form",
@@ -84,7 +83,6 @@ all_question_types_form = Form.create!(
   question_section_completed: true,
   declaration_text: "",
   declaration_section_completed: true,
-  organisation_id:,
   privacy_policy_url: "https://www.gov.uk/help/privacy-notice",
   submission_email:,
   support_email: "your.email+fakedata84701@gmail.com.gov.uk",

--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -1,18 +1,4 @@
 namespace :forms do
-  desc "Update the organisation that owns a form"
-  task :update_organisation, %i[form_id organisation_id] => :environment do |_, args|
-    usage_message = "usage: rake forms:update_organisation[<form_id>, <organisation_id>]".freeze
-    abort usage_message if args[:form_id].blank? || args[:organisation_id].blank?
-
-    form = Form.find_by(id: args[:form_id])
-    abort "Form with ID: #{args[:form_id]} not found" unless form
-
-    form.organisation_id = args[:organisation_id]
-    form.save!
-
-    puts "Updated organisation for Form: #{form.id} to be #{args[:organisation_id]}"
-  end
-
   desc "Sets the external_id for all forms to their id"
   task set_external_ids: :environment do
     puts "setting external_id for each form to their id"

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     sequence(:form_slug) { |n| "form-#{n}" }
     submission_email { Faker::Internet.email(domain: "example.gov.uk") }
     privacy_policy_url { Faker::Internet.url(host: "gov.uk") }
-    organisation_id { 1 }
     support_email { nil }
     support_phone { nil }
     support_url { nil }

--- a/spec/lib/tasks/forms.rake_spec.rb
+++ b/spec/lib/tasks/forms.rake_spec.rb
@@ -8,30 +8,6 @@ RSpec.describe "forms.rake" do
     Rake::Task.define_task(:environment)
   end
 
-  describe "forms:update_organisation" do
-    subject(:task) do
-      Rake::Task["forms:update_organisation"]
-        .tap(&:reenable) # make sure task is invoked every time
-    end
-
-    let(:form) { create :form, id: 1, organisation_id: 1 }
-    let(:target_organisation_id) { 2 }
-
-    it "aborts when the form is not found" do
-      expect { task.invoke(2, target_organisation_id) }
-        .to output(/Form with ID: 2 not found/)
-              .to_stderr
-              .and raise_error(SystemExit) { |e| expect(e).not_to be_success }
-    end
-
-    it "updates the organisation for a form" do
-      expect { task.invoke(form.id, target_organisation_id) }
-        .to change { form.reload.organisation_id }.to(target_organisation_id)
-        .and output(/Updated organisation for Form: 1 to be 2/)
-              .to_stdout
-    end
-  end
-
   describe "forms:set_external_ids" do
     subject(:task) do
       Rake::Task["forms:set_external_ids"]

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -129,8 +129,8 @@ RSpec.describe Form, type: :model do
   end
 
   describe "scopes" do
-    let(:form_a) { create :form, organisation_id: 111 }
-    let(:form_b) { create :form, creator_id: 123, organisation_id: 111 }
+    let(:form_a) { create :form }
+    let(:form_b) { create :form, creator_id: 123 }
     let(:form_c) { create :form, creator_id: 1234 }
 
     it "return forms with matching creator ID" do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -136,16 +136,6 @@ RSpec.describe Form, type: :model do
     it "return forms with matching creator ID" do
       expect(described_class.filter_by_creator_id(1234)).to eq([form_c])
     end
-
-    it "return forms with matching organisation" do
-      expect(described_class.filter_by_organisation_id(111)).to eq([form_a, form_b])
-    end
-
-    it "return forms with matching organisation and creator ID" do
-      described_class.filter_by_organisation_id(111)
-      forms = described_class.filter_by_creator_id(123)
-      expect(forms).to eq([form_b])
-    end
   end
 
   describe "#make_live! from FormStateMachine" do

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -284,7 +284,6 @@ RSpec.describe Form, type: :model do
         "id",
         "name",
         "submission_email",
-        "organisation_id",
         "creator_id",
         "created_at",
         "updated_at",

--- a/spec/requests/api/v1/forms_controller_spec.rb
+++ b/spec/requests/api/v1/forms_controller_spec.rb
@@ -145,16 +145,15 @@ describe Api::V1::FormsController, type: :request do
     end
 
     it "when given an existing id, returns 200 and form data" do
-      form1 = Form.create!(name: "test form 1", organisation_id: 1, creator_id: 123)
+      form1 = Form.create!(name: "test form 1", creator_id: 123)
       get form_path(form1), as: :json
       expect(response).to have_http_status(:ok)
       expect(response.headers["Content-Type"]).to eq("application/json")
 
-      expect(json_body).to match(
+      expect(json_body).to include(
         id: form1.id,
         name: "test form 1",
         submission_email: nil,
-        organisation_id: 1,
         creator_id: 123,
         has_draft_version: true,
         has_live_version: false,

--- a/spec/requests/api/v1/forms_controller_spec.rb
+++ b/spec/requests/api/v1/forms_controller_spec.rb
@@ -357,59 +357,6 @@ describe Api::V1::FormsController, type: :request do
     end
   end
 
-  describe "#update_organisation_for_creator" do
-    let(:selected_creator_id) { 1234 }
-    let(:updated_organisation_id) { 111 }
-
-    before do
-      patch update_organisation_for_creator_forms_path, params: { creator_id: selected_creator_id, organisation_id: updated_organisation_id }
-    end
-
-    context "when some forms match creator ID" do
-      it "updates organisation only if creator ID matches" do
-        expect(response).to have_http_status(:no_content)
-
-        all_forms.each do |form|
-          form.reload
-          if form.creator_id == selected_creator_id
-            expect(form.organisation_id).to eq(updated_organisation_id)
-          else
-            expect(form.organisation_id).not_to eq(updated_organisation_id)
-          end
-        end
-      end
-    end
-
-    context "when no forms match creator ID" do
-      let(:selected_creator_id) { 321 }
-
-      it "does not update organisation" do
-        expect(response).to have_http_status(:no_content)
-
-        all_forms.each do |form|
-          form.reload
-          expect(form.organisation_id).not_to eq(updated_organisation_id)
-        end
-      end
-    end
-
-    context "without creator ID" do
-      let(:selected_creator_id) { nil }
-
-      it "returns bad request if creator ID is missing" do
-        expect(response).to have_http_status(:bad_request)
-      end
-    end
-
-    context "without organisation ID" do
-      let(:updated_organisation_id) { nil }
-
-      it "returns bad request if organisation ID is missing" do
-        expect(response).to have_http_status(:bad_request)
-      end
-    end
-  end
-
   describe "#archive" do
     it "when no forms exists for an id, returns 404 an error" do
       post archive_form_path(123), as: :json

--- a/spec/requests/api/v1/forms_controller_spec.rb
+++ b/spec/requests/api/v1/forms_controller_spec.rb
@@ -148,7 +148,7 @@ describe Api::V1::FormsController, type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.headers["Content-Type"]).to eq("application/json")
 
-      expect(json_body).to include(
+      expect(json_body).to match(
         id: form1.id,
         name: "test form 1",
         submission_email: nil,

--- a/spec/requests/api/v1/forms_controller_spec.rb
+++ b/spec/requests/api/v1/forms_controller_spec.rb
@@ -65,7 +65,7 @@ describe Api::V1::FormsController, type: :request do
 
   describe "#create" do
     let(:created_form) { Form.find_by(name: "test form one") }
-    let(:new_form_params) { { organisation_id: 1, name: "test form one", submission_email: "test@example.gov.uk" } }
+    let(:new_form_params) { { name: "test form one", submission_email: "test@example.gov.uk" } }
 
     before do
       freeze_time
@@ -86,7 +86,6 @@ describe Api::V1::FormsController, type: :request do
       it "created the form in the DB" do
         expect(created_form[:name]).to eq("test form one")
         expect(created_form[:submission_email]).to eq("test@example.gov.uk")
-        expect(created_form[:organisation_id]).to eq(1)
       end
     end
 
@@ -101,7 +100,7 @@ describe Api::V1::FormsController, type: :request do
     end
 
     context "with extra params" do
-      let(:new_form_params) { { organisation_id: 1, name: "test form one", submission_email: "test@example.gov.uk", support_url: "http://example.org" } }
+      let(:new_form_params) { { name: "test form one", submission_email: "test@example.gov.uk", support_url: "http://example.org" } }
 
       it "returns a status code 201" do
         expect(response).to have_http_status(:created)
@@ -112,13 +111,12 @@ describe Api::V1::FormsController, type: :request do
       it "created the form in the DB" do
         expect(created_form[:name]).to eq("test form one")
         expect(created_form[:submission_email]).to eq("test@example.gov.uk")
-        expect(created_form[:organisation_id]).to eq(1)
         expect(created_form[:support_url]).to eq("http://example.org")
       end
     end
 
     context "with created_at and updated_at params" do
-      let(:new_form_params) { { organisation_id: 1, name: "test form one", submission_email: "test@example.gov.uk", created_at: "2023-01-11T16:22:22.661+00:00", updated_at: "2023-01-11T16:24:22.661+00:00" } }
+      let(:new_form_params) { { name: "test form one", submission_email: "test@example.gov.uk", created_at: "2023-01-11T16:22:22.661+00:00", updated_at: "2023-01-11T16:24:22.661+00:00" } }
 
       it "does not use the provided created_at or updated_at values" do
         expect(response).to have_http_status(:created)

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -40,7 +40,7 @@ describe ApplicationController, type: :request do
       end
 
       it "returns 200" do
-        get forms_path, params: { organisation_id: 1 }, headers: req_headers
+        get forms_path, headers: req_headers
         expect(response.status).to eq(200)
       end
     end
@@ -49,7 +49,7 @@ describe ApplicationController, type: :request do
       it "returns 200" do
         Settings.forms_api.auth_key = 123_456
         Settings.forms_api.enabled_auth = true
-        get forms_path, params: { organisation_id: 1 }, headers: req_headers
+        get forms_path, headers: req_headers
         expect(response.status).to eq(200)
       end
     end
@@ -64,7 +64,7 @@ describe ApplicationController, type: :request do
       it "returns 401" do
         Settings.forms_api.auth_key = 123_456
         Settings.forms_api.enabled_auth = true
-        get forms_path, params: { organisation_id: 1 }, headers: req_headers
+        get forms_path, headers: req_headers
         expect(response.status).to eq(401)
       end
     end
@@ -74,7 +74,7 @@ describe ApplicationController, type: :request do
 
       it "returns 200" do
         Settings.forms_api.auth_key = 123_456
-        get forms_path, params: { organisation_id: 1 }, headers: req_headers
+        get forms_path, headers: req_headers
         expect(response.status).to eq(401)
       end
     end
@@ -98,7 +98,7 @@ describe ApplicationController, type: :request do
         access_token.save!
         freeze_time do
           time_now
-          get forms_path, params: { organisation_id: 1 }, headers: req_headers
+          get forms_path, headers: req_headers
         end
       end
 
@@ -117,7 +117,7 @@ describe ApplicationController, type: :request do
           access_token
           token
           access_token.save!
-          get forms_path, params: { organisation_id: 1 }, headers: req_headers
+          get forms_path, headers: req_headers
         end
 
         it "returns 401" do
@@ -149,7 +149,7 @@ describe ApplicationController, type: :request do
         access_token.save!
         freeze_time do
           time_now
-          get forms_path, params: { organisation_id: 1 }, headers: req_headers
+          get forms_path, headers: req_headers
         end
       end
 
@@ -168,7 +168,7 @@ describe ApplicationController, type: :request do
           access_token
           token
           access_token.save!
-          get forms_path, params: { organisation_id: 1 }, headers: req_headers
+          get forms_path, headers: req_headers
         end
 
         it "returns 401" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/ZHGNp5Lk/1774-remove-organisationid-from-forms-api

Forms-admin no longer consumes the `form.organisation_id` - see https://github.com/alphagov/forms-admin/pull/1423.

This PR removes all uses of `form.organisation_id` from the forms-api code. It also sets the `ignored_columns` for the Forms ActiveModel to safely allow the column to be dropped. See the [ActiveRecord documentation](https://api.rubyonrails.org/v7.1.3.4/classes/ActiveRecord/ModelSchema/ClassMethods.html#method-i-ignored_columns-3D) for usage of `ignored_columns`.

This follows the steps outlined in this [blog](https://andycroll.com/ruby/safely-remove-a-column-field-from-active-record/) to safely remove a column.

Once this is merged, a follow-up PR will include a migration to drop the column from the forms table.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
