### PR TITLE
Remove next_page column from pages table

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,8 +1,6 @@
 require "govuk_forms_markdown"
 
 class Page < ApplicationRecord
-  self.ignored_columns += %w[next_page]
-
   has_paper_trail
 
   before_destroy :destroy_secondary_skip_conditions

--- a/db/migrate/20250709114304_remove_next_page_from_pages.rb
+++ b/db/migrate/20250709114304_remove_next_page_from_pages.rb
@@ -1,0 +1,5 @@
+class RemoveNextPageFromPages < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :pages, :next_page, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_23_142043) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_09_114304) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -89,7 +89,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_23_142043) do
     t.text "question_text"
     t.text "hint_text"
     t.text "answer_type"
-    t.integer "next_page"
     t.boolean "is_optional", null: false
     t.jsonb "answer_settings"
     t.datetime "created_at", null: false


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

This column hasn't been used since before we migrated from grape (see PR #116), when we migrated to grape we switched to using the acts_as_list gem and the position column instead (see commit e8cc03).

Let's remove this column now. Note that we do still need the `next_page` attribute in our JSON responses, as it used by consumers, but it is calculated by a method based on the acts_as_list code, we don't need it in our database.

The column was ignored in #791, so is now safe to actually remove the column.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?