### PR TITLE
Keep FormDocuments up to date in V1 API calls

### DIFF
--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -7,6 +7,7 @@ class Api::V1::PagesController < ApplicationController
     new_page = form.pages.new(page_params)
 
     if new_page.save_and_update_form
+      update_form_document
       render json: new_page.to_json, status: :created
     end
   end
@@ -19,12 +20,14 @@ class Api::V1::PagesController < ApplicationController
     page.assign_attributes(page_params)
 
     if page.save_and_update_form
+      update_form_document
       render json: page.to_json, status: :ok
     end
   end
 
   def destroy
     page.destroy_and_update_form!
+    update_form_document
     render status: :no_content
   end
 
@@ -32,7 +35,9 @@ class Api::V1::PagesController < ApplicationController
     unless page.last?
       page.move_lower
       form.update!(question_section_completed: false)
+      update_form_document
     end
+
     render json: page.to_json, status: :ok
   end
 
@@ -40,7 +45,9 @@ class Api::V1::PagesController < ApplicationController
     unless page.first?
       page.move_higher
       form.update!(question_section_completed: false)
+      update_form_document
     end
+
     render json: page.to_json, status: :ok
   end
 
@@ -94,5 +101,9 @@ private
       *guidance_params,
       answer_setting_params,
     )
+  end
+
+  def update_form_document
+    Api::V2::ModelSync.new.update_draft(form.id, form.snapshot, form.external_id)
   end
 end

--- a/app/models/api/v2/form.rb
+++ b/app/models/api/v2/form.rb
@@ -2,6 +2,7 @@
 # as it uses the same database table
 class Api::V2::Form < ApplicationRecord
   include Rails.application.routes.url_helpers # TODO: do we need a presenter instead?
+  has_many :form_documents, dependent: :delete_all
 
   self.table_name = "forms"
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -5,6 +5,7 @@ class Form < ApplicationRecord
 
   has_many :pages, -> { order(position: :asc) }, dependent: :destroy
   has_many :made_live_forms, -> { order(created_at: :asc) }, dependent: :destroy
+  has_many :form_documents, dependent: :delete_all, class_name: "Api::V2::FormDocument"
 
   enum :submission_type, {
     email: "email",

--- a/app/service/api/v2/model_sync.rb
+++ b/app/service/api/v2/model_sync.rb
@@ -1,0 +1,40 @@
+class Api::V2::ModelSync
+  def initialize
+    @converter = Api::V2::Converter.new
+  end
+
+  def create_form(id, external_id, form_blob)
+    update_or_create_form_document(id, :draft, form_blob, form_id: external_id)
+  end
+
+  def update_draft(id, form_blob, external_id)
+    update_or_create_form_document(id, :draft, form_blob, form_id: external_id)
+  end
+
+  def make_live(id, form_blob, from_state, external_id)
+    update_or_create_form_document(id, :live, form_blob, form_id: external_id)
+    cleanup_form_documents(id, from_state)
+  end
+
+  def archive_live_form(id, form_blob, external_id)
+    update_or_create_form_document(id, :archived, form_blob, form_id: external_id)
+    delete_form_documents(id, :live)
+  end
+
+private
+
+  def update_or_create_form_document(id, tag, form_blob, options = {})
+    form_document = Api::V2::FormDocument.find_or_initialize_by(form_id: id, tag:)
+    form_document.content = @converter.to_api_v2_form_document(form_blob, **options)
+    form_document.save!
+  end
+
+  def cleanup_form_documents(id, from_state)
+    delete_form_documents(id, :draft) if %i[draft archived_with_draft live_with_draft].include?(from_state)
+    delete_form_documents(id, :archived) if %i[archived archived_with_draft].include?(from_state)
+  end
+
+  def delete_form_documents(id, tag)
+    Api::V2::FormDocument.where(form_id: id, tag:).delete_all
+  end
+end

--- a/app/state_machines/form_state_machine.rb
+++ b/app/state_machines/form_state_machine.rb
@@ -1,6 +1,10 @@
 module FormStateMachine
   extend ActiveSupport::Concern
 
+  def form_sync
+    Api::V2::ModelSync.new
+  end
+
   included do
     include AASM
 
@@ -32,6 +36,8 @@ module FormStateMachine
 
           form_blob = snapshot(live_at:)
           made_live_forms.create!(json_form_blob: form_blob.to_json, created_at: live_at)
+
+          form_sync.make_live(id, form_blob, aasm.from_state, external_id)
         end
 
         transitions from: %i[draft live_with_draft archived archived_with_draft], to: :live, guard: proc { ready_for_live }
@@ -46,6 +52,11 @@ module FormStateMachine
       end
 
       event :archive_live_form do
+        after do
+          form_blob = JSON.parse(archived_live_version)
+          form_sync.archive_live_form(id, form_blob, external_id)
+        end
+
         transitions from: :live, to: :archived
         transitions from: :live_with_draft, to: :archived_with_draft
       end

--- a/spec/requests/api/v1/forms_controller_spec.rb
+++ b/spec/requests/api/v1/forms_controller_spec.rb
@@ -300,6 +300,13 @@ describe Api::V1::FormsController, type: :request do
       expect(response.headers["Content-Type"]).to eq("application/json")
       expect(json_body).to include(live_at: Time.zone.now)
     end
+
+    it "creates a form document with the tag :live" do
+      form_to_be_made_live = create(:form, :ready_for_live)
+      post make_live_form_path(form_to_be_made_live), as: :json
+      expect(response).to have_http_status(:ok)
+      expect(Api::V2::FormDocument.find_by(form_id: form_to_be_made_live.id, tag: :live)).to be_present
+    end
   end
 
   describe "#show_live" do
@@ -376,6 +383,19 @@ describe Api::V1::FormsController, type: :request do
         expect(response).to have_http_status(:ok)
         expect(response.headers["Content-Type"]).to eq("application/json")
         expect(json_body).to include(state: "archived")
+      end
+
+      it "creates a FormDocument with the tag :archived" do
+        form = create(:made_live_form).form
+        post archive_form_path(form), as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(Api::V2::FormDocument.find_by(form_id: form.id, tag: :archived)).to be_present
+      end
+
+      it "removes the FormDocument with the tag :live" do
+        form = create(:made_live_form).form
+        expect { post archive_form_path(form), as: :json }.to change { Api::V2::FormDocument.find_by(form_id: form.id, tag: :live) }.to(nil)
       end
     end
 

--- a/spec/service/api/v2/model_sync_spec.rb
+++ b/spec/service/api/v2/model_sync_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+RSpec.describe Api::V2::ModelSync do
+  subject(:model_sync) { described_class.new }
+
+  let(:form_id) { form.id }
+  let(:form) { create :form }
+  let(:external_id) { "external_123" }
+  let(:form_blob) { { "title" => "Test Form" } }
+  let(:api_converter) { instance_double(Api::V2::Converter) }
+
+  before do
+    allow(Api::V2::Converter).to receive(:new).and_return(api_converter)
+    allow(api_converter).to receive(:to_api_v2_form_document).and_return({ data: { **form_blob } })
+  end
+
+  describe "#create_form" do
+    it "creates a new draft form document" do
+      expect {
+        model_sync.create_form(form_id, external_id, form_blob)
+      }.to change(Api::V2::FormDocument, :count).by(1)
+
+      form_document = Api::V2::FormDocument.last
+      expect(form_document.form_id).to eq(form_id)
+      expect(form_document.tag).to eq("draft")
+      expect(form_document.content).to be_present
+      expect(api_converter).to have_received(:to_api_v2_form_document).with(form_blob, form_id: external_id)
+    end
+  end
+
+  describe "#update_draft" do
+    it "updates an existing draft form document" do
+      existing_draft = Api::V2::FormDocument.create!(form_id:, tag: :draft, content: {})
+
+      model_sync.update_draft(form_id, form_blob, external_id)
+
+      existing_draft.reload
+      expect(existing_draft.content).to be_present
+      expect(api_converter).to have_received(:to_api_v2_form_document).with(form_blob, form_id: external_id)
+    end
+
+    it "creates a new draft form document if it does not exist" do
+      expect {
+        model_sync.update_draft(form_id, form_blob, external_id)
+      }.to change(Api::V2::FormDocument, :count).by(1)
+
+      form_document = Api::V2::FormDocument.last
+      expect(form_document.form_id).to eq(form_id)
+      expect(form_document.tag).to eq("draft")
+      expect(form_document.content).to be_present
+      expect(api_converter).to have_received(:to_api_v2_form_document).with(form_blob, form_id: external_id)
+    end
+  end
+
+  describe "#make_live" do
+    it "creates or updates a live form document" do
+      model_sync.make_live(form_id, form_blob, :draft, external_id)
+
+      form_document = Api::V2::FormDocument.find_by(form_id:, tag: :live)
+      expect(form_document).to be_present
+      expect(form_document.content).to be_present
+      expect(api_converter).to have_received(:to_api_v2_form_document).with(form_blob, form_id: external_id)
+    end
+
+    it "removes draft version when making live from draft state" do
+      Api::V2::FormDocument.create!(form_id:, tag: :draft, content: {})
+
+      expect {
+        model_sync.make_live(form_id, form_blob, :draft, external_id)
+      }.to change { Api::V2::FormDocument.where(form_id:, tag: :draft).count }.from(1).to(0)
+    end
+
+    it "removes archived version when making live from archived state" do
+      Api::V2::FormDocument.create!(form_id:, tag: :archived, content: {})
+
+      expect {
+        model_sync.make_live(form_id, form_blob, :archived, external_id)
+      }.to change { Api::V2::FormDocument.where(form_id:, tag: :archived).count }.from(1).to(0)
+    end
+  end
+
+  describe "#archive_live_form" do
+    it "creates an archived form document" do
+      expect {
+        model_sync.archive_live_form(form_id, form_blob, external_id)
+      }.to change { Api::V2::FormDocument.where(form_id:, tag: :archived).count }.by(1)
+
+      expect(api_converter).to have_received(:to_api_v2_form_document).with(form_blob, form_id: external_id)
+    end
+
+    it "removes the live form document" do
+      Api::V2::FormDocument.create!(form_id:, tag: :live, content: {})
+
+      expect {
+        model_sync.archive_live_form(form_id, form_blob, external_id)
+      }.to change { Api::V2::FormDocument.where(form_id:, tag: :live).count }.from(1).to(0)
+    end
+  end
+end

--- a/spec/state_machines/form_state_machine_spec.rb
+++ b/spec/state_machines/form_state_machine_spec.rb
@@ -109,6 +109,13 @@ RSpec.describe FormStateMachine do
   end
 
   describe ".archive_live_form" do
+    let(:form_sync) { instance_double(Api::V2::ModelSync) }
+
+    before do
+      allow(form_sync).to receive(:make_live)
+      allow(form_sync).to receive(:archive_live_form)
+    end
+
     context "when the form is draft" do
       let(:form) { FakeForm.new(state: :draft) }
 
@@ -120,6 +127,10 @@ RSpec.describe FormStateMachine do
     context "when the form is live" do
       let(:form) { FakeForm.new(state: :live) }
 
+      before do
+        allow(form).to receive_messages(form_sync:, archived_live_version: "{}")
+      end
+
       it "transitions to archived if form is live" do
         expect(form).to transition_from(:live).to(:archived).on_event(:archive_live_form)
       end
@@ -127,6 +138,10 @@ RSpec.describe FormStateMachine do
 
     context "when form is live_with_draft" do
       let(:form) { FakeForm.new(state: :live_with_draft) }
+
+      before do
+        allow(form).to receive_messages(form_sync:, archived_live_version: "{}")
+      end
 
       it "transitions to archived_with_draft" do
         expect(form).to transition_from(:live_with_draft).to(:archived_with_draft).on_event(:archive_live_form)

--- a/spec/support/shared_examples/state_machine.rb
+++ b/spec/support/shared_examples/state_machine.rb
@@ -1,8 +1,11 @@
 RSpec.shared_examples "transition to live state" do |form_object, form_state|
   let(:form) { form_object.new(state: form_state) }
+  let(:form_sync) { instance_double(Api::V2::ModelSync) }
 
   before do
-    allow(form).to receive(:ready_for_live).and_return(true)
+    allow(form_sync).to receive(:make_live)
+    allow(form_sync).to receive(:archive_live_form)
+    allow(form).to receive_messages(ready_for_live: true, form_sync:)
   end
 
   it "transitions to live state" do


### PR DESCRIPTION
### This PR ensures that the V2 API models are updated from V1 API calls

Trello card: https://trello.com/c/l48nxEEO/1789-8-add-a-form-documents-table-to-forms-api

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
