### PR TITLE
Add state to all add another answer forms report

### DIFF
--- a/app/services/features_report_service.rb
+++ b/app/services/features_report_service.rb
@@ -54,6 +54,7 @@ private
       {
         form_id: form.id,
         name: form.name,
+        state: form.state,
         repeatable_pages: form.pages.map { |page| { page_id: page.id, question_text: page.question_text } if page.is_repeatable },
       }
     end

--- a/spec/requests/api/v1/reports_controller_spec.rb
+++ b/spec/requests/api/v1/reports_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Api::V1::ReportsController, type: :request do
         live_forms_with_routing: 1,
         live_forms_with_add_another_answer: 1,
         live_forms_with_csv_submission_enabled: 1,
-        all_forms_with_add_another_answer: [{ form_id: form_with_repeatable_question.id, name: form_with_repeatable_question.name, repeatable_pages: [{ page_id: repeatable_page.id, question_text: repeatable_page.question_text }] }],
+        all_forms_with_add_another_answer: [{ form_id: form_with_repeatable_question.id, name: form_with_repeatable_question.name, state: form_with_repeatable_question.state, repeatable_pages: [{ page_id: repeatable_page.id, question_text: repeatable_page.question_text }] }],
       })
     end
 

--- a/spec/services/features_report_service_spec.rb
+++ b/spec/services/features_report_service_spec.rb
@@ -161,7 +161,7 @@ describe FeaturesReportService do
         it "obtains all forms in the add another answer report" do
           response = features_report_service.report
 
-          expect(response[:all_forms_with_add_another_answer]).to eq([{ form_id: add_another_answer_form.id, name: add_another_answer_form.name, repeatable_pages: [{ page_id: pages_with_add_another_answer.first.id, question_text: pages_with_add_another_answer.first.question_text }] }])
+          expect(response[:all_forms_with_add_another_answer]).to eq([{ form_id: add_another_answer_form.id, name: add_another_answer_form.name, state: add_another_answer_form.state, repeatable_pages: [{ page_id: pages_with_add_another_answer.first.id, question_text: pages_with_add_another_answer.first.question_text }] }])
         end
       end
     end


### PR DESCRIPTION
This adds the state field to the add another answer forms report. This will let us identify what state forms are in with the report, which will help filter out draft forms from live ones.

### What problem does this pull request solve?

Trello card: https://trello.com/c/a2bMFMxU/1827-report-when-forms-are-using-add-another-answer-single-qn

Adds a state field to the add another answer report, so that we can more easily sift through all the forms!

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
