### PR TITLE
Permit exit page heading and markdown for condition endpoint

### DIFF
--- a/app/controllers/api/v1/conditions_controller.rb
+++ b/app/controllers/api/v1/conditions_controller.rb
@@ -57,6 +57,8 @@ private
       :goto_page_id,
       :skip_to_end,
       :answer_value,
+      :exit_page_heading,
+      :exit_page_markdown,
     )
   end
 

--- a/spec/requests/api/v1/conditions_controller_spec.rb
+++ b/spec/requests/api/v1/conditions_controller_spec.rb
@@ -40,6 +40,8 @@ describe Api::V1::ConditionsController, type: :request do
         goto_page_id: goto_page.id,
         skip_to_end: false,
         answer_value: "hello",
+        exit_page_heading: nil,
+        exit_page_markdown: nil,
       }
     end
 


### PR DESCRIPTION
### What problem does this pull request solve?
https://trello.com/c/MdPcqbFI/2154-allow-form-creators-to-add-an-exit-page-to-a-route

Allow `exit_page_heading` and `exit_page_markdown` when interacting with the conditions endpoint. It's necessary for the exit page work!

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
