### PR TITLE
Update URI Gem to 1.0.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -342,7 +342,7 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
-    uri (1.0.2)
+    uri (1.0.3)
     useragent (0.16.11)
     validate_url (1.0.15)
       activemodel (>= 3.0.0)


### PR DESCRIPTION
# Update the version of the URI Gem for this CVE:

https://www.cve.org/CVERecord?id=CVE-2025-27221
