### PR TITLE
Update V2 Form models with V1 API endpoints

### DIFF
--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -16,6 +16,7 @@ class Api::V1::FormsController < ApplicationController
   def create
     new_form = Form.new(form_params)
     if new_form.save
+      Api::V2::FormDocumentSyncService.new.synchronize_form(new_form)
       render json: new_form.to_json, status: :created
     else
       render json: new_form.errors.to_json, status: :bad_request
@@ -29,6 +30,8 @@ class Api::V1::FormsController < ApplicationController
       form.create_draft_from_live_form! if form.live?
       form.create_draft_from_archived_form! if form.archived?
 
+      Api::V2::FormDocumentSyncService.new.synchronize_form(form)
+
       render json: form.to_json, status: :ok
     else
       render json: form.errors.to_json, status: :bad_request
@@ -41,6 +44,7 @@ class Api::V1::FormsController < ApplicationController
 
   def destroy
     form.destroy!
+
     render status: :no_content
   end
 

--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -7,6 +7,7 @@ class Api::V1::PagesController < ApplicationController
     new_page = form.pages.new(page_params)
 
     if new_page.save_and_update_form
+      update_form_document
       render json: new_page.to_json, status: :created
     end
   end
@@ -19,12 +20,14 @@ class Api::V1::PagesController < ApplicationController
     page.assign_attributes(page_params)
 
     if page.save_and_update_form
+      update_form_document
       render json: page.to_json, status: :ok
     end
   end
 
   def destroy
     page.destroy_and_update_form!
+    update_form_document
     render status: :no_content
   end
 
@@ -32,7 +35,9 @@ class Api::V1::PagesController < ApplicationController
     unless page.last?
       page.move_lower
       form.update!(question_section_completed: false)
+      update_form_document
     end
+
     render json: page.to_json, status: :ok
   end
 
@@ -40,7 +45,9 @@ class Api::V1::PagesController < ApplicationController
     unless page.first?
       page.move_higher
       form.update!(question_section_completed: false)
+      update_form_document
     end
+
     render json: page.to_json, status: :ok
   end
 
@@ -94,5 +101,9 @@ private
       *guidance_params,
       answer_setting_params,
     )
+  end
+
+  def update_form_document
+    Api::V2::FormDocumentSyncService.new.synchronize_form(form)
   end
 end

--- a/app/models/api/v2/form.rb
+++ b/app/models/api/v2/form.rb
@@ -2,6 +2,7 @@
 # as it uses the same database table
 class Api::V2::Form < ApplicationRecord
   include Rails.application.routes.url_helpers # TODO: do we need a presenter instead?
+  has_many :form_documents, dependent: :delete_all
 
   self.table_name = "forms"
 

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -5,6 +5,7 @@ class Form < ApplicationRecord
 
   has_many :pages, -> { order(position: :asc) }, dependent: :destroy
   has_many :made_live_forms, -> { order(created_at: :asc) }, dependent: :destroy
+  has_many :form_documents, dependent: :delete_all, class_name: "Api::V2::FormDocument"
 
   enum :submission_type, {
     email: "email",

--- a/app/service/api/v2/form_document_sync_service.rb
+++ b/app/service/api/v2/form_document_sync_service.rb
@@ -1,0 +1,53 @@
+class Api::V2::FormDocumentSyncService
+  def synchronize_form(form)
+    case form.state
+    when "live"
+      sync_live_form(form)
+    when "live_with_draft"
+      sync_live_with_draft_form(form)
+    when "draft"
+      sync_draft_form(form)
+    when "archived"
+      sync_archived_form(form)
+    when "archived_with_draft"
+      sync_archived_with_draft_form(form)
+    end
+  end
+
+  def sync_live_form(form)
+    update_or_create_form_document(form, :live, JSON.parse(form.live_version))
+    delete_form_documents(form, %i[draft archived])
+  end
+
+  def sync_live_with_draft_form(form)
+    update_or_create_form_document(form, :live, JSON.parse(form.live_version))
+    update_or_create_form_document(form, :draft, form.snapshot)
+    delete_form_documents(form, [:archived])
+  end
+
+  def sync_draft_form(form)
+    update_or_create_form_document(form, :draft, form.snapshot)
+    delete_form_documents(form, %i[live archived])
+  end
+
+  def sync_archived_form(form)
+    update_or_create_form_document(form, :archived, form.snapshot)
+    delete_form_documents(form, %i[live draft])
+  end
+
+  def sync_archived_with_draft_form(form)
+    update_or_create_form_document(form, :archived, form.snapshot)
+    update_or_create_form_document(form, :draft, form.snapshot)
+    delete_form_documents(form, [:live])
+  end
+
+  def update_or_create_form_document(form, tag, form_blob)
+    form_document = Api::V2::FormDocument.find_or_initialize_by(form_id: form.id, tag:)
+    form_document.content = Api::V2::Converter.new.to_api_v2_form_document(form_blob, form_id: form.external_id)
+    form_document.save!
+  end
+
+  def delete_form_documents(form, tags)
+    Api::V2::FormDocument.where(form_id: form.id, tag: tags).delete_all
+  end
+end

--- a/app/state_machines/form_state_machine.rb
+++ b/app/state_machines/form_state_machine.rb
@@ -32,6 +32,8 @@ module FormStateMachine
 
           form_blob = snapshot(live_at:)
           made_live_forms.create!(json_form_blob: form_blob.to_json, created_at: live_at)
+
+          Api::V2::FormDocumentSyncService.new.synchronize_form(self)
         end
 
         transitions from: %i[draft live_with_draft archived archived_with_draft], to: :live, guard: proc { ready_for_live }
@@ -56,6 +58,10 @@ module FormStateMachine
       event :archive_live_form do
         transitions from: :live, to: :archived
         transitions from: :live_with_draft, to: :archived_with_draft
+
+        after do
+          Api::V2::FormDocumentSyncService.new.synchronize_form(self)
+        end
       end
     end
   end

--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -56,10 +56,12 @@ namespace :forms do
       Form.find_each do |form|
         Api::V2::FormDocumentSyncService.new.synchronize_form(form)
       end
+
+      Rails.logger.info({ post_synchronise_form_documents_dry_run: summarise_form_documents })
+
       raise ActiveRecord::Rollback
     end
 
-    Rails.logger.info({ post_synchronise_form_documents_dry_run: summarise_form_documents })
     Rails.logger.info "forms:synchronise_form_documents_dry_run finished"
   end
 

--- a/spec/requests/api/v1/pages_controller_spec.rb
+++ b/spec/requests/api/v1/pages_controller_spec.rb
@@ -77,6 +77,27 @@ describe Api::V1::PagesController, type: :request do
                                                            is_repeatable: false).as_json)
     end
 
+    it "updates the FormDocument draft" do
+      form_document = Api::V2::FormDocument.find_by(form_id: form.id, tag: :draft)
+      expect(form_document.content["steps"].first).to include({
+        "id" => new_page.id,
+        "data" => {
+          "hint_text" => "Should be first/last name",
+          "answer_type" => "text",
+          "is_optional" => false,
+          "page_heading" => nil,
+          "is_repeatable" => false,
+          "question_text" => "What is your first name?",
+          "answer_settings" => { "input_type" => "single_line" },
+          "guidance_markdown" => nil,
+        },
+        "type" => "question_page",
+        "position" => 1,
+        "next_step_id" => nil,
+        "routing_conditions" => [],
+      })
+    end
+
     context "with params missing required keys" do
       let(:new_page_params) do
         { wrong: "" }
@@ -169,6 +190,12 @@ describe Api::V1::PagesController, type: :request do
       expect(first_page.hint_text).to be_nil
     end
 
+    it "updates the FormDocument draft" do
+      form_document = Api::V2::FormDocument.find_by(form_id: form.id, tag: :draft)
+      first_step_question_text = form_document.content["steps"].first["data"]["question_text"]
+      expect(first_step_question_text).to eq "updated page title"
+    end
+
     [
       ["selection",
        {
@@ -234,6 +261,11 @@ describe Api::V1::PagesController, type: :request do
         expect(form.pages.count).to eq(1)
         expect(form.reload.question_section_completed).to be false
       end
+
+      it "updates the FormDocument draft" do
+        form_document = Api::V2::FormDocument.find_by(form_id: form.id, tag: :draft)
+        expect(form_document.content["steps"].count).to eq(1)
+      end
     end
 
     context "with unknown form" do
@@ -288,6 +320,11 @@ describe Api::V1::PagesController, type: :request do
       it "marks a forms question section as incomplete" do
         expect(form_with_pages.reload.question_section_completed).to be false
       end
+
+      it "updates the FormDocument draft" do
+        form_document = Api::V2::FormDocument.find_by(form_id: form_with_pages.id, tag: :draft)
+        expect(form_document.content["steps"].map { |step| step["id"] }).to eq([second_page.id, page_to_move.id, third_page.id, fourth_page.id, last_page.id])
+      end
     end
 
     context "with page already at the end of the list" do
@@ -338,6 +375,11 @@ describe Api::V1::PagesController, type: :request do
 
       it "marks a forms question section as incomplete" do
         expect(form_with_pages.reload.question_section_completed).to be false
+      end
+
+      it "updates the FormDocument draft" do
+        form_document = Api::V2::FormDocument.find_by(form_id: form_with_pages.id, tag: :draft)
+        expect(form_document.content["steps"].map { |step| step["id"] }).to eq([page_to_move.id, first_page.id, third_page.id, fourth_page.id, last_page.id])
       end
     end
 

--- a/spec/service/api/v2/form_document_sync_service_spec.rb
+++ b/spec/service/api/v2/form_document_sync_service_spec.rb
@@ -1,0 +1,133 @@
+require "rails_helper"
+
+RSpec.describe Api::V2::FormDocumentSyncService do
+  let(:service) { described_class.new }
+  let(:form) { create(:form) }
+  let(:converter) { instance_double(Api::V2::Converter) }
+
+  before do
+    allow(Api::V2::Converter).to receive(:new).and_return(converter)
+    allow(converter).to receive(:to_api_v2_form_document).and_return({})
+  end
+
+  describe "#synchronize_form" do
+    context "when form state is live" do
+      before { allow(form).to receive(:state).and_return("live") }
+
+      it "calls sync_live_form" do
+        expect(service).to receive(:sync_live_form).with(form)
+        service.synchronize_form(form)
+      end
+    end
+
+    context "when form state is live_with_draft" do
+      before { allow(form).to receive(:state).and_return("live_with_draft") }
+
+      it "calls sync_live_with_draft_form" do
+        expect(service).to receive(:sync_live_with_draft_form).with(form)
+        service.synchronize_form(form)
+      end
+    end
+
+    context "when form state is draft" do
+      before { allow(form).to receive(:state).and_return("draft") }
+
+      it "calls sync_draft_form" do
+        expect(service).to receive(:sync_draft_form).with(form)
+        service.synchronize_form(form)
+      end
+    end
+
+    context "when form state is archived" do
+      before { allow(form).to receive(:state).and_return("archived") }
+
+      it "calls sync_archived_form" do
+        expect(service).to receive(:sync_archived_form).with(form)
+        service.synchronize_form(form)
+      end
+    end
+
+    context "when form state is archived_with_draft" do
+      before { allow(form).to receive(:state).and_return("archived_with_draft") }
+
+      it "calls sync_archived_with_draft_form" do
+        expect(service).to receive(:sync_archived_with_draft_form).with(form)
+        service.synchronize_form(form)
+      end
+    end
+  end
+
+  describe "#sync_live_form" do
+    let(:form) { create(:form, :live) }
+
+    it "updates or creates live form document and deletes draft and archived documents" do
+      expect(service).to receive(:update_or_create_form_document).with(form, :live, anything)
+      expect(service).to receive(:delete_form_documents).with(form, %i[draft archived])
+      service.sync_live_form(form)
+    end
+  end
+
+  describe "#sync_live_with_draft_form" do
+    let(:form) { create(:form, :live) }
+
+    it "updates or creates live and draft form documents and deletes archived document" do
+      expect(service).to receive(:update_or_create_form_document).with(form, :live, anything)
+      expect(service).to receive(:update_or_create_form_document).with(form, :draft, anything)
+      expect(service).to receive(:delete_form_documents).with(form, [:archived])
+      service.sync_live_with_draft_form(form)
+    end
+  end
+
+  describe "#sync_draft_form" do
+    it "updates or creates draft form document and deletes live and archived documents" do
+      expect(service).to receive(:update_or_create_form_document).with(form, :draft, anything)
+      expect(service).to receive(:delete_form_documents).with(form, %i[live archived])
+      service.sync_draft_form(form)
+    end
+  end
+
+  describe "#sync_archived_form" do
+    it "updates or creates archived form document and deletes live and draft documents" do
+      expect(service).to receive(:update_or_create_form_document).with(form, :archived, anything)
+      expect(service).to receive(:delete_form_documents).with(form, %i[live draft])
+      service.sync_archived_form(form)
+    end
+  end
+
+  describe "#sync_archived_with_draft_form" do
+    it "updates or creates archived and draft form documents and deletes live document" do
+      expect(service).to receive(:update_or_create_form_document).with(form, :archived, anything)
+      expect(service).to receive(:update_or_create_form_document).with(form, :draft, anything)
+      expect(service).to receive(:delete_form_documents).with(form, [:live])
+      service.sync_archived_with_draft_form(form)
+    end
+  end
+
+  describe "#update_or_create_form_document" do
+    let(:form_document) { instance_double(Api::V2::FormDocument, save!: true) }
+
+    before do
+      allow(Api::V2::FormDocument).to receive(:find_or_initialize_by).and_return(form_document)
+    end
+
+    it "finds or initializes a form document and updates its content" do
+      expect(Api::V2::FormDocument).to receive(:find_or_initialize_by).with(form_id: form.id, tag: :live)
+      expect(form_document).to receive(:content=)
+      expect(form_document).to receive(:save!)
+      service.update_or_create_form_document(form, :live, {})
+    end
+  end
+
+  describe "#delete_form_documents" do
+    it "deletes form documents with specified tags" do
+      form_documents = instance_double(ActiveRecord::Relation)
+      allow(Api::V2::FormDocument).to receive(:where).with(form_id: form.id, tag: %i[draft archived]).and_return(form_documents)
+      allow(form_documents).to receive(:delete_all).and_return(true)
+
+      service.delete_form_documents(form, %i[draft archived])
+
+      expect(Api::V2::FormDocument).to have_received(:where).with(form_id: form.id, tag: %i[draft archived])
+      expect(form_documents).to have_received(:delete_all)
+    end
+  end
+end

--- a/spec/service/api/v2/form_document_sync_service_spec.rb
+++ b/spec/service/api/v2/form_document_sync_service_spec.rb
@@ -120,14 +120,13 @@ RSpec.describe Api::V2::FormDocumentSyncService do
 
   describe "#delete_form_documents" do
     it "deletes form documents with specified tags" do
-      form_documents = instance_double(ActiveRecord::Relation)
-      allow(Api::V2::FormDocument).to receive(:where).with(form_id: form.id, tag: %i[draft archived]).and_return(form_documents)
-      allow(form_documents).to receive(:delete_all).and_return(true)
+      create(:form_document, form_id: form.id, tag: :draft)
+      create(:form_document, form_id: form.id, tag: :archived)
+      create(:form_document, form_id: form.id, tag: :live)
 
-      service.delete_form_documents(form, %i[draft archived])
-
-      expect(Api::V2::FormDocument).to have_received(:where).with(form_id: form.id, tag: %i[draft archived])
-      expect(form_documents).to have_received(:delete_all)
+      expect {
+        service.delete_form_documents(form, %i[live draft archived])
+      }.to change(Api::V2::FormDocument, :count).from(3).to(0)
     end
   end
 end

--- a/spec/state_machines/form_state_machine_spec.rb
+++ b/spec/state_machines/form_state_machine_spec.rb
@@ -7,6 +7,13 @@ end
 RSpec.describe FormStateMachine do
   let(:form) { FakeForm.new }
 
+  let(:form_document_sync_service) { instance_double(Api::V2::FormDocumentSyncService) }
+
+  before do
+    allow(Api::V2::FormDocumentSyncService).to receive(:new).and_return(form_document_sync_service)
+    allow(form_document_sync_service).to receive(:synchronize_form)
+  end
+
   it "has a default state of 'draft'" do
     expect(form).to have_state(:draft)
   end

--- a/spec/support/shared_examples/state_machine.rb
+++ b/spec/support/shared_examples/state_machine.rb
@@ -1,8 +1,11 @@
 RSpec.shared_examples "transition to live state" do |form_object, form_state|
   let(:form) { form_object.new(state: form_state) }
+  let(:form_document_sync_service) { instance_double(Api::V2::FormDocumentSyncService) }
 
   before do
     allow(form).to receive(:ready_for_live).and_return(true)
+    allow(Api::V2::FormDocumentSyncService).to receive(:new).and_return(form_document_sync_service)
+    allow(form_document_sync_service).to receive(:synchronize_form)
   end
 
   it "transitions to live state" do


### PR DESCRIPTION
### Create, update and delete FormDocuments when using the V1 API

Trello card: https://trello.com/c/l48nxEEO/1789-8-add-a-form-documents-table-to-forms-api

This PR adds a migration and inserts calls into the V1 API to ensure the V2 FormDocument models are updated with calls to the current, V1 API.

It's tempting to add callbacks into the `Form` and `Page` model to update `FormDocuments` when they are committed to the database. That ends up being less code but feels more likely to cause issues somewhere along the line. Adding the calls to the controller is more inline with our goal - updating FormDocuments in API calls.

The code to keep the FormDocuments in sync is aiming to keep things simple at the cost of making more database calls. Rather than use separate methods for the migration and ongoing updates, it uses only one.

 
### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
