### PR TITLE
Fix markdown in exit page seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -210,6 +210,7 @@ Condition.create!(
   exit_page_heading: "You are not eligible to submit this form",
   exit_page_markdown: <<~MARKDOWN,
     To complete this form you must:
+
       - Be over 16
       - Confirmed that you are eligible to submit this form
   MARKDOWN


### PR DESCRIPTION
The markdown for the exit page in the database seed didn't have the right spacing for a list.

### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
