### PR TITLE
Fix condition validations

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -59,14 +59,9 @@ class Condition < ApplicationRecord
   end
 
   def warning_goto_page_before_check_page
-    return nil if check_page.nil? || goto_page.nil?
-
-    routing_page_position = routing_page.position
-    goto_page_position = goto_page.position
-
-    return { name: "cannot_have_goto_page_before_routing_page" } if goto_page_position < (routing_page_position + 1)
-
-    nil
+    if goto_page.present? && (goto_page.position <= routing_page.position)
+      { name: "cannot_have_goto_page_before_routing_page" }
+    end
   end
 
   def is_check_your_answers?

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -61,10 +61,10 @@ class Condition < ApplicationRecord
   def warning_goto_page_before_check_page
     return nil if check_page.nil? || goto_page.nil?
 
-    check_page_position = check_page.position
+    routing_page_position = routing_page.position
     goto_page_position = goto_page.position
 
-    return { name: "cannot_have_goto_page_before_routing_page" } if goto_page_position < (check_page_position + 1)
+    return { name: "cannot_have_goto_page_before_routing_page" } if goto_page_position < (routing_page_position + 1)
 
     nil
   end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -24,7 +24,7 @@ class Condition < ApplicationRecord
       warning_goto_page_doesnt_exist,
       warning_answer_doesnt_exist,
       warning_routing_to_next_page,
-      warning_goto_page_before_check_page,
+      warning_goto_page_before_routing_page,
     ].compact
   end
 
@@ -58,7 +58,7 @@ class Condition < ApplicationRecord
     nil
   end
 
-  def warning_goto_page_before_check_page
+  def warning_goto_page_before_routing_page
     if goto_page.present? && (goto_page.position <= routing_page.position)
       { name: "cannot_have_goto_page_before_routing_page" }
     end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -50,10 +50,10 @@ class Condition < ApplicationRecord
   def warning_routing_to_next_page
     return nil if check_page.nil? || goto_page.nil? && !is_check_your_answers?
 
-    check_page_position = check_page.position
+    routing_page_position = routing_page.position
     goto_page_position = is_check_your_answers? ? form.pages.last.position + 1 : goto_page.position
 
-    return { name: "cannot_route_to_next_page" } if goto_page_position == (check_page_position + 1)
+    return { name: "cannot_route_to_next_page" } if goto_page_position == (routing_page_position + 1)
 
     nil
   end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -169,62 +169,107 @@ RSpec.describe Condition, type: :model do
   end
 
   describe "#warning_routing_to_next_page" do
-    let(:form) { create :form }
-    let(:current_page) { create :page, form: }
-    let(:next_page) { create :page, form: }
-    let(:last_page) { create :page, form: }
-    let(:condition) { create :condition, routing_page_id: current_page.id, check_page_id: current_page.id, goto_page_id: last_page.id }
+    let(:form) { build :form, pages: [check_page, current_page, next_page, last_page] }
+    let(:check_page) { build :page, position: 1 }
+    let(:current_page) { build :page, position: 2 }
+    let(:next_page) { build :page, position: 3 }
+    let(:last_page) { build :page, position: 4 }
 
-    before do
-      current_page
-      next_page
-      last_page
+    shared_examples "returns no warning" do
+      it "returns nil" do
+        expect(condition.warning_routing_to_next_page).to be_nil
+      end
     end
 
-    it "returns nil if go to page is not the next page" do
-      expect(condition.warning_routing_to_next_page).to be_nil
-    end
-
-    context "when goto page is the next page" do
-      let(:condition) { create :condition, routing_page_id: current_page.id, check_page_id: current_page.id, goto_page_id: next_page.id }
-
-      it "returns object with error short name code" do
+    shared_examples "returns routing warning" do
+      it "returns cannot_route_to_next_page warning" do
         expect(condition.warning_routing_to_next_page).to eq({ name: "cannot_route_to_next_page" })
       end
     end
 
-    context "when goto page nil" do
-      let(:condition) { create :condition, routing_page_id: current_page.id, check_page_id: current_page.id, goto_page_id: nil }
+    context "when routing to a non-adjacent page" do
+      let(:condition) do
+        create :condition,
+               routing_page: current_page,
+               check_page: check_page,
+               goto_page: last_page
+      end
 
-      it "returns nil" do
-        expect(condition.warning_routing_to_next_page).to be_nil
+      it_behaves_like "returns no warning"
+    end
+
+    context "when routing to the next sequential page" do
+      let(:condition) do
+        create :condition,
+               routing_page: current_page,
+               check_page: check_page,
+               goto_page: next_page
+      end
+
+      it_behaves_like "returns routing warning"
+    end
+
+    context "with nil values" do
+      context "when goto_page is nil" do
+        let(:condition) do
+          create :condition,
+                 routing_page: current_page,
+                 check_page: check_page,
+                 goto_page: nil
+        end
+
+        it_behaves_like "returns no warning"
+      end
+
+      context "when check_page is nil" do
+        let(:condition) do
+          create :condition,
+                 routing_page: current_page,
+                 check_page: nil,
+                 goto_page: next_page
+        end
+
+        it_behaves_like "returns no warning"
       end
     end
 
-    context "when check page nil" do
-      let(:condition) { create :condition, routing_page_id: current_page.id, check_page_id: nil, goto_page_id: next_page.id }
+    context "with skip_to_end functionality" do
+      context "when routing from the last page" do
+        let(:condition) do
+          create :condition,
+                 routing_page: last_page,
+                 check_page: check_page,
+                 goto_page: nil,
+                 skip_to_end: true
+        end
 
-      it "returns nil" do
-        expect(condition.warning_routing_to_next_page).to be_nil
+        it_behaves_like "returns routing warning"
+      end
+
+      context "when routing from a non-last page" do
+        let(:condition) do
+          create :condition,
+                 routing_page: current_page,
+                 check_page: check_page,
+                 goto_page: nil,
+                 skip_to_end: false
+        end
+
+        it_behaves_like "returns no warning"
       end
     end
 
-    context "when goto page is nil and skip_to_end is true" do
-      context "when the routing_page is at the end of the form" do
-        let(:condition) { create :condition, routing_page_id: last_page.id, check_page_id: last_page.id, goto_page_id: nil, skip_to_end: true }
-
-        it "returns object with error short name code" do
-          expect(condition.warning_routing_to_next_page).to eq({ name: "cannot_route_to_next_page" })
-        end
+    context "with non-sequential page positions" do
+      let(:current_page) { build :page, position: 2 }
+      let(:next_page) { build :page, position: 4 }
+      let(:condition) do
+        create :condition,
+               routing_page: current_page,
+               check_page: check_page,
+               goto_page: next_page
       end
 
-      context "when the routing_page is not at the end of the form" do
-        let(:condition) { create :condition, routing_page_id: current_page.id, check_page_id: current_page.id, goto_page_id: nil, skip_to_end: false }
-
-        it "returns nil" do
-          expect(condition.warning_routing_to_next_page).to be_nil
-        end
-      end
+      it_behaves_like "returns no warning"
     end
   end
 

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Condition, type: :model do
       %i[warning_goto_page_doesnt_exist
          warning_answer_doesnt_exist
          warning_routing_to_next_page
-         warning_goto_page_before_check_page ].each do |validation_methods|
+         warning_goto_page_before_routing_page ].each do |validation_methods|
         expect(condition).to receive(validation_methods)
       end
       condition.validation_errors
@@ -273,7 +273,7 @@ RSpec.describe Condition, type: :model do
     end
   end
 
-  describe "#warning_goto_page_before_check_page" do
+  describe "#warning_goto_page_before_routing_page" do
     let(:form) { build :form, pages: [previous_page, current_page, next_page, last_page] }
     let(:check_page) { build :page, position: 1 }
     let(:previous_page) { build :page, position: 2 }
@@ -283,13 +283,13 @@ RSpec.describe Condition, type: :model do
 
     shared_examples "returns no warning" do
       it "returns nil" do
-        expect(condition.warning_goto_page_before_check_page).to be_nil
+        expect(condition.warning_goto_page_before_routing_page).to be_nil
       end
     end
 
     shared_examples "returns routing warning" do
       it "returns cannot_have_goto_page_before_routing_page warning" do
-        expect(condition.warning_goto_page_before_check_page).to(
+        expect(condition.warning_goto_page_before_routing_page).to(
           eq({ name: "cannot_have_goto_page_before_routing_page" }),
         )
       end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -321,11 +321,14 @@ RSpec.describe Page, type: :model do
   end
 
   describe "#has_routing_errors" do
-    let(:routing_page) { create :page, form: }
-    let(:goto_page) { create :page, form: }
-    let(:goto_page_id) { goto_page.id }
-    let(:routing_conditions) { [condition] }
-    let(:condition) { create :condition, routing_page_id: routing_page.id, goto_page_id: }
+    subject(:page) { build :page, :with_selections_settings, routing_conditions: [condition] }
+
+    let(:condition) { build :condition }
+    let(:has_routing_errors) { false }
+
+    before do
+      allow(condition).to receive(:has_routing_errors).and_return(has_routing_errors)
+    end
 
     context "when there are no validation errors" do
       it "returns false" do
@@ -334,7 +337,7 @@ RSpec.describe Page, type: :model do
     end
 
     context "when there are validation errors" do
-      let(:goto_page_id) { nil }
+      let(:has_routing_errors) { true }
 
       it "returns true" do
         expect(page.has_routing_errors).to be true

--- a/spec/requests/api/v1/conditions_controller_spec.rb
+++ b/spec/requests/api/v1/conditions_controller_spec.rb
@@ -25,7 +25,7 @@ describe Api::V1::ConditionsController, type: :request do
       expect(response.headers["Content-Type"]).to eq("application/json")
       expect(json_body.count).to eq(routing_page.routing_conditions.count)
       routing_page.routing_conditions.each_with_index do |p, i|
-        expect(json_body[i]).to eq(JSON.parse(p.to_json).symbolize_keys)
+        expect(json_body[i]).to match(p.as_json.deep_symbolize_keys)
       end
     end
   end
@@ -95,7 +95,7 @@ describe Api::V1::ConditionsController, type: :request do
       it "returns condition, status code 200" do
         expect(response.status).to eq(200)
         expect(response.headers["Content-Type"]).to eq("application/json")
-        expect(json_body).to eq(JSON.parse(condition.to_json).symbolize_keys)
+        expect(json_body).to match(condition.as_json.deep_symbolize_keys)
       end
     end
 


### PR DESCRIPTION
# Change routing validations to take into account secondary skips

### What problem does this pull request solve?

Trello card: https://trello.com/c/5kRIGgDY/2581-change-api-validations-for-conditions-to-use-routingpageid-instead-of-checkpageid

The validations used to make sure conditions make sense within a form do not take into account secondary skips.

This creates issues when displaying secondary skips within the page list and can result in forms with loops being made live.

Because the exisitning validation code used the check_page as a reference it could report incorrect errors in two ways.

- It would produce errors which say that a secondary skip is invalid because the route is next to the end route, even when it wasn't
- It would miss loops in forms

Both cases are fixed by changing the validation code to use `routing_page` instead of `check_page`. For exisiting forms with a basic route, this shouldn't result in any changes.

For forms created with secondary skips, it should now report the correct errors.

### Example of an incorrect error based on position
![image](https://github.com/user-attachments/assets/cce95b87-3dc8-40c9-bed5-06696c7e379b)

### Example of a form with a loop and no error
![image](https://github.com/user-attachments/assets/6b2e1365-fc7d-4fb0-a47c-fee5d6a5c373)



<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
