### PR TITLE
Prepare next_page column in pages table to be removed

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -77,6 +77,7 @@ class Form < ApplicationRecord
                 include: {
                   routing_conditions: { methods: :validation_errors },
                 },
+                methods: [:next_page],
               },
             }, methods: [:start_page]).merge(kwargs)
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,6 +1,8 @@
 require "govuk_forms_markdown"
 
 class Page < ApplicationRecord
+  self.ignored_columns += %w[next_page]
+
   has_paper_trail
 
   before_destroy :destroy_secondary_skip_conditions

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe Form, type: :model do
   end
 
   describe "#snapshot" do
-    let(:snapshot) { create(:form).snapshot }
+    let(:snapshot) { create(:form, :with_pages).snapshot }
 
     it "creates a version of a form with its pages" do
       expect(snapshot.keys).to contain_exactly(
@@ -332,6 +332,36 @@ RSpec.describe Form, type: :model do
         "s3_bucket_region",
         "language",
       )
+    end
+
+    it "includes the form pages" do
+      pages = snapshot["pages"]
+      expect(pages).to all match(
+        a_hash_including(
+          "id",
+          "next_page",
+          "position",
+          "question_text",
+          "hint_text",
+          "answer_settings",
+          "is_optional",
+          "is_repeatable",
+          "page_heading",
+          "guidance_markdown",
+          "routing_conditions",
+        ),
+      )
+    end
+
+    it "includes the next page id for each page" do
+      pages = snapshot["pages"]
+      expect(pages).to match [
+        a_hash_including("position" => pages[0]["position"], "next_page" => pages[1]["id"]),
+        a_hash_including("position" => pages[0]["position"] + 1, "next_page" => pages[2]["id"]),
+        a_hash_including("position" => pages[0]["position"] + 2, "next_page" => pages[3]["id"]),
+        a_hash_including("position" => pages[0]["position"] + 3, "next_page" => pages[4]["id"]),
+        a_hash_including("position" => pages[0]["position"] + 4, "next_page" => nil),
+      ]
     end
   end
 


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

While working on migrating the forms models from forms-api to forms-admin I noticed that the next_page column for a page in the forms-api database is always set to nil.

As far as I can tell this column hasn't been used since before we migrated from grape (see PR #116), when we migrated to grape we switched to using the acts_as_list gem and the position column instead (see commit e8cc03).

I think we should remove this column now.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?