### PR TITLE
Allow answer value to be nil for condition reached after another condition

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -39,6 +39,8 @@ class Condition < ApplicationRecord
   end
 
   def warning_answer_doesnt_exist
+    return nil if has_precondition? && answer_value.nil?
+
     answer_options = check_page&.answer_settings&.dig("selection_options")&.pluck("name")
     return nil if answer_options.blank? || answer_options.include?(answer_value) || answer_value == :none_of_the_above.to_s && check_page.is_optional?
 
@@ -80,5 +82,11 @@ class Condition < ApplicationRecord
 
   def has_routing_errors
     validation_errors.any?
+  end
+
+private
+
+  def has_precondition?
+    check_page_id && check_page_id != routing_page_id && !check_page.routing_conditions.empty?
   end
 end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -102,9 +102,13 @@ RSpec.describe Condition, type: :model do
     let(:check_page) { create :page, :with_selections_settings, form: }
     let(:goto_page) { create :page, form: }
     let(:condition) do
-      new_condition = create :condition, routing_page_id: check_page.id, check_page_id: check_page.id, goto_page_id: goto_page.id
-      new_condition.answer_value = check_page.answer_settings["selection_options"].first["name"]
-      new_condition
+      create(
+        :condition,
+        routing_page_id: check_page.id,
+        check_page_id: check_page.id,
+        goto_page_id: goto_page.id,
+        answer_value: check_page.answer_settings["selection_options"].first["name"],
+      )
     end
 
     it "returns nil if answer exists" do

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -149,6 +149,23 @@ RSpec.describe Condition, type: :model do
         end
       end
     end
+
+    context "when condition is a after another condition for a branch route" do
+      let(:routing_page) { create :page, form: }
+      let(:after_condition) do
+        create(
+          :condition,
+          answer_value: nil,
+          check_page_id: condition.check_page_id,
+          routing_page_id: routing_page.id,
+          skip_to_end: true,
+        )
+      end
+
+      it "returns nil" do
+        expect(after_condition.warning_answer_doesnt_exist).to be_nil
+      end
+    end
   end
 
   describe "#warning_routing_to_next_page" do


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/dUkpDNku/1959-allow-conditions-without-answer-value-as-part-of-branch-routing-in-forms-api <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

We want to model a branching route in a form as two conditions with the same check page but different routing pages: the condition for the first page reached skips the pages in the first branch if it is met, and the condition for the page at the end of the first branch skips the pages in the second branch. Because the second condition can only be reached in the case where it should skip, it is redundant to specify the answer value, so we want to be able to omit it.

This commit changes the `warning_answer_doesnt_exist` validation so that if a condition is after another condition then `answer_value` is allowed to be `nil`.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?