### PR TITLE
Change response of /api/v1/forms/:id/make-live

### DIFF
--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -50,7 +50,7 @@ class Api::V1::FormsController < ApplicationController
 
   def make_live
     form.make_live!
-    render json: form.live_version, status: :ok
+    render json: form, status: :ok
   rescue AASM::InvalidTransition
     render json: form.incomplete_tasks.to_json, status: :forbidden
   end


### PR DESCRIPTION
### What problem does this pull request solve?

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->

forms-admin had been assuming that the response from POST-ing to the make_live endpoint is a form object (see for instance https://github.com/alphagov/forms-admin/blob/4ce3b3473dcc48627cf387de156f37d06126a91e/app/services/form_repository.rb#L34-L43), but it's actually the made live form document. This is less useful because it doesn't contain the state (the attribute that is actually changed), and differs from the response that we get from the archive endpoint, even though they're the conceptually similar actions.

This commit changes the response to be the updated form object as expected.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Has all relevant documentation been updated?