### PR TITLE
Store s3 bucket region on form

### DIFF
--- a/db/migrate/20241022154933_add_s3_bucket_region_to_forms.rb
+++ b/db/migrate/20241022154933_add_s3_bucket_region_to_forms.rb
@@ -1,0 +1,5 @@
+class AddS3BucketRegionToForms < ActiveRecord::Migration[7.2]
+  def change
+    add_column :forms, :s3_bucket_region, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_17_144118) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_22_154933) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -70,6 +70,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_17_144118) do
     t.boolean "share_preview_completed", default: false, null: false
     t.string "s3_bucket_name"
     t.string "s3_bucket_aws_account_id"
+    t.string "s3_bucket_region"
     t.index ["external_id"], name: "index_forms_on_external_id", unique: true
   end
 

--- a/lib/tasks/forms.rake
+++ b/lib/tasks/forms.rake
@@ -25,17 +25,20 @@ namespace :forms do
   end
 
   desc "Set submission_type to s3"
-  task :set_submission_type_to_s3, %i[form_id s3_bucket_name s3_bucket_aws_account_id] => :environment do |_, args|
-    usage_message = "usage: rake forms:set_submission_type_to_s3[<form_id>, <s3_bucket_name>, <s3_bucket_aws_account_id>]".freeze
+  task :set_submission_type_to_s3, %i[form_id s3_bucket_name s3_bucket_aws_account_id s3_bucket_region] => :environment do |_, args|
+    usage_message = "usage: rake forms:set_submission_type_to_s3[<form_id>, <s3_bucket_name>, <s3_bucket_aws_account_id>, <s3_bucket_region>]".freeze
     abort usage_message if args[:form_id].blank?
     abort usage_message if args[:s3_bucket_name].blank?
     abort usage_message if args[:s3_bucket_aws_account_id].blank?
+    abort usage_message if args[:s3_bucket_region].blank?
+    abort "s3_bucket_region must be one of eu-west-1 or eu-west-2" unless %w[eu-west-1 eu-west-2].include? args[:s3_bucket_region]
 
     Rails.logger.info("setting submission_type to s3 and s3_bucket_name to #{args[:s3_bucket_name]} for form: #{args[:form_id]}")
     form = Form.find(args[:form_id])
     form.submission_type = "s3"
     form.s3_bucket_name = args[:s3_bucket_name]
     form.s3_bucket_aws_account_id = args[:s3_bucket_aws_account_id]
+    form.s3_bucket_region = args[:s3_bucket_region]
     form.save!
 
     if form.has_live_version
@@ -45,6 +48,7 @@ namespace :forms do
       form_blob[:submission_type] = "s3"
       form_blob[:s3_bucket_name] = args[:s3_bucket_name]
       form_blob[:s3_bucket_aws_account_id] = args[:s3_bucket_aws_account_id]
+      form_blob[:s3_bucket_region] = args[:s3_bucket_region]
 
       made_live_form.update!(json_form_blob: form_blob.to_json)
     end

--- a/spec/lib/tasks/forms.rake_spec.rb
+++ b/spec/lib/tasks/forms.rake_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe "forms.rake" do
     let!(:other_form) { create :form, :live }
     let(:s3_bucket_name) { "a-bucket" }
     let(:s3_bucket_aws_account_id) { "an-aws-account-id" }
+    let(:s3_bucket_region) { "eu-west-1" }
 
     context "when the form is live" do
       before do
@@ -114,56 +115,56 @@ RSpec.describe "forms.rake" do
       end
 
       it "sets a form's submission_type to s3" do
-        expect { task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id) }
+        expect { task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id, s3_bucket_region) }
           .to change { form.reload.submission_type }.to("s3")
       end
 
       it "sets a form's s3_bucket_name" do
-        expect { task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id) }
+        expect { task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id, s3_bucket_region) }
           .to change { form.reload.s3_bucket_name }.to(s3_bucket_name)
       end
 
       it "sets a form's s3_bucket_aws_account_id" do
-        expect { task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id) }
+        expect { task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id, s3_bucket_region) }
           .to change { form.reload.s3_bucket_aws_account_id }.to(s3_bucket_aws_account_id)
       end
 
       it "does not update a form's older live versions" do
-        task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id)
+        task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id, s3_bucket_region)
         expect(JSON.parse(form.made_live_forms.first.json_form_blob)["submission_type"]).to eq("email")
         expect(JSON.parse(form.made_live_forms.first.json_form_blob)["s3_bucket_name"]).to be_nil
       end
 
       it "updates a form's latest live version" do
-        task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id)
+        task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id, s3_bucket_region)
         expect(JSON.parse(form.made_live_forms.last.json_form_blob)["submission_type"]).to eq("s3")
         expect(JSON.parse(form.made_live_forms.last.json_form_blob)["s3_bucket_name"]).to eq(s3_bucket_name)
       end
 
       it "does not update a different form" do
-        expect { task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id) }
+        expect { task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id, s3_bucket_region) }
           .not_to(change { other_form.reload.submission_type })
       end
 
       it "does not update a different form's latest live version" do
-        task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id)
+        task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id, s3_bucket_region)
         expect(JSON.parse(other_form.made_live_forms.last.json_form_blob)["submission_type"]).to eq("email")
       end
     end
 
     context "when the form is not live" do
       it "sets a form's submission_type to s3" do
-        expect { task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id) }
+        expect { task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id, s3_bucket_region) }
           .to change { form.reload.submission_type }.to("s3")
       end
 
       it "sets a form's s3_bucket_name" do
-        expect { task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id) }
+        expect { task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id, s3_bucket_region) }
           .to change { form.reload.s3_bucket_name }.to(s3_bucket_name)
       end
 
       it "sets a form's s3_bucket_aws_account_id" do
-        expect { task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id) }
+        expect { task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id, s3_bucket_region) }
           .to change { form.reload.s3_bucket_aws_account_id }.to(s3_bucket_aws_account_id)
       end
     end
@@ -175,12 +176,12 @@ RSpec.describe "forms.rake" do
       end
 
       it "sets a form's submission_type to s3" do
-        expect { task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id) }
+        expect { task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id, s3_bucket_region) }
           .to change { form.reload.submission_type }.to("s3")
       end
 
       it "does not update the forms latest made live version" do
-        task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id)
+        task.invoke(form.id, s3_bucket_name, s3_bucket_aws_account_id, s3_bucket_region)
         expect(JSON.parse(form.made_live_forms.last.json_form_blob)["submission_type"]).to eq("email")
       end
     end
@@ -190,7 +191,7 @@ RSpec.describe "forms.rake" do
         expect {
           task.invoke
         }.to raise_error(SystemExit)
-               .and output("usage: rake forms:set_submission_type_to_s3[<form_id>, <s3_bucket_name>, <s3_bucket_aws_account_id>]\n").to_stderr
+               .and output("usage: rake forms:set_submission_type_to_s3[<form_id>, <s3_bucket_name>, <s3_bucket_aws_account_id>, <s3_bucket_region>]\n").to_stderr
       end
     end
 
@@ -199,7 +200,7 @@ RSpec.describe "forms.rake" do
         expect {
           task.invoke(1)
         }.to raise_error(SystemExit)
-               .and output("usage: rake forms:set_submission_type_to_s3[<form_id>, <s3_bucket_name>, <s3_bucket_aws_account_id>]\n").to_stderr
+               .and output("usage: rake forms:set_submission_type_to_s3[<form_id>, <s3_bucket_name>, <s3_bucket_aws_account_id>, <s3_bucket_region>]\n").to_stderr
       end
     end
 
@@ -208,7 +209,25 @@ RSpec.describe "forms.rake" do
         expect {
           task.invoke(1, s3_bucket_name)
         }.to raise_error(SystemExit)
-               .and output("usage: rake forms:set_submission_type_to_s3[<form_id>, <s3_bucket_name>, <s3_bucket_aws_account_id>]\n").to_stderr
+               .and output("usage: rake forms:set_submission_type_to_s3[<form_id>, <s3_bucket_name>, <s3_bucket_aws_account_id>, <s3_bucket_region>]\n").to_stderr
+      end
+    end
+
+    context "without region argument" do
+      it "aborts with a usage message" do
+        expect {
+          task.invoke(1, s3_bucket_name, s3_bucket_aws_account_id)
+        }.to raise_error(SystemExit)
+               .and output("usage: rake forms:set_submission_type_to_s3[<form_id>, <s3_bucket_name>, <s3_bucket_aws_account_id>, <s3_bucket_region>]\n").to_stderr
+      end
+    end
+
+    context "when region is not allowed" do
+      it "aborts with message" do
+        expect {
+          task.invoke(1, s3_bucket_name, s3_bucket_aws_account_id, "eu-west-3")
+        }.to raise_error(SystemExit)
+               .and output("s3_bucket_region must be one of eu-west-1 or eu-west-2\n").to_stderr
       end
     end
   end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -329,6 +329,7 @@ RSpec.describe Form, type: :model do
         "share_preview_completed",
         "s3_bucket_name",
         "s3_bucket_aws_account_id",
+        "s3_bucket_region",
       )
     end
   end

--- a/spec/requests/api/v1/forms_controller_spec.rb
+++ b/spec/requests/api/v1/forms_controller_spec.rb
@@ -196,6 +196,7 @@ describe Api::V1::FormsController, type: :request do
         submission_type: "email",
         s3_bucket_name: nil,
         s3_bucket_aws_account_id: nil,
+        s3_bucket_region: nil,
       )
     end
   end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/ToXPf8zb/

When using the AWS SDK for Ruby, it is required to provide the bucket region. If the region is different to the region the bucket was created in, we get the following error:

Aws::s3::Errors::PermanentRedirect - The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.

Add a column `s3_bucket_region` to the forms table to store the region for the S3 bucket to send form submission data to.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
