### PR TITLE
Add full form report for add another answer

### DIFF
--- a/app/services/features_report_service.rb
+++ b/app/services/features_report_service.rb
@@ -8,6 +8,7 @@ class FeaturesReportService
       live_forms_with_routing:,
       live_forms_with_add_another_answer:,
       live_forms_with_csv_submission_enabled:,
+      all_forms_with_add_another_answer:,
     }
   end
 
@@ -17,6 +18,7 @@ private
   # This means that they may include updates which have been made to forms since they were made live.
   # As a result, the figures in the report may vary slightly from the actual live figures.
   # TODO: rewrite the queries to only check the content of live forms
+
   def total_live_forms
     Form.where(state: %w[live live_with_draft]).count
   end
@@ -43,5 +45,17 @@ private
 
   def live_forms_with_csv_submission_enabled
     Form.where(state: %w[live live_with_draft]).where(submission_type: "email_with_csv").count
+  end
+
+  def all_forms_with_add_another_answer
+    forms = Form.includes(:pages).where(pages: { is_repeatable: true })
+
+    forms.map do |form|
+      {
+        form_id: form.id,
+        name: form.name,
+        repeatable_pages: form.pages.map { |page| { page_id: page.id, question_text: page.question_text } if page.is_repeatable },
+      }
+    end
   end
 end

--- a/spec/requests/api/v1/reports_controller_spec.rb
+++ b/spec/requests/api/v1/reports_controller_spec.rb
@@ -2,6 +2,9 @@ require "rails_helper"
 
 RSpec.describe Api::V1::ReportsController, type: :request do
   describe "GET /features" do
+    let!(:form_with_repeatable_question) { create(:form, state: :live, pages: [repeatable_page]) }
+    let(:repeatable_page) { build(:page, answer_type: "text", is_repeatable: true) }
+
     before do
       create :form, state: :live, payment_url: Faker::Internet.url(host: "gov.uk"), submission_type: "email_with_csv", pages: [
         (build :page, answer_type: "text"),
@@ -12,7 +15,7 @@ RSpec.describe Api::V1::ReportsController, type: :request do
         (build :page, answer_type: "name"),
         (build :page, answer_type: "organisation_name"),
         (build :page, answer_type: "phone_number"),
-        (build :page, answer_type: "email", is_repeatable: true),
+        (build :page, answer_type: "email"),
         (build :page, answer_type: "address"),
         (build :page, answer_type: "national_insurance_number"),
         (build :page, answer_type: "date"),
@@ -28,20 +31,8 @@ RSpec.describe Api::V1::ReportsController, type: :request do
       response_hash = JSON.parse(response.body, symbolize_names: true)
 
       expect(response_hash).to eq({
-        total_live_forms: 2,
+        total_live_forms: 3,
         live_forms_with_answer_type: {
-          name: 1,
-          organisation_name: 1,
-          phone_number: 1,
-          email: 1,
-          address: 1,
-          national_insurance_number: 1,
-          date: 1,
-          number: 1,
-          selection: 1,
-          text: 2,
-        },
-        live_pages_with_answer_type: {
           name: 1,
           organisation_name: 1,
           phone_number: 1,
@@ -53,10 +44,23 @@ RSpec.describe Api::V1::ReportsController, type: :request do
           selection: 1,
           text: 3,
         },
+        live_pages_with_answer_type: {
+          name: 1,
+          organisation_name: 1,
+          phone_number: 1,
+          email: 1,
+          address: 1,
+          national_insurance_number: 1,
+          date: 1,
+          number: 1,
+          selection: 1,
+          text: 4,
+        },
         live_forms_with_payment: 1,
         live_forms_with_routing: 1,
         live_forms_with_add_another_answer: 1,
         live_forms_with_csv_submission_enabled: 1,
+        all_forms_with_add_another_answer: [{ form_id: form_with_repeatable_question.id, name: form_with_repeatable_question.name, repeatable_pages: [{ page_id: repeatable_page.id, question_text: repeatable_page.question_text }] }],
       })
     end
 

--- a/spec/services/features_report_service_spec.rb
+++ b/spec/services/features_report_service_spec.rb
@@ -153,6 +153,17 @@ describe FeaturesReportService do
           expect(response[:live_forms_with_csv_submission_enabled]).to eq 1
         end
       end
+
+      context "when a draft form uses the add another answer feature" do
+        let!(:add_another_answer_form) { create(:form, state: "draft", pages: form_5_pages) }
+        let(:form_5_pages) { pages_with_add_another_answer }
+
+        it "obtains all forms in the add another answer report" do
+          response = features_report_service.report
+
+          expect(response[:all_forms_with_add_another_answer]).to eq([{ form_id: add_another_answer_form.id, name: add_another_answer_form.name, repeatable_pages: [{ page_id: pages_with_add_another_answer.first.id, question_text: pages_with_add_another_answer.first.question_text }] }])
+        end
+      end
     end
 
     context "when there are no live forms" do


### PR DESCRIPTION
This adds a new report which will return all forms that contain a question that has `is_repeatable` set to true. This includes forms in draft states only, as we want to get an idea of how this feature is being used even in non-live forms.

### What problem does this pull request solve?

Trello card: https://trello.com/c/a2bMFMxU/1827-5-report-when-forms-are-using-add-another-answer-single-qn

This adds an additional report field which will give a few details about every form with a repeatable question. It will bundle each form as a combination of its form id, form name, and then every repeatable question within that form. Each question will have its id and question text bundled up as well. 

This is in order to create a minimal report in admin, which can display the name of a form and the questions' texts, as well as provide links to them. 

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
