### PR TITLE
Rename host logging field

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,7 @@ class ApplicationController < ActionController::API
 
   def append_info_to_payload(payload)
     super
-    payload[:host] = request.host
+    payload[:request_host] = request.host
     payload[:request_id] = request.request_id
     payload[:requested_by] = "#{@access_token.owner}-#{@access_token.id}" if @access_token.present?
     payload[:form_id] = params[:form_id] if params[:form_id].present?

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,7 +57,7 @@ module FormsApi
 
     config.lograge.custom_options = lambda do |event|
       {}.tap do |h|
-        h[:host] = event.payload[:host]
+        h[:request_host] = event.payload[:request_host]
         h[:request_id] = event.payload[:request_id]
         h[:requested_by] = event.payload[:requested_by] if event.payload[:requested_by]
         h[:form_id] = event.payload[:form_id] if event.payload[:form_id]


### PR DESCRIPTION
### What problem does this pull request solve?

Rename the "host" logging field to "hostname". An additional "host" field is added to the logs that go to Splunk for Kenesis. This means we end up with 2 values for "host" making it difficult to filter searches by it.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
