### PR TITLE
Make "db/" into a volume inside the Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,9 +58,10 @@ RUN chmod 0755 bin/*
 COPY --chown=ruby:ruby --from=build /usr/local/bundle /usr/local/bundle
 COPY --chown=ruby:ruby --from=build /app /app
 
-RUN mkdir -p "/app/tmp/" && chown ruby:ruby "/app/tmp/"
+RUN mkdir -p "/app/tmp/" && chown ruby:ruby "/app/tmp/" && chown ruby:ruby "/app/db/"
 VOLUME "/tmp/"
 VOLUME "/app/tmp/"
+VOLUME "/app/db/"
 
 EXPOSE 9292
 


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: https://trello.com/c/KoHvaEUA/681-aws-m112-ecs-read-only-root-filesystem-configuration

AWS ECS docs [1] say that a file that exists in a directory that is subsequently marked as a volume will be copied to the host and remounted into the container.

This is necessary for us to do with the "db/" directory because the "db:migrate" Rake task writes to "db/schema.rb"

[1] https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?
