### PR TITLE
Add separate endpoint for add another answer report

### DIFF
--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -5,6 +5,12 @@ class Api::V1::ReportsController < ApplicationController
     render json: feature_stats.to_json, status: :ok
   end
 
+  def add_another_answer_forms
+    data = Reports::FeatureUsageService.new.add_another_answer_forms
+
+    render json: data.to_json, status: :ok
+  end
+
   def selection_questions_summary
     statistics = Reports::SelectionQuestionService.new.live_form_statistics
 

--- a/app/services/reports/feature_usage_service.rb
+++ b/app/services/reports/feature_usage_service.rb
@@ -12,6 +12,13 @@ class Reports::FeatureUsageService
     }
   end
 
+  def add_another_answer_forms
+    forms = all_forms_with_add_another_answer
+
+    # adding the count even though forms-admin doesn't use it as ActiveResource doesn't like parsing JSON with a single root key
+    { forms:, count: forms.length }
+  end
+
 private
 
   # NOTE: all of these methods currently query the Form table rather than the MadeLiveForm table.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
 
     scope :reports do
       get "/features", to: "api/v1/reports#features"
+      get "/add-another-answer-forms", to: "api/v1/reports#add_another_answer_forms"
       get "/selection-questions-summary", to: "api/v1/reports#selection_questions_summary"
       get "/selection-questions-with-autocomplete", to: "api/v1/reports#selection_questions_with_autocomplete"
       get "/selection-questions-with-radios", to: "api/v1/reports#selection_questions_with_radios"

--- a/spec/requests/api/v1/reports_controller_spec.rb
+++ b/spec/requests/api/v1/reports_controller_spec.rb
@@ -69,6 +69,42 @@ RSpec.describe Api::V1::ReportsController, type: :request do
     end
   end
 
+  describe "GET /add-another-answer-forms" do
+    let!(:form_with_repeatable_question) { create(:form, state: :live, pages: [repeatable_page]) }
+    let(:repeatable_page) { build(:page, answer_type: "text", is_repeatable: true) }
+
+    before do
+      create :form, state: :live, pages: [
+        (build :page, answer_type: "text"),
+        (build :page, answer_type: "text"),
+      ]
+
+      get "/api/v1/reports/add-another-answer-forms"
+    end
+
+    it "returns the forms with repeatable questions" do
+      response_hash = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response_hash).to eq({
+        count: 1,
+        forms: [
+          {
+            form_id: form_with_repeatable_question.id,
+            name: form_with_repeatable_question.name,
+            state: form_with_repeatable_question.state,
+            repeatable_pages: [
+              { page_id: repeatable_page.id, question_text: repeatable_page.question_text },
+            ],
+          },
+        ],
+      })
+    end
+
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+  end
+
   describe "GET /selection-questions-summary" do
     before do
       form_1_pages = [

--- a/spec/services/reports/feature_usage_service_spec.rb
+++ b/spec/services/reports/feature_usage_service_spec.rb
@@ -196,4 +196,40 @@ describe Reports::FeatureUsageService do
       end
     end
   end
+
+  describe "#add_another_answer_forms" do
+    let!(:add_another_answer_draft_form) { create(:form, state: "draft", pages: draft_form_pages) }
+    let(:draft_form_pages) { pages_with_add_another_answer }
+    let!(:add_another_answer_live_form) { create(:form, state: "live", pages: live_form_pages) }
+    let(:live_form_pages) do
+      [
+        (build :page, answer_type: "name", is_repeatable: true),
+        (build :page, answer_type: "text", is_repeatable: true),
+      ]
+    end
+
+    it "obtains all forms in the add another answer report" do
+      report = features_report_service.add_another_answer_forms
+
+      expect(report[:forms]).to contain_exactly({
+        form_id: add_another_answer_draft_form.id,
+        name: add_another_answer_draft_form.name,
+        state: add_another_answer_draft_form.state,
+        repeatable_pages: contain_exactly({ page_id: draft_form_pages.first.id, question_text: draft_form_pages.first.question_text }),
+      }, {
+        form_id: add_another_answer_live_form.id,
+        name: add_another_answer_live_form.name,
+        state: add_another_answer_live_form.state,
+        repeatable_pages: contain_exactly(
+          { page_id: live_form_pages.first.id, question_text: live_form_pages.first.question_text },
+          { page_id: live_form_pages.second.id, question_text: live_form_pages.second.question_text },
+        ),
+      })
+    end
+
+    it "returns the count" do
+      report = features_report_service.add_another_answer_forms
+      expect(report[:count]).to eq 2
+    end
+  end
 end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: [<!-- link -->](https://trello.com/c/SgDCKXcY/145-improve-our-feature-reports)

The report to list forms with add another questions is shown on a different page to the main feature usage report. The feature report in forms-admin now sources its data from the `/api/v2/form_documents` endpoint rather than `/api/v1/reports/features`.

So that we can remove `/api/v1/reports/features`, separate the report to list forms with add another answer questions into its own endpoint. We can remove `/features` once forms-admin is using this new endpoint.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
