### PR TITLE
Use full precision timestamps in JSON responses

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,6 +42,9 @@ module FormsApi
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
 
+    # Include full precision of timestamps in JSON responses
+    config.active_support.time_precision = 6
+
     #### lOGGING #####
     # Include generic and useful information about system operation, but avoid logging too much
     # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/spec/requests/api/v1/pages_controller_spec.rb
+++ b/spec/requests/api/v1/pages_controller_spec.rb
@@ -70,8 +70,8 @@ describe Api::V1::PagesController, type: :request do
                                                            position: 1,
                                                            routing_conditions: [],
                                                            has_routing_errors: false,
-                                                           created_at: "2023-01-01T12:00:00.000Z",
-                                                           updated_at: "2023-01-01T12:00:00.000Z",
+                                                           created_at: "2023-01-01T12:00:00.000000Z",
+                                                           updated_at: "2023-01-01T12:00:00.000000Z",
                                                            page_heading: nil,
                                                            guidance_markdown: nil,
                                                            is_repeatable: false).as_json)


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

Currently we store timestamps with microsecond precision (the default and maximum for PostgreSQL), but over the wire we only send milliseconds (the default for Rails). This is fine for most purposes, but as we're migrating data from forms-api to forms-admin at the moment it's helpful to get the full precision so we can easily compare the contents of the two databases without noise from truncated timestamps.

This commit uses the ActiveSupport configuration parameter to change the `TimeWithZone#as_json` method to return all 6 digits of precision.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?