### PR TITLE
Delete the secondary skip for a branch route if the branching question is deleted

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -5,7 +5,7 @@ class Page < ApplicationRecord
 
   belongs_to :form
   has_many :routing_conditions, class_name: "Condition", foreign_key: "routing_page_id", dependent: :destroy
-  has_many :check_conditions, class_name: "Condition", foreign_key: "check_page_id", dependent: :nullify
+  has_many :check_conditions, class_name: "Condition", foreign_key: "check_page_id", dependent: :destroy
   has_many :goto_conditions, class_name: "Condition", foreign_key: "goto_page_id", dependent: :nullify
   acts_as_list scope: :form
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -30,11 +30,10 @@ RSpec.describe Page, type: :model do
       let(:routing_page) { create :page, form: }
       let!(:condition) { page.check_conditions.create! routing_page: }
 
-      it "removes association from the condition if it is deleted" do
+      it "deletes the condition if it is deleted" do
         page.destroy!
 
-        expect(condition).not_to be_destroyed
-        expect(condition.goto_page).to be_nil
+        expect(condition).to be_destroyed
       end
     end
 
@@ -47,6 +46,21 @@ RSpec.describe Page, type: :model do
 
         expect(condition).not_to be_destroyed
         expect(condition.goto_page).to be_nil
+      end
+    end
+
+    context "when it has a branch route with skip and secondary skip" do
+      let(:first_branch) { create :page, form: }
+      let(:second_branch) { create :page, form: }
+
+      let!(:skip_condition) { page.routing_conditions.create! goto_page: second_branch }
+      let!(:secondary_skip_condition) { page.check_conditions.create! routing_page: first_branch, skip_to_end: true }
+
+      it "deletes all the conditions if it is deleted" do
+        page.destroy!
+
+        expect(skip_condition).to be_destroyed
+        expect(secondary_skip_condition).to be_destroyed
       end
     end
   end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -12,6 +12,45 @@ RSpec.describe Page, type: :model do
     expect(page).to be_valid
   end
 
+  describe "associations" do
+    let(:form) { create :form }
+    let(:page) { create :page, form: }
+
+    context "when it has a routing condition" do
+      let!(:condition) { page.routing_conditions.create! }
+
+      it "deletes the condition if it is deleted" do
+        page.destroy!
+
+        expect(condition).to be_destroyed
+      end
+    end
+
+    context "when it has a check condition" do
+      let(:routing_page) { create :page, form: }
+      let!(:condition) { page.check_conditions.create! routing_page: }
+
+      it "removes association from the condition if it is deleted" do
+        page.destroy!
+
+        expect(condition).not_to be_destroyed
+        expect(condition.goto_page).to be_nil
+      end
+    end
+
+    context "when it has a go to condition" do
+      let(:routing_page) { create :page, form: }
+      let!(:condition) { page.goto_conditions.create! routing_page: }
+
+      it "removes association from the condition if it is deleted" do
+        page.destroy!
+
+        expect(condition).not_to be_destroyed
+        expect(condition.goto_page).to be_nil
+      end
+    end
+  end
+
   describe "versioning", :versioning do
     it "enables paper trail" do
       expect(page).to be_versioned


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/UThSZ8ga/2037-fix-behaviour-of-deleting-page-with-secondary-skip-route <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

It doesn't makes sense to have a secondary skip condition when the precondition skip route has been deleted, but that's currently what happens when you delete a page with a skip and secondary skip.

Instead let's just delete all check conditions for a page when that page is deleted, same as we do for the routing conditions. This shouldn't have any other side effects, as the only case currently where a check condition isn't also a routing condition for a page is for a secondary skip.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?