### PR TITLE
Remove organisation_id column from forms table

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -14,8 +14,6 @@ class Form < ApplicationRecord
 
   after_create :set_external_id
 
-  self.ignored_columns = %w[organisation_id]
-
   def start_page
     pages&.first&.id
   end

--- a/db/migrate/20240910115155_remove_organisation_id_from_forms.rb
+++ b/db/migrate/20240910115155_remove_organisation_id_from_forms.rb
@@ -1,0 +1,5 @@
+class RemoveOrganisationIdFromForms < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :forms, :organisation_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_01_123903) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_10_115155) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,7 +52,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_01_123903) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "creator_id"
-    t.bigint "organisation_id"
     t.text "what_happens_next_markdown"
     t.string "state"
     t.string "payment_url"


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/ZHGNp5Lk/1774-remove-organisationid-from-forms-api

This column is no longer referenced, and is ignored by the Forms ActiveRecord, so can be safely dropped.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
