### PR TITLE
Add submission type to live forms

### DIFF
--- a/db/migrate/20240918153233_add_submission_type_to_made_live_forms.rb
+++ b/db/migrate/20240918153233_add_submission_type_to_made_live_forms.rb
@@ -1,0 +1,22 @@
+class AddSubmissionTypeToMadeLiveForms < ActiveRecord::Migration[7.1]
+  class MadeLiveForm < ApplicationRecord
+    self.table_name = :made_live_forms
+  end
+
+  def change
+    reversible do |direction|
+      MadeLiveForm.find_each do |made_live_form|
+        form_blob = JSON.parse(made_live_form.json_form_blob, symbolize_names: true)
+
+        direction.up do
+          form_blob[:submission_type] = "email"
+        end
+        direction.down do
+          form_blob.delete(:submission_type)
+        end
+
+        made_live_form.update!(json_form_blob: form_blob.to_json)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_16_122719) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_18_153233) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -13,10 +13,21 @@ namespace :forms do
     usage_message = "usage: rake forms:set_submission_type_to_email_with_csv[<form_id>]".freeze
     abort usage_message if args[:form_id].blank?
 
-    puts "setting submission_type to email_with_csv for form: #{args[:form_id]}"
+    Rails.logger.info("setting submission_type to email_with_csv for form: #{args[:form_id]}")
 
-    Form.find(args[:form_id]).email_with_csv!
+    form = Form.find(args[:form_id])
+    form.email_with_csv!
 
-    puts "set submission_type to email_with_csv for form: #{args[:form_id]}"
+    made_live_form = form.made_live_forms.last
+
+    if made_live_form.present?
+      form_blob = JSON.parse(made_live_form.json_form_blob, symbolize_names: true)
+
+      form_blob[:submission_type] = "email_with_csv"
+
+      made_live_form.update!(json_form_blob: form_blob.to_json)
+    end
+
+    Rails.logger.info("set submission_type to email_with_csv for form: #{args[:form_id]}")
   end
 end

--- a/spec/lib/tasks/forms.rake_spec.rb
+++ b/spec/lib/tasks/forms.rake_spec.rb
@@ -14,15 +14,64 @@ RSpec.describe "forms.rake" do
         .tap(&:reenable)
     end
 
-    let(:form) { create :form, id: form_id }
-    let(:form_id) { 3 }
+    let(:form) { create :form }
 
     it "sets a form's external_id to its id" do
       form.update!(external_id: nil)
       expect { task.invoke }
-        .to change { form.reload.external_id }.to(form_id.to_s)
+        .to change { form.reload.external_id }.to(form.id.to_s)
         .and output(/external_id has been set for each form to their id/)
               .to_stdout
+    end
+  end
+
+  describe "forms:set_submission_type_to_email_with_csv" do
+    subject(:task) do
+      Rake::Task["forms:set_submission_type_to_email_with_csv"]
+        .tap(&:reenable)
+    end
+
+    let(:form) { create :form, :live }
+    let!(:other_form) { create :form, :live }
+
+    context "when the form is live" do
+      before do
+        # make this form live twice to create multiple versions
+        form.create_draft_from_live_form!
+        form.make_live!
+      end
+
+      it "sets a form's submission_type to email_with_csv" do
+        expect { task.invoke(form.id) }
+          .to change { form.reload.submission_type }.to("email_with_csv")
+      end
+
+      it "does not update a form's older live versions" do
+        task.invoke(form.id)
+        expect(JSON.parse(form.made_live_forms.first.json_form_blob)["submission_type"]).to eq("email")
+      end
+
+      it "updates a form's latest live version" do
+        task.invoke(form.id)
+        expect(JSON.parse(form.made_live_forms.last.json_form_blob)["submission_type"]).to eq("email_with_csv")
+      end
+
+      it "does not update a different form" do
+        expect { task.invoke(form.id) }
+          .not_to(change { other_form.reload.submission_type })
+      end
+
+      it "does not update a different form's latest live version" do
+        task.invoke(form.id)
+        expect(JSON.parse(other_form.made_live_forms.last.json_form_blob)["submission_type"]).to eq("email")
+      end
+    end
+
+    context "when the form is not live" do
+      it "sets a form's submission_type to email_with_csv" do
+        expect { task.invoke(form.id) }
+          .to change { form.reload.submission_type }.to("email_with_csv")
+      end
     end
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/DQCipW8q

This PR adds a `submission_type` attribute to the snapshot JSON of every made live form. This is necessary so that forms-runner can safely use this attribute to determine submission type.

This PR also updates the `set_submission_type_to_email_with_csv` rake task to set the `submission_type` to `email_with_csv` for a form's live versions.

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
