### PR TITLE
Add markdown for exit pages

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -70,6 +70,10 @@ class Condition < ApplicationRecord
     goto_page.nil? && skip_to_end
   end
 
+  def is_exit_page?
+    !exit_page_markdown.nil?
+  end
+
   def as_json(options = {})
     super(options.reverse_merge(
       except: [:next_page],

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -31,6 +31,7 @@ class Condition < ApplicationRecord
   end
 
   def warning_goto_page_doesnt_exist
+    return nil if is_exit_page?
     # goto_page_id isn't needed if the route is skipping to the end of the form
     return nil if is_check_your_answers?
 

--- a/db/migrate/20250306120134_add_exit_page_fields_to_conditions.rb
+++ b/db/migrate/20250306120134_add_exit_page_fields_to_conditions.rb
@@ -1,0 +1,8 @@
+class AddExitPageFieldsToConditions < ActiveRecord::Migration[8.0]
+  def change
+    change_table(:conditions, bulk: true) do |t|
+      t.column :exit_page_markdown, :text, comment: "When not nil this condition should be treated as an exit page. When set it contains the markdown for the body of the exit page"
+      t.column :exit_page_heading, :text, comment: "Text for the heading of the exit page"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_22_154933) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_06_120134) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
 
   create_table "access_tokens", force: :cascade do |t|
     t.string "token_digest"
@@ -42,6 +42,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_22_154933) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "skip_to_end", default: false
+    t.text "exit_page_markdown", comment: "When not nil this condition should be treated as an exit page. When set it contains the markdown for the body of the exit page"
+    t.text "exit_page_heading", comment: "Text for the heading of the exit page"
     t.index ["check_page_id"], name: "index_conditions_on_check_page_id"
     t.index ["goto_page_id"], name: "index_conditions_on_goto_page_id"
     t.index ["routing_page_id"], name: "index_conditions_on_routing_page_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -122,6 +122,18 @@ branch_route_form = Form.create!(
   name: "Branch route form",
   pages: [
     Page.create(
+      question_text: "Are you eligible to submit this form?",
+      answer_type: "selection",
+      answer_settings: {
+        only_one_option: "true",
+        selection_options: [
+          { "name": "Yes" },
+          { "name": "No" },
+        ],
+      },
+      is_optional: false,
+    ),
+    Page.create(
       question_text: "How many times have you filled out this form?",
       answer_type: "selection",
       answer_settings: {
@@ -179,15 +191,27 @@ branch_route_form = Form.create!(
   share_preview_completed: true,
 )
 Condition.create!(
-  check_page: branch_route_form.pages.first,
-  routing_page: branch_route_form.pages.first,
-  goto_page: branch_route_form.pages.fourth,
+  check_page: branch_route_form.pages.second,
+  routing_page: branch_route_form.pages.second,
+  goto_page: branch_route_form.pages.fifth,
   answer_value: "More than once",
 )
 Condition.create!(
-  check_page: branch_route_form.pages.first,
-  routing_page: branch_route_form.pages.third,
+  check_page: branch_route_form.pages.second,
+  routing_page: branch_route_form.pages.fourth,
   goto_page: branch_route_form.pages.last,
   answer_value: nil,
+)
+Condition.create!(
+  check_page: branch_route_form.pages.first,
+  routing_page: branch_route_form.pages.first,
+  goto_page: nil,
+  answer_value: "No",
+  exit_page_heading: "You are not eligible to submit this form",
+  exit_page_markdown: <<~MARKDOWN,
+    To complete this form you must:
+      - Be over 16
+      - Confirmed that you are eligible to submit this form
+  MARKDOWN
 )
 branch_route_form.reload.make_live!

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -146,6 +146,14 @@ RSpec.describe Condition, type: :model do
         expect(condition.warning_goto_page_doesnt_exist).to eq({ name: "goto_page_doesnt_exist" })
       end
     end
+
+    context "when is_exit_page?" do
+      let(:condition) { create :condition, routing_page_id: routing_page.id, goto_page_id: nil, exit_page_markdown: "exit page" }
+
+      it "returns nil" do
+        expect(condition.warning_goto_page_doesnt_exist).to be_nil
+      end
+    end
   end
 
   describe "#warning_answer_doesnt_exist" do

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -47,6 +47,18 @@ RSpec.describe Condition, type: :model do
     end
   end
 
+  describe "#is_exit_page?" do
+    it "returns false when exit_page_markdown is nil" do
+      condition.exit_page_markdown = nil
+      expect(condition.is_exit_page?).to be false
+    end
+
+    it "returns true when exit_page_markdown is not nil" do
+      condition.exit_page_markdown = ""
+      expect(condition.is_exit_page?).to be true
+    end
+  end
+
   describe "versioning", :versioning do
     it "enables paper trail" do
       expect(condition).to be_versioned


### PR DESCRIPTION
### Add columns for storing the markdown content for exit pages to Condition

Trello card: https://trello.com/c/LYs67GUv/2150-add-somewhere-to-store-exit-page-guidance-in-our-database

This PR adds two columns to the Condition model for storing the heading and markdown content for exit pages.

Exit pages will be represented by a Condition with check_page_id, routing_page_id set and a string value, which could be "", for exit_page_markown.

The Condition validation which reports an error when the goto_page is nil has been changed to ignore exit pages.

It doesn't add any other validations we might need for exit pages. The guidance content stored in pages [uses validations which might be useful](https://github.com/alphagov/forms-api/blob/ff61d5a8b84108b872b00fe074c08ad62cab1d19/app/models/page.rb#L75) such as checking the heading is set if the content is set and checks on content and length.

The branching example form in the seed has been extended to include an exit page.

We are keeping the admin and API database table definitions in sync to make migrating easier. Another PR will be raised against admin when this is approved to add the same fields to the conditions table. 

[Displaying exit pages to form fillers](https://trello.com/c/pfNYulxC/2151-add-support-for-exit-pages-to-forms-runner) and allowing form creators to create and change exit pages and separate tickets.

 
### Things to consider when reviewing

- Does this sound like a good way to represent exit pages?
- Does the design allow us creating/modifying exit pages?
- Does it make anything about our current condition code harder?
- Does it make it possible to display exit_pages to form fillers?
