### PR TITLE
Finalise share preview task

### DIFF
--- a/app/services/task_status_service.rb
+++ b/app/services/task_status_service.rb
@@ -11,7 +11,8 @@ class TaskStatusService
     { missing_pages: pages_status,
       missing_what_happens_next: what_happens_next_status,
       missing_privacy_policy_url: privacy_policy_status,
-      missing_contact_details: support_contact_details_status }.reject { |_k, v| v == :completed }.map { |k, _v| k }
+      missing_contact_details: support_contact_details_status,
+      share_preview_not_completed: share_preview_status }.reject { |_k, v| v == :completed }.map { |k, _v| k }
   end
 
   def task_statuses

--- a/app/services/task_status_service.rb
+++ b/app/services/task_status_service.rb
@@ -80,6 +80,7 @@ private
   end
 
   def share_preview_status
+    return :cannot_start unless @form.pages.any?
     return :completed if @form.share_preview_completed?
 
     :not_started

--- a/app/state_machines/form_state_machine.rb
+++ b/app/state_machines/form_state_machine.rb
@@ -38,10 +38,18 @@ module FormStateMachine
       end
 
       event :create_draft_from_live_form do
+        after do
+          update!(share_preview_completed: false)
+        end
+
         transitions from: :live, to: :live_with_draft
       end
 
       event :create_draft_from_archived_form do
+        after do
+          update!(share_preview_completed: false)
+        end
+
         transitions from: :archived, to: :archived_with_draft
       end
 

--- a/spec/lib/tasks/forms.rake_spec.rb
+++ b/spec/lib/tasks/forms.rake_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe "forms.rake" do
       before do
         # make this form live twice to create multiple versions
         form.create_draft_from_live_form!
+        form.share_preview_completed = true
         form.make_live!
       end
 

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -407,7 +407,8 @@ RSpec.describe Form, type: :model do
       let(:new_form) { build :form, :new_form }
 
       it "returns a set of keys related to missing fields" do
-        expect(new_form.incomplete_tasks).to match_array(%i[missing_pages missing_privacy_policy_url missing_contact_details missing_what_happens_next])
+        expect(new_form.incomplete_tasks).to match_array(%i[missing_pages missing_privacy_policy_url missing_contact_details missing_what_happens_next share_preview_not_completed])
+        expect(new_form.incomplete_tasks).to match_array(%i[missing_pages missing_privacy_policy_url missing_contact_details missing_what_happens_next share_preview_not_completed])
       end
     end
   end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -145,42 +145,60 @@ RSpec.describe Form, type: :model do
     end
   end
 
-  describe "#make_live! from FormStateMachine" do
-    let(:form_to_be_made_live) { create :form, :ready_for_live }
-    let(:time_now) { Time.zone.now }
+  describe "FormStateMachine" do
+    describe "#make_live!" do
+      let(:form_to_be_made_live) { create :form, :ready_for_live }
+      let(:time_now) { Time.zone.now }
 
-    before do
-      freeze_time do
-        time_now
-        form_to_be_made_live.make_live!
+      before do
+        freeze_time do
+          time_now
+          form_to_be_made_live.make_live!
+        end
+      end
+
+      it "sets a forms live_at to make the form live" do
+        expect(form_to_be_made_live.live_at).to eq(time_now)
+      end
+
+      it "creates a made live version" do
+        expect(form_to_be_made_live.made_live_forms.last.json_form_blob)
+          .to eq(form_to_be_made_live.snapshot(live_at: time_now).to_json)
+      end
+
+      it "the made live version has a live_at datetime" do
+        form_blob = JSON.parse(
+          form_to_be_made_live.made_live_forms.last.json_form_blob,
+          symbolize_names: true,
+        )
+
+        expect(Time.zone.parse(form_blob[:live_at])).to eq time_now
+      end
+
+      it "makes timestamps consistent" do
+        form = create :form, :ready_for_live
+        form.make_live!
+        made_live_form = form.made_live_forms.last
+
+        expect(form.live_at).to eq(made_live_form.created_at)
+        expect(form.updated_at).to eq(made_live_form.created_at)
       end
     end
 
-    it "sets a forms live_at to make the form live" do
-      expect(form_to_be_made_live.live_at).to eq(time_now)
+    describe "#create_draft_from_live_form!" do
+      let(:form) { create :form, :live }
+
+      it "sets share_preview_completed to false" do
+        expect { form.create_draft_from_live_form! }.to change(form, :share_preview_completed).to(false)
+      end
     end
 
-    it "creates a made live version" do
-      expect(form_to_be_made_live.made_live_forms.last.json_form_blob)
-        .to eq(form_to_be_made_live.snapshot(live_at: time_now).to_json)
-    end
+    describe "#create_draft_from_archived_form!" do
+      let(:form) { create :form, :archived }
 
-    it "the made live version has a live_at datetime" do
-      form_blob = JSON.parse(
-        form_to_be_made_live.made_live_forms.last.json_form_blob,
-        symbolize_names: true,
-      )
-
-      expect(Time.zone.parse(form_blob[:live_at])).to eq time_now
-    end
-
-    it "makes timestamps consistent" do
-      form = create :form, :ready_for_live
-      form.make_live!
-      made_live_form = form.made_live_forms.last
-
-      expect(form.live_at).to eq(made_live_form.created_at)
-      expect(form.updated_at).to eq(made_live_form.created_at)
+      it "sets share_preview_completed to false" do
+        expect { form.create_draft_from_archived_form! }.to change(form, :share_preview_completed).to(false)
+      end
     end
   end
 

--- a/spec/requests/api/v1/forms_controller_spec.rb
+++ b/spec/requests/api/v1/forms_controller_spec.rb
@@ -182,7 +182,7 @@ describe Api::V1::FormsController, type: :request do
                          what_happens_next_status: "not_started",
                          payment_link_status: "optional",
                          receive_csv_status: "optional",
-                         share_preview_status: "not_started" },
+                         share_preview_status: "cannot_start" },
         state: "draft",
         payment_url: nil,
         submission_type: "email",

--- a/spec/requests/api/v1/forms_controller_spec.rb
+++ b/spec/requests/api/v1/forms_controller_spec.rb
@@ -171,7 +171,7 @@ describe Api::V1::FormsController, type: :request do
         created_at: form1.created_at.as_json,
         updated_at: form1.updated_at.as_json,
         has_routing_errors: false,
-        incomplete_tasks: %w[missing_pages missing_what_happens_next missing_privacy_policy_url missing_contact_details],
+        incomplete_tasks: %w[missing_pages missing_what_happens_next missing_privacy_policy_url missing_contact_details share_preview_not_completed],
         ready_for_live: false,
         task_statuses: { declaration_status: "not_started",
                          make_live_status: "cannot_start",
@@ -271,7 +271,7 @@ describe Api::V1::FormsController, type: :request do
         post make_live_form_path(form_to_be_made_live), as: :json
         expect(response).to have_http_status(:forbidden)
         expect(response.headers["Content-Type"]).to eq("application/json")
-        expect(json_body).to eq(%w[missing_pages missing_what_happens_next missing_privacy_policy_url missing_contact_details])
+        expect(json_body).to eq(%w[missing_pages missing_what_happens_next missing_privacy_policy_url missing_contact_details share_preview_not_completed])
       end
     end
 

--- a/spec/services/task_status_service_spec.rb
+++ b/spec/services/task_status_service_spec.rb
@@ -302,7 +302,7 @@ describe TaskStatusService do
       let(:form) { build :form, :new_form }
 
       it "returns a set of keys related to missing fields" do
-        expect(task_status_service.incomplete_tasks).to match_array(%i[missing_pages missing_privacy_policy_url missing_contact_details missing_what_happens_next])
+        expect(task_status_service.incomplete_tasks).to match_array(%i[missing_pages missing_privacy_policy_url missing_contact_details missing_what_happens_next share_preview_not_completed])
       end
     end
   end

--- a/spec/services/task_status_service_spec.rb
+++ b/spec/services/task_status_service_spec.rb
@@ -175,19 +175,39 @@ describe TaskStatusService do
     end
 
     describe "share_preview_status" do
-      context "with a new form" do
-        let(:form) { build(:form, :new_form) }
+      context "with share_preview_completed set to false" do
+        context "when the form does not have any pages" do
+          let(:form) { build(:form, :new_form) }
 
-        it "returns not_started" do
-          expect(task_status_service.task_statuses[:share_preview_status]).to eq :not_started
+          it "returns cannot_start" do
+            expect(task_status_service.task_statuses[:share_preview_status]).to eq :cannot_start
+          end
+        end
+
+        context "when the form has pages" do
+          let(:form) { build(:form, :with_pages) }
+
+          it "returns not_started" do
+            expect(task_status_service.task_statuses[:share_preview_status]).to eq :not_started
+          end
         end
       end
 
       context "with share_preview_completed set to true" do
-        let(:form) { build(:form, :new_form, share_preview_completed: true) }
+        context "when the form does not have any pages" do
+          let(:form) { build(:form, :new_form, share_preview_completed: true) }
 
-        it "returns completed" do
-          expect(task_status_service.task_statuses[:share_preview_status]).to eq :completed
+          it "returns cannot_start" do
+            expect(task_status_service.task_statuses[:share_preview_status]).to eq :cannot_start
+          end
+        end
+
+        context "when the form has pages" do
+          let(:form) { build(:form, :with_pages, share_preview_completed: true) }
+
+          it "returns completed" do
+            expect(task_status_service.task_statuses[:share_preview_status]).to eq :completed
+          end
         end
       end
     end

--- a/spec/state_machines/form_state_machine_spec.rb
+++ b/spec/state_machines/form_state_machine_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe FormStateMachine do
     let(:form) { FakeForm.new(state: :live) }
 
     it "transitions to live_with_draft if form is live" do
+      allow(form).to receive(:update!)
       expect(form).to transition_from(:live).to(:live_with_draft).on_event(:create_draft_from_live_form)
     end
 
@@ -95,7 +96,11 @@ RSpec.describe FormStateMachine do
   describe ".create_draft_from_archived_form" do
     let(:form) { FakeForm.new(state: :archived) }
 
-    it "transitions to archived_with_draft if form is archived" do
+    before do
+      allow(form).to receive(:update!)
+    end
+
+    it "transitions to archived_with_draft" do
       expect(form).to transition_from(:archived).to(:archived_with_draft).on_event(:create_draft_from_archived_form)
     end
 
@@ -120,7 +125,7 @@ RSpec.describe FormStateMachine do
     context "when the form is live" do
       let(:form) { FakeForm.new(state: :live) }
 
-      it "transitions to archived if form is live" do
+      it "transitions to archived" do
         expect(form).to transition_from(:live).to(:archived).on_event(:archive_live_form)
       end
     end


### PR DESCRIPTION
> [!warning] 
> This PR should only be merged after https://github.com/alphagov/forms-admin/pull/1493 has been merged

### What problem does this pull request solve?

Trello card: https://trello.com/c/QuqK5jmG/1867-add-new-task-to-share-a-preview-of-your-draft-form-for-drafts-of-new-live-and-archived-forms

This PR makes it so that:

- The task status for the share preview task is "Cannot start yet" if the form has no questions. We want to do this because the link to the preview will show a 404 page if there are no questions.
- The task is set as not completed when a new draft is made of an existing form. We want users to consider sharing a preview of their new draft before they make it live.
- It is mandatory to complete the task before the form is made live. This PR should only be merged after the admin PR to add the task to the task list has been merged.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
