### PR TITLE
Add api_v2_form_documents table and model

### DIFF
--- a/app/models/api/v2.rb
+++ b/app/models/api/v2.rb
@@ -1,0 +1,5 @@
+module Api::V2
+  def self.table_name_prefix
+    "api_v2_"
+  end
+end

--- a/app/models/api/v2/form_document.rb
+++ b/app/models/api/v2/form_document.rb
@@ -1,0 +1,5 @@
+class Api::V2::FormDocument < ApplicationRecord
+  belongs_to :form, class_name: "Api::V2::Form", optional: false
+
+  validates :tag, presence: true
+end

--- a/db/migrate/20240916122719_create_api_v2_form_documents.rb
+++ b/db/migrate/20240916122719_create_api_v2_form_documents.rb
@@ -1,0 +1,13 @@
+class CreateApiV2FormDocuments < ActiveRecord::Migration[7.1]
+  def change
+    create_table :api_v2_form_documents do |t|
+      t.references :form, foreign_key: true, comment: "The form this document belongs to"
+      t.text :tag, null: false,  comment: "The tag for the form, for example: 'live' or 'draft'"
+      t.jsonb :content, comment: "The JSON which describes the form"
+
+      t.timestamps
+
+      t.index %i[form_id tag], unique: true, name: "index_api_v2_form_documents_on_form_id_and_tag"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_13_151655) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_16_122719) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_13_151655) do
     t.datetime "updated_at", null: false
     t.datetime "last_accessed_at"
     t.string "description"
+  end
+
+  create_table "api_v2_form_documents", force: :cascade do |t|
+    t.bigint "form_id", comment: "The form this document belongs to"
+    t.text "tag", null: false, comment: "The tag for the form, for example: 'live' or 'draft'"
+    t.jsonb "content", comment: "The JSON which describes the form"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["form_id", "tag"], name: "index_api_v2_form_documents_on_form_id_and_tag", unique: true
+    t.index ["form_id"], name: "index_api_v2_form_documents_on_form_id"
   end
 
   create_table "conditions", force: :cascade do |t|
@@ -96,6 +106,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_13_151655) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  add_foreign_key "api_v2_form_documents", "forms"
   add_foreign_key "made_live_forms", "forms"
   add_foreign_key "pages", "forms"
 end

--- a/spec/factories/api/v2/form_documents.rb
+++ b/spec/factories/api/v2/form_documents.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :form_document, class: "Api::V2::FormDocument" do
+    form { association :api_v2_form }
+    tag { :draft }
+  end
+end

--- a/spec/models/api/v2/form_document_spec.rb
+++ b/spec/models/api/v2/form_document_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe Api::V2::FormDocument, type: :model do
+  it "is valid with valid attributes" do
+    form_document = build(:form_document)
+    expect(form_document).to be_valid
+  end
+
+  it "is invalid without a form" do
+    form_document = build(:form_document, form: nil)
+    expect(form_document).not_to be_valid
+  end
+
+  it "is invalid without a tag" do
+    form_document = build(:form_document, tag: nil)
+    expect(form_document).not_to be_valid
+  end
+
+  it "has a default created_at and updated_at" do
+    travel_to Time.zone.local(2023, 10, 1, 10, 0, 0) do
+      form_document = create(:form_document)
+
+      expect(form_document.created_at).to eq(Time.zone.now)
+      expect(form_document.updated_at).to eq(Time.zone.now)
+    end
+  end
+
+  it "belongs to a Api::V2::Form" do
+    form_document = build(:form_document)
+
+    expect(form_document.form).to be_a(Api::V2::Form)
+  end
+
+  it "tags must be unique for a given form" do
+    form_document = create(:form_document, tag: "live")
+    expect { create(:form_document, form: form_document.form, tag: "live") }.to raise_error(ActiveRecord::RecordNotUnique)
+  end
+end


### PR DESCRIPTION
### Add Form_document


Trello card: https://trello.com/c/l48nxEEO/1789-8-add-a-form-documents-table-to-forms-api

This PR just covers creating and settling the table structure and model for form documents. It doesn't try to update the new model with either version of the API and doesn't add new endpoints. These will come in other PRs.

To represent `form_documents` which will be used to model the v2 API we need a new model and database table.

This model will hold the 'content' of a form as a JSON structure. A form can have more than one form_document and will be referenced by its tag.

Tags will be used to represent the different states of a form. For example most forms will have a form_document with a tag draft. Forms which have been made live will have a form with the tag 'live' and archived forms will have a form document with the tag 'archived'.

Currently there is no validation on the form_document, other than it has to be present. There is also no index on tag, which might be something to add in the future if needed.

FormDocuments belong to Api_v2_forms rather than the standard Form.

This commit doesn't include the association on Api_v2_forms. That should be added as needed.


<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
