### PR TITLE
Mount a volume at /app/tmp/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,11 +37,8 @@ COPY --chown=ruby:ruby . .
 
 FROM base AS app
 
-# Each directory that Rails or our application needs to
-# write to under /app/tmp/ must be added individually
 VOLUME "/tmp/"
-VOLUME "/app/tmp/sockets/"
-VOLUME "/app/tmp/cache"
+VOLUME "/app/tmp/"
 
 ENV RAILS_ENV="${RAILS_ENV:-production}" \
     PATH="${PATH}:/home/ruby/.local/bin" \


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/KoHvaEUA/681-aws-m112-ecs-read-only-root-filesystem-configuration

`forms-api` needs to write to a number of directories under `/app/tmp/`, so to avoid iterating and finding out which ones we mount a volume at `/app/tmp/`.
