### PR TITLE
Add rake task to update submission type

### DIFF
--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -7,4 +7,13 @@ namespace :forms do
 
     puts "external_id has been set for each form to their id"
   end
+
+  desc "Set submission_type to email_with_csv"
+  task :set_submission_type_to_email_with_csv, %i[form_id] => :environment do |_, args|
+    puts "setting submission_type to email_with_csv for form: #{args[:form_id]}"
+
+    Form.find(args[:form_id]).email_with_csv!
+
+    puts "set submission_type to email_with_csv for form: #{args[:form_id]}"
+  end
 end

--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -10,6 +10,9 @@ namespace :forms do
 
   desc "Set submission_type to email_with_csv"
   task :set_submission_type_to_email_with_csv, %i[form_id] => :environment do |_, args|
+    usage_message = "usage: rake forms:set_submission_type_to_email_with_csv[<form_id>]".freeze
+    abort usage_message if args[:form_id].blank?
+
     puts "setting submission_type to email_with_csv for form: #{args[:form_id]}"
 
     Form.find(args[:form_id]).email_with_csv!


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/DQCipW8q

This PR adds a rake task to update `submission_type` for a given form. This will be a temporary rake task to set the `submission_type` for forms that currently have CSV submission enabled via the per form feature flag.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
