### PR TITLE
Fix api_v2_form factory to use valid external_id

### DIFF
--- a/spec/factories/api/v2/forms.rb
+++ b/spec/factories/api/v2/forms.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :api_v2_form, class: "Api::V2::Form" do
-    external_id { Faker::String.random(length: 8) }
+    external_id { Faker::Alphanumeric.alphanumeric(number: 8) }
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Tests which create `api_v2_form` factories sometimes fail with the error
`string contains null byte (ArgumentError)`. There isn't much more
context given.

I think this happens because of the way the factory generates the
`external_id` attribute.

Currently it uses:

```ruby
external_id { Faker::String.random(length: 8) }
```

The documentation for Faker says that `String.random` can produce all UTF-8
code points, which would include the null byte.

We can confirm that setting `external_id` with a string containing the null byte causes the
error:

```ruby
FactoryBot::create :api_v2_form, external_id: "\u0000"
```

The error comes from postgres, so only shows up when using `create` not
`build`.

Creating enough `api_v2_forms`, it's generally possible to get the error.

```ruby
strs = (0...100).map { Faker::String.random(length: 8) }
strs.each.with_index {|str, i| puts "#{i}: #{str}";  FactoryBot::create :api_v2_form, external_id: str }
```

To fix this issues, we change the external_id generating function to:

```ruby
external_id { Faker::Alphanumeric.alphanumeric(number: 8) }
```

This ensures the string will only be letters and numbers and won't
contain any difficult code points.

This might not match our chosen external_id format. That doesn't matter
here though as there is no validation on the model.


### Things to consider when reviewing

