### PR TITLE
add new form to seeds for end to end testing

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -91,3 +91,29 @@ all_question_types_form = Form.create!(
   share_preview_completed: true,
 )
 all_question_types_form.make_live!
+
+e2e_s3_forms = Form.create!(
+  name: "s3 submission test form",
+  pages: [
+    Page.create(
+      question_text: "Single line of text",
+      answer_type: "text",
+      answer_settings: {
+        input_type: "single_line",
+      },
+      is_optional: false,
+    ),
+  ],
+  question_section_completed: true,
+  declaration_text: "",
+  declaration_section_completed: true,
+  privacy_policy_url: "https://www.gov.uk/help/privacy-notice",
+  submission_email:,
+  support_email: "your.email+fakedata84701@gmail.com.gov.uk",
+  support_phone: "08000800",
+  what_happens_next_markdown: "Test",
+  share_preview_completed: true,
+  submission_type: "s3",
+  s3_bucket_region: "eu-west-2",
+)
+e2e_s3_forms.make_live!


### PR DESCRIPTION
### What problem does this pull request solve?

we're adding a new end to end test that will test forms with a submission type of s3. There's no front end way to set a form  to a type of s3, so we can't create the form in the e2e tests. Instead, when testing locally, we will use this new seeded form.

[Trello card](https://trello.com/c/64CM50hZ/1921-add-an-e2e-test-for-s3-submissions)

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
