### PR TITLE
Change value sent for 'None of the above' option for conditions

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -45,7 +45,7 @@ class Condition < ApplicationRecord
     return nil if has_precondition? && answer_value.nil?
 
     answer_options = check_page&.answer_settings&.dig("selection_options")&.pluck("name")
-    return nil if answer_options.blank? || answer_options.include?(answer_value) || answer_value == :none_of_the_above.to_s && check_page.is_optional?
+    return nil if answer_options.blank? || answer_options.include?(answer_value) || answer_value == "None of the above" && check_page.is_optional?
 
     { name: "answer_value_doesnt_exist" }
   end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe Condition, type: :model do
     end
 
     context "when answer_value is 'None of the above" do
-      let(:condition) { create :condition, routing_page_id: check_page.id, check_page_id: check_page.id, goto_page_id: goto_page.id, answer_value: :none_of_the_above.to_s }
+      let(:condition) { create :condition, routing_page_id: check_page.id, check_page_id: check_page.id, goto_page_id: goto_page.id, answer_value: "None of the above" }
       let(:check_page) { create :page, :with_selections_settings, form:, is_optional: }
 
       context "and routing page has 'None of the above' as an option" do


### PR DESCRIPTION
### What problem does this pull request solve?

https://trello.com/c/2H6cVned/2228-routes-based-on-none-of-the-above-answers-do-not-work

This reconciles a bug which we've encountered in forms runner - where we've been saving the answer value for optional selection questions as `none_of_the_above`, which will not be sucessfully compared with the forms runner's value of `None of the above`. 

The change in the API is to make sure that our `answer value doesn't exist` error is now looking for a value of `None of the above` when it's an optional question, rather than `none_of_the_above`. 

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
