### PR TITLE
Log bad request errors in FormsController

### DIFF
--- a/app/controllers/api/v1/forms_controller.rb
+++ b/app/controllers/api/v1/forms_controller.rb
@@ -19,6 +19,7 @@ class Api::V1::FormsController < ApplicationController
       Api::V2::FormDocumentSyncService.new.synchronize_form(new_form)
       render json: new_form.to_json, status: :created
     else
+      Rails.logger.info("Error creating form", { errors: form.errors })
       render json: new_form.errors.to_json, status: :bad_request
     end
   end
@@ -34,6 +35,7 @@ class Api::V1::FormsController < ApplicationController
 
       render json: form.to_json, status: :ok
     else
+      Rails.logger.info("Error updating form", { errors: form.errors })
       render json: form.errors.to_json, status: :bad_request
     end
   end


### PR DESCRIPTION
We've seen bad request responses returned by forms-api when attempting to update a form. We're now relying on forms-admin to do any validation of the form before updating. This suggests that there's some mismatch between either the validation in forms-api and forms-admin or the form has got out of sync in the 2 databases.

We can't see the errors returned, so it's difficult to diagnose what's happening.