### PR TITLE
Allow getting draft form from v2 API even when form does not have draft version

### DIFF
--- a/app/service/api/v2/form_document_repository.rb
+++ b/app/service/api/v2/form_document_repository.rb
@@ -31,7 +31,7 @@ class Api::V2::FormDocumentRepository
     def v1_blob(v1_form, tag)
       case tag.to_sym
       when :draft
-        v1_form.draft_version if v1_form.has_draft_version
+        v1_form.draft_version
       when :live
         v1_form.live_version if v1_form.has_live_version
       when :archived

--- a/spec/service/api/v2/form_document_repository_spec.rb
+++ b/spec/service/api/v2/form_document_repository_spec.rb
@@ -55,10 +55,9 @@ RSpec.describe Api::V2::FormDocumentRepository do
             .to include("name" => "Test form")
         end
 
-        it "raises an exception if the draft tag is given" do
-          expect {
-            described_class.find(form.id, :draft)
-          }.to raise_error(ActiveRecord::RecordNotFound)
+        it "uses the current form snapshot if the draft tag is given" do
+          expect(described_class.find(form.id, :draft))
+            .to include("name" => "Test form")
         end
 
         it "raises an exception if the archived tag is given" do
@@ -99,10 +98,9 @@ RSpec.describe Api::V2::FormDocumentRepository do
             .to include("name" => "Test form")
         end
 
-        it "raises an exception if the draft tag is given" do
-          expect {
-            described_class.find(form.id, :draft)
-          }.to raise_error(ActiveRecord::RecordNotFound)
+        it "uses the current form snapshot if the draft tag is given" do
+          expect(described_class.find(form.id, :draft))
+            .to include("name" => "Test form")
         end
 
         it "raises an exception if the live tag is given" do


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

This commit changes the v2 form document repository so that a draft form document can always be retrieved, even if the v1 form returns false to `#has_draft_version`.

This maintains backwards compatibility of v2 API with v1 API and fixes preview links in forms-admin when forms-runner is using v2 API.

Ideally we would in future consider whether this behaviour is what we want, or if the logic can be moved to forms-runner or forms-admin somehow.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?