### PR TITLE
Set the owner of the /app/tmp and /tmp volumes in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,6 @@ COPY --chown=ruby:ruby . .
 
 FROM base AS app
 
-VOLUME "/tmp/"
-VOLUME "/app/tmp/"
-
 ENV RAILS_ENV="${RAILS_ENV:-production}" \
     PATH="${PATH}:/home/ruby/.local/bin" \
     USER="ruby"
@@ -60,6 +57,10 @@ RUN chmod 0755 bin/*
 
 COPY --chown=ruby:ruby --from=build /usr/local/bundle /usr/local/bundle
 COPY --chown=ruby:ruby --from=build /app /app
+
+RUN mkdir -p "/app/tmp/" && chown ruby:ruby "/app/tmp/"
+VOLUME "/tmp/"
+VOLUME "/app/tmp/"
 
 EXPOSE 9292
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/KoHvaEUA/681-aws-m112-ecs-read-only-root-filesystem-configuration

AWS ECS documentation [1] shows how volume ownership should be set

[1] https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
