### PR TITLE
Add CSV submission to features report

### DIFF
--- a/app/services/features_report_service.rb
+++ b/app/services/features_report_service.rb
@@ -13,6 +13,10 @@ class FeaturesReportService
 
 private
 
+  # NOTE: all of these methods currently query the Form table rather than the MadeLiveForm table.
+  # This means that they may include updates which have been made to forms since they were made live.
+  # As a result, the figures in the report may vary slightly from the actual live figures.
+  # TODO: rewrite the queries to only check the content of live forms
   def total_live_forms
     Form.where(state: %w[live live_with_draft]).count
   end

--- a/app/services/features_report_service.rb
+++ b/app/services/features_report_service.rb
@@ -7,6 +7,7 @@ class FeaturesReportService
       live_forms_with_payment:,
       live_forms_with_routing:,
       live_forms_with_add_another_answer:,
+      live_forms_with_csv_submission_enabled:,
     }
   end
 
@@ -34,5 +35,9 @@ private
 
   def live_forms_with_add_another_answer
     Page.joins(:form).where(forms: { state: %w[live live_with_draft] }).select("forms.id,pages.is_repeatable").where(pages: { is_repeatable: true }).count("forms.id")
+  end
+
+  def live_forms_with_csv_submission_enabled
+    Form.where(state: %w[live live_with_draft]).where(submission_type: "email_with_csv").count
   end
 end

--- a/spec/requests/api/v1/reports_controller_spec.rb
+++ b/spec/requests/api/v1/reports_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Api::V1::ReportsController, type: :request do
   describe "GET /features" do
     before do
-      create :form, state: :live, payment_url: Faker::Internet.url(host: "gov.uk"), pages: [
+      create :form, state: :live, payment_url: Faker::Internet.url(host: "gov.uk"), submission_type: "email_with_csv", pages: [
         (build :page, answer_type: "text"),
         (build :page, answer_type: "text"),
       ]
@@ -56,6 +56,7 @@ RSpec.describe Api::V1::ReportsController, type: :request do
         live_forms_with_payment: 1,
         live_forms_with_routing: 1,
         live_forms_with_add_another_answer: 1,
+        live_forms_with_csv_submission_enabled: 1,
       })
     end
 

--- a/spec/services/features_report_service_spec.rb
+++ b/spec/services/features_report_service_spec.rb
@@ -63,6 +63,7 @@ describe FeaturesReportService do
   let(:form_6_pages) { pages_with_with_add_another_answer }
 
   let(:payment_url) { nil }
+  let(:submission_type) { "email" }
 
   describe "#report" do
     before do
@@ -73,7 +74,7 @@ describe FeaturesReportService do
 
     context "when there are live forms" do
       before do
-        create(:form, state: "live", pages: form_4_pages, payment_url:)
+        create(:form, state: "live", pages: form_4_pages, payment_url:, submission_type:)
         create(:form, state: "live_with_draft", pages: form_5_pages, payment_url: nil)
       end
 
@@ -142,6 +143,16 @@ describe FeaturesReportService do
           expect(response[:live_forms_with_add_another_answer]).to eq 1
         end
       end
+
+      context "when a live form has CSV submission enabled" do
+        let(:submission_type) { "email_with_csv" }
+
+        it "counts the form in the CSV submission part of the report" do
+          response = features_report_service.report
+
+          expect(response[:live_forms_with_csv_submission_enabled]).to eq 1
+        end
+      end
     end
 
     context "when there are no live forms" do
@@ -165,6 +176,7 @@ describe FeaturesReportService do
 
         expect(response[:live_forms_with_payment]).to eq 0
         expect(response[:live_forms_with_routing]).to eq 0
+        expect(response[:live_forms_with_csv_submission_enabled]).to eq 0
       end
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->None, followup from the additional submission types work

Adds the number of forms which have CSV submissions enabled to the features report API which admin consumes.

Needed for https://github.com/alphagov/forms-admin/pull/1523

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
