### PR TITLE
Rename unprocessable_entity to unprocessable_content

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,6 +65,6 @@ private
   end
 
   def invalid_record(resource)
-    render json: resource.record.errors, status: :unprocessable_entity
+    render json: resource.record.errors, status: :unprocessable_content
   end
 end


### PR DESCRIPTION
### What problem does this pull request solve?
When the 422 status was initially proposed in [RFC4918](https://datatracker.ietf.org/doc/html/rfc4918) (2007), it was called 'Unprocessable entity'.

When it became a standard in [RFC9110](https://datatracker.ietf.org/doc/html/rfc9110) (2022), it was renamed 'Unprocessable content'.

Rack now supports it as `:unprocessable_content` and [deprecated `:unprocessable_entity` in v3.1.0](https://github.com/rack/rack/blob/main/CHANGELOG.md#deprecated-1). This commit updates it to use the new name.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Ensure that you consider the wider context.
- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
